### PR TITLE
Sending Tari: Adding a recipient by QR Code

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/model/QRScanData.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/QRScanData.kt
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.model
+
+/**
+ * QR scan result model class.
+ *
+ * @author The Tari Development Team
+ */
+data class QRScanData(val publicKey: String, val emojiId: String)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddRecipientFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddRecipientFragment.kt
@@ -32,7 +32,9 @@
  */
 package com.tari.android.wallet.ui.fragment.send
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.AsyncTask
 import android.os.Bundle
 import android.text.Editable
@@ -50,16 +52,14 @@ import butterknife.*
 import com.tari.android.wallet.R
 import com.tari.android.wallet.model.*
 import com.tari.android.wallet.service.TariWalletService
+import com.tari.android.wallet.ui.activity.EXTRA_QR_DATA
+import com.tari.android.wallet.ui.activity.QRScannerActivity
 import com.tari.android.wallet.ui.fragment.BaseFragment
 import com.tari.android.wallet.ui.fragment.send.adapter.RecipientListAdapter
 import com.tari.android.wallet.ui.util.UiUtil
 import com.tari.android.wallet.util.*
-import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.Constants.Wallet.emojiFormatterChunkSize
 import com.tari.android.wallet.util.Constants.Wallet.emojiIdLength
-import com.tari.android.wallet.util.EmojiUtil
-import com.tari.android.wallet.util.numberOfEmojis
-import com.tari.android.wallet.util.firstNCharactersAreEmojis
 import java.lang.ref.WeakReference
 import kotlin.math.min
 
@@ -68,6 +68,9 @@ import kotlin.math.min
  *
  * @author The Tari Development Team
  */
+
+private const val REQUEST_QR_SCANNER = 101
+
 class AddRecipientFragment(private val walletService: TariWalletService) : BaseFragment(),
     RecipientListAdapter.Listener,
     RecyclerView.OnItemTouchListener,
@@ -198,6 +201,15 @@ class AddRecipientFragment(private val walletService: TariWalletService) : BaseF
         listenerWR = WeakReference(context as Listener)
     }
 
+    /**
+     * Open QR code scanner on button click.
+     */
+    @OnClick(R.id.add_recipient_btn_qr_code)
+    fun onQrButtonClick() {
+        val intent = Intent(activity, QRScannerActivity::class.java)
+        startActivityForResult(intent, REQUEST_QR_SCANNER)
+        activity?.overridePendingTransition(R.anim.slide_up, 0)
+    }
 
     /**
      * Checks whether an emoji id is in the clipboard data.
@@ -542,6 +554,19 @@ class AddRecipientFragment(private val walletService: TariWalletService) : BaseF
 
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == REQUEST_QR_SCANNER && resultCode == Activity.RESULT_OK && data != null) {
+            data.getStringExtra(EXTRA_QR_DATA)?.let {
+                val qrData = WalletUtil.getQrScanData(it)
+                searchEditText.setText(
+                    qrData.emojiId,
+                    TextView.BufferType.EDITABLE
+                )
+            }
+        }
+    }
     // end region
 
     // region listener interface

--- a/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
@@ -32,7 +32,9 @@
  */
 package com.tari.android.wallet.util
 
+import android.net.Uri
 import com.tari.android.wallet.model.MicroTari
+import com.tari.android.wallet.model.QRScanData
 import java.io.File
 import java.math.BigInteger
 import java.math.RoundingMode
@@ -88,5 +90,20 @@ internal object WalletUtil {
 
     fun getQRContent(publicKey: String, emojiId: String): String {
         return Constants.Wallet.QR_DEEP_LINK_URL + "/$publicKey?emoji_id=$emojiId"
+    }
+
+    /*
+    *  PublicKey and emojiId data from qr scan result
+    * */
+    fun getQrScanData(content: String): QRScanData {
+        val url = Uri.parse(content)
+        val pathSegment = url.pathSegments
+        var publickKey = ""
+        if (pathSegment.isNotEmpty()) {
+            publickKey = pathSegment[0]
+        }
+        val emojiId = url.getQueryParameter("emoji_id") ?: ""
+
+        return QRScanData(publickKey, emojiId)
     }
 }


### PR DESCRIPTION
Fixes #70

Changes:
 - Use QR scanner activity to allow adding recipient by scanning QR code. 