### PR TITLE
Ignore jniLibs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ fastlane/readme.md
 # cmake
 CMakeFiles/
 CMakeCache.txt
+
+jniLibs/


### PR DESCRIPTION
The 64bit binaries are too large to be included in the source code,
and are brought in by hand (built or downloaded)
so the jniLibs folder should be added to .gitgnore