### PR TITLE
Fixed JNI methods accepting long instead of BigInteger, added additional methods to JNI

### DIFF
--- a/app/src/androidTest/java/com/tari/android/wallet/FFIWalletTests.kt
+++ b/app/src/androidTest/java/com/tari/android/wallet/FFIWalletTests.kt
@@ -39,6 +39,7 @@ package com.tari.android.wallet
 
 import com.orhanobut.logger.Logger
 import com.tari.android.wallet.ffi.*
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.math.BigInteger
@@ -137,8 +138,17 @@ class FFIWalletTests {
         assertTrue(completedTxFee > BigInteger("0"))
         val completedTxTimestamp = completedTx.getTimestamp()
         completedTxTimestamp.toString()
+        val completedTxIsOutbound = wallet.isCompletedTxOutbound(completedTx)
+        if (wallet.getPublicKey().toString() == completedTx.getSourcePublicKey().toString())
+        {
+            assertTrue(completedTxIsOutbound)
+        } else
+        {
+            assertFalse(completedTxIsOutbound)
+        }
+
         completedTx.destroy()
-        completedTx = wallet.getCompletedTxById(completedID.toLong())
+        completedTx = wallet.getCompletedTxById(completedID)
         assertTrue(completedTx.getPointer() != nullptr)
         assertTrue(wallet.testBroadcastTx(completedTx))
         assertTrue(wallet.testMineCompletedTx(completedTx))
@@ -160,7 +170,7 @@ class FFIWalletTests {
         val inboundTxTimestamp = inbound.getTimestamp()
         inboundTxTimestamp.toString()
         inbound.destroy()
-        inbound = wallet.getPendingInboundTxById(inboundTxID.toLong())
+        inbound = wallet.getPendingInboundTxById(inboundTxID)
         assertTrue(inbound.getPointer() != nullptr)
         assertTrue(wallet.testFinalizeReceivedTx(inbound))
         inbound.destroy()
@@ -177,10 +187,12 @@ class FFIWalletTests {
         assertTrue(outboundTxSource.getPointer() != nullptr)
         val outboundTxAmount = outboundTx.getAmount()
         assertTrue(outboundTxAmount > BigInteger("0"))
+        val outboundTxFee = outboundTx.getFee()
+        assertTrue(outboundTxFee > BigInteger("0"))
         val outboundTxTimestamp = outboundTx.getTimestamp()
         outboundTxTimestamp.toString()
         outboundTx.destroy()
-        outboundTx = wallet.getPendingOutboundTxById(outboundTxID.toLong())
+        outboundTx = wallet.getPendingOutboundTxById(outboundTxID)
         assertTrue(outboundTx.getPointer() != nullptr)
         assertTrue(wallet.testCompleteSentTx(outboundTx))
         outboundTx.destroy()
@@ -196,10 +208,10 @@ class FFIWalletTests {
 
         // test send tari
         assertTrue(
-            wallet.testSendTx(
+            wallet.sendTx(
                 contact.getPublicKey(),
-                1000000,
-                100,
+                BigInteger.valueOf(1000000L),
+                BigInteger.valueOf(100L),
                 "Android Wallet"
             )
         )

--- a/app/src/main/cpp/jniPendingOutboundTransaction.cpp
+++ b/app/src/main/cpp/jniPendingOutboundTransaction.cpp
@@ -88,6 +88,23 @@ Java_com_tari_android_wallet_ffi_FFIPendingOutboundTx_jniGetAmount(
     return result;
 }
 
+
+extern "C"
+JNIEXPORT jbyteArray JNICALL
+Java_com_tari_android_wallet_ffi_FFIPendingOutboundTx_jniGetFee(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jlong jpOutboundTx,
+        jobject error) {
+    int i = 0;
+    int *r = &i;
+    TariPendingOutboundTransaction *pOutboundTx = reinterpret_cast<TariPendingOutboundTransaction *>(jpOutboundTx);
+    jbyteArray result = getBytesFromUnsignedLongLong(jEnv, pending_outbound_transaction_get_fee(
+            pOutboundTx, r));
+    setErrorCode(jEnv, error, i);
+    return result;
+}
+
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_com_tari_android_wallet_ffi_FFIPendingOutboundTx_jniGetMessage(

--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -402,6 +402,23 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniRemoveContact(
 }
 
 extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniIsCompletedTxOutbound(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jlong jpWallet,
+        jlong jpCompletedTx,
+        jobject error) {
+    int i = 0;
+    int *r = &i;
+    TariWallet *pWallet = (TariWallet *) jpWallet;
+    TariCompletedTransaction *pTransaction = (TariCompletedTransaction*) jpCompletedTx;
+    jboolean result = wallet_is_completed_transaction_outbound(pWallet,pTransaction,r) != 0;
+    setErrorCode(jEnv, error, i);
+    return result;
+}
+
+extern "C"
 JNIEXPORT jlong JNICALL
 Java_com_tari_android_wallet_ffi_FFIWallet_jniGetCompletedTxs(
         JNIEnv *jEnv,
@@ -422,14 +439,18 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniGetCompletedTxById(
         JNIEnv *jEnv,
         jobject jThis,
         jlong jpWallet,
-        jlong jTxId,
+        jstring jTxId,
         jobject error) {
     int i = 0;
     int *r = &i;
     TariWallet *pWallet = reinterpret_cast<TariWallet *>(jpWallet);
+    const char* nativeString = jEnv->GetStringUTFChars(jTxId,JNI_FALSE);
+    char* pEnd;
+    unsigned long long id = strtoull(nativeString,&pEnd,10);
     jlong result = reinterpret_cast<jlong>(wallet_get_completed_transaction_by_id(pWallet,
-                                                                                  static_cast<unsigned long long>(jTxId),
+                                                                                  id,
                                                                                   r));
+    jEnv->ReleaseStringUTFChars(jTxId,nativeString);
     setErrorCode(jEnv, error, i);
     return result;
 }
@@ -456,14 +477,18 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniGetPendingOutboundTxById(
         JNIEnv *jEnv,
         jobject jThis,
         jlong jpWallet,
-        jlong jTxId,
+        jstring jTxId,
         jobject error) {
     int i = 0;
     int *r = &i;
     TariWallet *pWallet = reinterpret_cast<TariWallet *>(jpWallet);
+    const char* nativeString = jEnv->GetStringUTFChars(jTxId,JNI_FALSE);
+    char* pEnd;
+    unsigned long long id = strtoull(nativeString, &pEnd,10);
     jlong result = reinterpret_cast<jlong>(wallet_get_pending_outbound_transaction_by_id(pWallet,
-                                                                                         static_cast<unsigned long long>(jTxId),
+                                                                                         id,
                                                                                          r));
+    jEnv->ReleaseStringUTFChars(jTxId,nativeString);
     setErrorCode(jEnv, error, i);
     return result;
 }
@@ -489,14 +514,18 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniGetPendingInboundTxById(
         JNIEnv *jEnv,
         jobject jThis,
         jlong jpWallet,
-        jlong jTxId,
+        jstring jTxId,
         jobject error) {
     int i = 0;
     int *r = &i;
     TariWallet *pWallet = reinterpret_cast<TariWallet *>(jpWallet);
+    const char* nativeString = jEnv->GetStringUTFChars(jTxId,JNI_FALSE);
+    char* pEnd;
+    unsigned long long id = strtoull(nativeString, &pEnd,10);
     jlong result = reinterpret_cast<jlong>(wallet_get_pending_inbound_transaction_by_id(pWallet,
-                                                                                        static_cast<unsigned long long>(jTxId),
+                                                                                        id,
                                                                                         r));
+    jEnv->ReleaseStringUTFChars(jTxId,nativeString);
     setErrorCode(jEnv, error, i);
     return result;
 }
@@ -617,24 +646,31 @@ Java_com_tari_android_wallet_ffi_FFITestWallet_jniTestReceiveTx(
 
 extern "C"
 JNIEXPORT jlong JNICALL
-Java_com_tari_android_wallet_ffi_FFITestWallet_jniTestSendTx(
+Java_com_tari_android_wallet_ffi_FFIWallet_jniSendTx(
         JNIEnv *jEnv,
         jobject jThis,
         jlong jpWallet,
         jlong jdestination,
-        jlong jamount,
-        jlong jfee,
+        jstring jamount,
+        jstring jfee,
         jstring jmessage,
         jobject error) {
     int i = 0;
     int *r = &i;
     TariWallet *pWallet = reinterpret_cast<TariWallet *>(jpWallet);
     TariPublicKey *pDestination = reinterpret_cast<TariPublicKey *>(jdestination);
-    unsigned long long amount = static_cast<unsigned long long>(jamount);
-    unsigned long long fee = static_cast<unsigned long long>(jfee);
-    const char *pMessage = jEnv->GetStringUTFChars(jmessage, JNI_FALSE);
+    const char* nativeAmount = jEnv->GetStringUTFChars(jamount, JNI_FALSE);
+    const char* nativeFee = jEnv->GetStringUTFChars(jfee, JNI_FALSE);
+    const char* pMessage = jEnv->GetStringUTFChars(jmessage, JNI_FALSE);
+    char* pAmountEnd;
+    char* pFeeEnd;
+    unsigned long long fee = strtoull(nativeFee, &pFeeEnd,10);
+    unsigned long long amount = strtoull(nativeAmount, &pAmountEnd,10);
+
     jboolean result = wallet_send_transaction(pWallet, pDestination, amount, fee, pMessage, r) != 0;
     setErrorCode(jEnv, error, i);
+    jEnv->ReleaseStringUTFChars(jamount,nativeAmount);
+    jEnv->ReleaseStringUTFChars(jfee,nativeFee);
     jEnv->ReleaseStringUTFChars(jmessage, pMessage);
     return result;
 }

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIPendingOutboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIPendingOutboundTx.kt
@@ -56,6 +56,11 @@ internal class FFIPendingOutboundTx(pointer: FFIPendingOutboundTxPtr): FFIBase()
         libError: FFIError
     ): ByteArray
 
+    private external fun jniGetFee(
+        ptr: FFIPendingOutboundTxPtr,
+        libError: FFIError
+    ): ByteArray
+
     private external fun jniGetTimestamp(
         ptr: FFIPendingOutboundTxPtr,
         libError: FFIError
@@ -101,6 +106,15 @@ internal class FFIPendingOutboundTx(pointer: FFIPendingOutboundTxPtr): FFIBase()
     fun getAmount(): BigInteger {
         val error = FFIError()
         val bytes = jniGetAmount(ptr, error)
+        if (error.code != 0) {
+            throw RuntimeException()
+        }
+        return BigInteger(1, bytes)
+    }
+
+    fun getFee(): BigInteger {
+        val error = FFIError()
+        val bytes = jniGetFee(ptr, error)
         if (error.code != 0) {
             throw RuntimeException()
         }

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITestWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITestWallet.kt
@@ -32,6 +32,8 @@
  */
 package com.tari.android.wallet.ffi
 
+import java.math.BigInteger
+
 /**
  * Test wallet implementation. Contains only the test functions to separate concerns with
  * the actual wallet implementation.
@@ -75,15 +77,6 @@ internal class FFITestWallet(commsConfig: FFICommsConfig, logPath: String) :
 
     private external fun jniTestReceiveTx(walletPtr: FFIWalletPtr, libError: FFIError): Boolean
 
-    private external fun jniTestSendTx(
-        walletPtr: FFIWalletPtr,
-        publicKeyPtr: FFIPublicKeyPtr,
-        amount: Long,
-        fee: Long,
-        message: String,
-        libError: FFIError
-    ): Boolean
-
     // endregion
 
 
@@ -92,30 +85,6 @@ internal class FFITestWallet(commsConfig: FFICommsConfig, logPath: String) :
     fun generateTestData(datastorePath: String): Boolean {
         val error = FFIError()
         val result = jniGenerateTestData(getPointer(), datastorePath, error)
-        if (error.code != 0) {
-            throw RuntimeException()
-        }
-        return result
-    }
-
-    fun testSendTx(
-        destination: FFIPublicKey,
-        amount: Long,
-        fee: Long,
-        message: String
-    ): Boolean {
-        val minimumLibFee = 100
-        if (fee < minimumLibFee) {
-            throw RuntimeException("Fee is less than the minimum of $minimumLibFee taris.")
-        }
-        if (amount < 0) {
-            throw RuntimeException("Amount is less than 0.")
-        }
-        if (destination == getPublicKey()) {
-            throw RuntimeException("Tx source and destination are the same.")
-        }
-        val error = FFIError()
-        val result = jniTestSendTx(ptr, destination.getPointer(), amount, fee, message, error)
         if (error.code != 0) {
             throw RuntimeException()
         }

--- a/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
@@ -299,7 +299,7 @@ class WalletService : Service(), FFIWalletListenerAdapter {
         }
 
         override fun getCompletedTxById(id: TxId): CompletedTx {
-            val completedTxFFI = wallet.getCompletedTxById(id.value.toLong())
+            val completedTxFFI = wallet.getCompletedTxById(id.value)
             val sourcePublicKeyFFI = completedTxFFI.getSourcePublicKey()
             val destinationPublicKeyFFI = completedTxFFI.getDestinationPublicKey()
             val status = when (completedTxFFI.getStatus()) {
@@ -362,7 +362,7 @@ class WalletService : Service(), FFIWalletListenerAdapter {
         }
 
         override fun getPendingInboundTxById(id: TxId): PendingInboundTx {
-            val pendingInboundTxFFI = wallet.getPendingInboundTxById(id.value.toLong())
+            val pendingInboundTxFFI = wallet.getPendingInboundTxById(id.value)
             val sourcePublicKeyFFI = pendingInboundTxFFI.getSourcePublicKey()
             val pendingInboundTx = PendingInboundTx(
                 pendingInboundTxFFI.getId(),
@@ -405,7 +405,7 @@ class WalletService : Service(), FFIWalletListenerAdapter {
         }
 
         override fun getPendingOutboundTxById(id: TxId): PendingOutboundTx {
-            val pendingOutboundTxFFI = wallet.getPendingOutboundTxById(id.value.toLong())
+            val pendingOutboundTxFFI = wallet.getPendingOutboundTxById(id.value)
             val destinationPublicKeyFFI = pendingOutboundTxFFI.getDestinationPublicKey()
             val pendingOutboundTx = PendingOutboundTx(
                 pendingOutboundTxFFI.getId(),
@@ -426,16 +426,16 @@ class WalletService : Service(), FFIWalletListenerAdapter {
             fee: MicroTari,
             message: String
         ): Boolean {
-            return wallet.testSendTx(
+            return wallet.sendTx(
                 FFIPublicKey(HexString(contact.publicKeyHexString)),
-                amount.value.toLong(),
-                fee.value.toLong(),
+                amount.value,
+                fee.value,
                 message
             )
         }
 
         override fun testComplete(tx: PendingOutboundTx): Boolean {
-            val txFFI = wallet.getPendingOutboundTxById(tx.id.toLong())
+            val txFFI = wallet.getPendingOutboundTxById(tx.id)
             val success = wallet.testCompleteSentTx(txFFI)
             txFFI.destroy()
             return success

--- a/jniLibs/wallet.h
+++ b/jniLibs/wallet.h
@@ -205,6 +205,9 @@ struct TariPublicKey *pending_outbound_transaction_get_destination_public_key(st
 // Gets the amount of a TariPendingOutboundTransaction
 unsigned long long pending_outbound_transaction_get_amount(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
+// Gets the fee of a TariPendingOutboundTransaction
+unsigned long long pending_outbound_transaction_get_fee(struct TariPendingOutboundTransaction *transaction,int* error_out);
+
 // Gets the message of a TariPendingOutboundTransaction
 const char *pending_outbound_transaction_get_message(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
@@ -331,6 +334,10 @@ struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_
 
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);
+
+// Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
+// i.e the transaction was originally sent from the wallet
+bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct TariCompletedTransaction *tx,int* error_out);
 
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, struct TariCompletedTransaction *tx, int* error_out);


### PR DESCRIPTION
Fixed jni methods for getting transactions by id accepting long instead of BigInteger

Added additional methods to JNI:
1) Get fee for outbound transaction
2) Check if completed transaction was originally outbound transaction

Updated tests

Updated header