### PR TITLE
Integrate Tor proxy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,4 +126,7 @@ dependencies {
 
     // encryption
     implementation "de.adorsys.android:securestoragelibrary:1.0.0"
+
+    // Tor binary
+    implementation 'org.torproject:tor-android-binary:0.4.2.5'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:extractNativeLibs="true"
         android:theme="@style/AppTheme"
         tools:replace="android:allowBackup">
 
@@ -33,6 +34,12 @@
                 <action android:name="com.tari.android.wallet.service.TariWalletService" />
             </intent-filter>
         </service>
+
+        <!-- Tor background service -->
+        <service
+            android:name=".service.TorService"
+            android:process=":torservice" />
+
         <!-- this receiver restarts the service on destroy & keeps the service running -->
         <receiver
             android:name=".service.ServiceRestartBroadcastReceiver"

--- a/app/src/main/aidl/com/tari/android/wallet/service/TariTorService.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariTorService.aidl
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.service;
+
+// import listener class
+import com.tari.android.wallet.service.TariTorServiceListener;
+
+interface TariTorService {
+
+    /**
+    * Registers new Tor service listener.
+    * Registered listener will be unregistered on death.
+    */
+    void registerListener(TariTorServiceListener listener);
+
+    /**
+    * Unregisters Tor service listener.
+    */
+    void unregisterListener(TariTorServiceListener listener);
+
+    /**
+    * Starts TOR with given config, it's a non-blocking function. Callers should use listener
+    * for error notifications
+    */
+    void start(int socksPort, String controlHost, int controlPort, String sock5Username, String sock5Password);
+
+}

--- a/app/src/main/aidl/com/tari/android/wallet/service/TariTorServiceListener.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariTorServiceListener.aidl
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.service;
+
+oneway interface TariTorServiceListener {
+
+    void onTorServiceError(in String error);
+
+}

--- a/app/src/main/cpp/jniTransportType.cpp
+++ b/app/src/main/cpp/jniTransportType.cpp
@@ -72,21 +72,22 @@ Java_com_tari_android_wallet_ffi_FFITransportType_jniTorTransport(
         jobject jThis,
         jstring jpControl,
         jint jPort,
-        jstring jpTorPassword,
-        jlong jpTorKey,
+        jlong jpTorCookie,
+        jlong jpTorIdentity,
         jstring jpSocksUser,
         jstring jpSocksPass,
         jobject error) {
     int i = 0;
     int *r = &i;
     char *pControl = const_cast<char *>(jEnv->GetStringUTFChars(jpControl, JNI_FALSE));
-    char *pTorPassword = const_cast<char *>(jEnv->GetStringUTFChars(jpTorPassword, JNI_FALSE));
+    ByteVector *pTorCookie = reinterpret_cast<ByteVector *>(jpTorCookie);
+    ByteVector *pTorIdentity = reinterpret_cast<ByteVector *>(jpTorIdentity);
     char *pSocksUsername = const_cast<char *>(jEnv->GetStringUTFChars(jpSocksUser, JNI_FALSE));
     char *pSocksPassword = const_cast<char *>(jEnv->GetStringUTFChars(jpSocksPass, JNI_FALSE));
-    ByteVector *pByteVector = reinterpret_cast<ByteVector *>(jpTorKey);
-    TariTransportType *transport = transport_tor_create(pControl,pTorPassword,pByteVector,static_cast<unsigned short>(jPort),pSocksUsername,pSocksPassword,r);
+    TariTransportType *transport = transport_tor_create(pControl, pTorCookie, pTorIdentity,
+                                                        static_cast<unsigned short>(jPort),
+                                                        pSocksUsername, pSocksPassword, r);
     jEnv->ReleaseStringUTFChars(jpControl, pControl);
-    jEnv->ReleaseStringUTFChars(jpTorPassword, pTorPassword);
     jEnv->ReleaseStringUTFChars(jpSocksUser, pSocksUsername);
     jEnv->ReleaseStringUTFChars(jpSocksPass, pSocksPassword);
     setErrorCode(jEnv, error, i);

--- a/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
@@ -64,7 +64,8 @@ import javax.inject.Singleton
         ApplicationModule::class,
         WalletModule::class,
         RestModule::class,
-        ConfigModule::class
+        ConfigModule::class,
+        TorModule::class
     ]
 )
 internal interface ApplicationComponent {

--- a/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.di
+
+import android.content.Context
+import com.tari.android.wallet.service.DIRECTORY_TOR_DATA
+import dagger.Module
+import dagger.Provides
+import java.io.File
+import java.net.ServerSocket
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * Dagger module to inject Tor-related dependencies.
+ *
+ * @author The Tari Development Team
+ */
+@Module
+class TorModule {
+
+    object FieldName {
+        const val torProxyPort = "tor_proxy_port"
+        const val torConnectionPort = "tor_connection_port"
+        const val torControlPort = "tor_control_port"
+        const val torControlHost = "tor_control_host"
+        const val torCookieFilePath = "tor_cookie_file_path"
+        const val torIdentity = "tor_identity"
+        const val torSock5Username = "tor_sock5_username"
+        const val torSock5Password = "tor_sock5_password"
+    }
+
+    /**
+     * Provides a port for TOR connection
+     */
+    @Provides
+    @Named(FieldName.torConnectionPort)
+    @Singleton
+    internal fun provideConnectionPort(): Int {
+        val socket = ServerSocket(0)
+        val port = socket.localPort
+        socket.close()
+        return port
+    }
+
+    /**
+     * Provides a port for TOR proxy
+     */
+    @Provides
+    @Named(FieldName.torProxyPort)
+    @Singleton
+    internal fun provideTorProxyPort(): Int {
+        val socket = ServerSocket(0)
+        val port = socket.localPort
+        socket.close()
+        return port
+    }
+
+    /**
+     * Provides a port for TOR control
+     */
+    @Provides
+    @Named(FieldName.torControlPort)
+    @Singleton
+    internal fun provideTorControlPort(): Int {
+        val socket = ServerSocket(0)
+        val port = socket.localPort
+        socket.close()
+        return port
+    }
+
+    /**
+     * Provides host for TOR control
+     */
+    @Provides
+    @Named(FieldName.torControlHost)
+    @Singleton
+    internal fun provideTorControlAddress(): String {
+        return "127.0.0.1"
+    }
+
+    /**
+     * Provides cookie file path for TOR
+     */
+    @Provides
+    @Named(FieldName.torCookieFilePath)
+    @Singleton
+    internal fun provideTorControlPassword(context: Context): String {
+        return File(
+            context.getDir(DIRECTORY_TOR_DATA, Context.MODE_PRIVATE),
+            "control_auth_cookie"
+        ).canonicalPath
+    }
+
+    /**
+     * Provides cookie file path for TOR
+     */
+    @Provides
+    @Named(FieldName.torIdentity)
+    @Singleton
+    internal fun provideTorIdentity(): ByteArray {
+        return ByteArray(0)
+    }
+
+    /**
+     * Provides sock5 username for TOR
+     */
+    @Provides
+    @Named(FieldName.torSock5Username)
+    @Singleton
+    internal fun provideTorSock5Username(): String {
+        return "user123"
+    }
+
+    /**
+     * Provides sock5 password for TOR
+     */
+    @Provides
+    @Named(FieldName.torSock5Password)
+    @Singleton
+    internal fun provideTorSock5Password(): String {
+        return "123456"
+    }
+
+    /**
+     * Provides config for TOR
+     */
+    @Provides
+    @Singleton
+    internal fun provideTorConfig(
+        @Named(FieldName.torControlHost) controlHost: String,
+        @Named(FieldName.torControlPort) controlPort: Int,
+        @Named(FieldName.torProxyPort) proxyPort: Int,
+        @Named(FieldName.torConnectionPort) connectionPort: Int,
+        @Named(FieldName.torCookieFilePath) cookieFilePath: String,
+        @Named(FieldName.torIdentity) torIdentity: ByteArray,
+        @Named(FieldName.torSock5Username) sock5Username: String,
+        @Named(FieldName.torSock5Password) sock5Passsword: String
+    ): TorConfig {
+        return TorConfig(
+            controlPort = controlPort,
+            controlHost = controlHost,
+            proxyPort = proxyPort,
+            connectionPort = connectionPort,
+            cookieFilePath = cookieFilePath,
+            identity = torIdentity,
+            sock5Username = sock5Username,
+            sock5Password = sock5Passsword
+        )
+    }
+}
+
+data class TorConfig(
+    val proxyPort: Int,
+    val controlHost: String,
+    val controlPort: Int,
+    val connectionPort: Int,
+    val cookieFilePath: String,
+    val identity: ByteArray,
+    val sock5Username: String,
+    val sock5Password: String
+)

--- a/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
@@ -38,6 +38,7 @@ import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.SharedPrefsWrapper
 import dagger.Module
 import dagger.Provides
+import java.io.File
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -87,18 +88,56 @@ internal class WalletModule {
     }
 
     /**
+     * Provides transport for wallet to use
+     */
+    @Provides
+    @Singleton
+    internal fun provideTorTransport(
+        torConfig: TorConfig
+    ): FFITransportType {
+
+
+        val cookieFile = File(torConfig.cookieFilePath)
+        var cookieString = ByteArray(0)
+        if (cookieFile.exists()) {
+            cookieString = cookieFile.readBytes()
+        }
+
+        val torCookie = FFIByteVector(cookieString)
+        var torIdentity = FFIByteVector(nullptr)
+        if (torConfig.identity.isNotEmpty()) {
+            torIdentity.destroy()
+            torIdentity = FFIByteVector(torConfig.identity)
+        }
+        return FFITransportType(
+            NetAddressString(
+                torConfig.controlHost,
+                torConfig.controlPort
+            ),
+            torConfig.connectionPort,
+            torCookie,
+            torIdentity,
+            torConfig.sock5Username,
+            torConfig.sock5Password
+        )
+    }
+
+    /**
      * Provides CommsConfig object for wallet configuration.
      */
     @Provides
     @Singleton
     internal fun provideCommsConfig(
         sharedPrefsWrapper: SharedPrefsWrapper,
-        @Named(FieldName.walletFilesDirPath) walletFilesDirPath: String
+        @Named(FieldName.walletFilesDirPath) walletFilesDirPath: String,
+        transport: FFITransportType
     ): FFICommsConfig {
-        //TODO: Change to tor
-        val transport = FFITransportType()
         return FFICommsConfig(
-            transport.getAddress(),
+            NetAddressString(
+                "127.0.0.1",
+                39069
+            ).toString(),
+            //transport.getAddress(),
             transport,
             Constants.Wallet.WALLET_DB_NAME,
             walletFilesDirPath,
@@ -124,6 +163,16 @@ internal class WalletModule {
             sharedPrefsWrapper.publicKeyHexString = publicKeyFFI.toString()
             sharedPrefsWrapper.emojiId = publicKeyFFI.getEmojiNodeId()
             publicKeyFFI.destroy()
+            //Todo: Below needs to be run once on first run
+
+            val baseNodeKeyFFI =
+                FFIPublicKey(HexString("90d8fe54c377ecabff383f7d8f0ba708c5b5d2a60590f326fbf1a2e74ea2441f"))
+            val baseNodeAddress =
+                "/onion3/plvcskybsckbfeubywjbmpnbm4kjqm2ip6kbwimakaim6xyucydpityd:18001"
+            wallet.addBaseNodePeer(baseNodeKeyFFI, baseNodeAddress)
+
+            baseNodeKeyFFI.destroy()
+
 
         }
         return FFITestWallet.instance!!

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIByteVector.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIByteVector.kt
@@ -70,6 +70,12 @@ internal class FFIByteVector constructor(pointer: FFIByteVectorPtr) : FFIBase() 
         }
     }
 
+    constructor(bytes: ByteArray) : this(nullptr) {
+        val error = FFIError()
+        ptr = jniCreate(bytes, error)
+        throwIf(error)
+    }
+
     fun getLength(): Int {
         val error = FFIError()
         val len = jniGetLength(ptr, error)

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITransportType.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITransportType.kt
@@ -57,8 +57,8 @@ internal class FFITransportType constructor(pointer: FFITransportTypePtr) : FFIB
     private external fun jniTorTransport(
         control_server_address: String,
         tor_port: Int,
-        tor_password: String,
-        tor_private_key: FFIByteVectorPtr,
+        tor_cookie: FFIByteVectorPtr,
+        tor_identity: FFIByteVectorPtr,
         socks_username: String,
         socks_password: String,
         libError: FFIError
@@ -86,8 +86,8 @@ internal class FFITransportType constructor(pointer: FFITransportTypePtr) : FFIB
     constructor(
         controlAddress: NetAddressString,
         torPort: Int,
-        torPassword: String,
-        torKey: FFIByteVector,
+        torCookie: FFIByteVector,
+        torIdentity: FFIByteVector,
         socksUsername: String,
         socksPassword: String
     ) : this(nullptr) {
@@ -95,15 +95,14 @@ internal class FFITransportType constructor(pointer: FFITransportTypePtr) : FFIB
         ptr = jniTorTransport(
             controlAddress.toString(),
             torPort,
-            torPassword,
-            torKey.getPointer(),
+            torCookie.getPointer(),
+            torIdentity.getPointer(),
             socksUsername,
             socksPassword,
             error
         )
         throwIf(error)
     }
-
     fun getPointer(): FFIPrivateKeyPtr {
         return ptr
     }

--- a/app/src/main/java/com/tari/android/wallet/service/TorService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/TorService.kt
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.service
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import org.torproject.android.binary.TorResourceInstaller
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+private const val TAG = "TorService"
+
+const val DIRECTORY_TOR_DATA = "tordata"
+
+class TorService : Service() {
+
+    private val listeners = mutableListOf<TariTorServiceListener>()
+
+    private var torBinPath: String? = null
+    private var installSuccess: Boolean = false
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service created")
+
+        installTor()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Service destroyed")
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return binder
+    }
+
+    private fun installTor() {
+        try {
+            val torResourceInstaller = TorResourceInstaller(this, filesDir)
+            val fileTorBin = torResourceInstaller.installResources()
+            installSuccess = fileTorBin != null && fileTorBin.canExecute()
+
+            if (installSuccess) {
+                Log.d(TAG, "TOR install success")
+                torBinPath = fileTorBin.canonicalPath
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "TOR install error: " + t.message)
+        }
+    }
+
+    private fun runTor(
+        socksPort: Int,
+        controlHost: String,
+        controlPort: Int,
+        sock5Username: String,
+        sock5Password: String
+    ) {
+        val appCacheHome =
+            getDir(DIRECTORY_TOR_DATA, MODE_PRIVATE)
+
+        val torCmdString = "${torBinPath!!} DataDirectory ${appCacheHome.canonicalPath} " +
+                "--allow-missing-torrc --ignore-missing-torrc " +
+                "--clientonly 1 " +
+                "--socksport $socksPort " +
+                "--controlport $controlHost:$controlPort " +
+                "--CookieAuthentication 1 " +
+                "--Socks5ProxyUsername $sock5Username " +
+                "--Socks5ProxyPassword $sock5Password " +
+                "--clientuseipv6 1"
+
+        var output = ""
+        try {
+            output = exec(torCmdString)
+        } catch (e: Throwable) {
+            Log.e(TAG, "Error while running TOR: " + e.message)
+            notifyError("Error while running TOR: " + e.message)
+        }
+
+        Log.d(TAG, "Tor finished with output $output")
+    }
+
+    private fun exec(command: String): String {
+        return try { // Executes the command.
+            val process =
+                Runtime.getRuntime().exec(command)
+            // Reads stdout.
+            val response = BufferedReader(
+                InputStreamReader(process.inputStream)
+            ).use(BufferedReader::readText)
+            // Waits for the command to finish.
+            process.waitFor()
+            response
+        } catch (e: Throwable) {
+            throw RuntimeException(e)
+        }
+    }
+
+    private fun checkAndNotifyInstallSuccess(): Boolean {
+        if (!installSuccess) {
+            notifyError("Tari install has failed, check logs for more details...")
+        }
+        return installSuccess
+    }
+
+    private fun notifyError(error: String?) {
+        error?.let { err -> listeners.forEach { it.onTorServiceError(err) } }
+    }
+
+    private val binder = object : TariTorService.Stub() {
+        override fun registerListener(listener: TariTorServiceListener) {
+            listeners.add(listener)
+            listener.asBinder().linkToDeath({
+                listeners.remove(listener)
+            }, 0)
+        }
+
+        override fun unregisterListener(listener: TariTorServiceListener) {
+            listeners.remove(listener)
+        }
+
+        override fun start(
+            socksPort: Int,
+            controlHost: String,
+            controlPort: Int,
+            sock5Username: String,
+            sock5Password: String
+        ) {
+            if (!checkAndNotifyInstallSuccess()) return
+
+            Thread {
+                runTor(
+                    socksPort,
+                    controlHost,
+                    controlPort,
+                    sock5Username,
+                    sock5Password
+                )
+            }.start()
+        }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/util/AppUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/AppUtil.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.util
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Process
+
+/**
+ * Provides name of the process this context is running in
+ */
+fun getProcessNameCompat(context: Context): String? {
+    val pid = Process.myPid()
+    val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    return manager?.runningAppProcesses?.filterNotNull()?.firstOrNull { it.pid == pid }?.processName
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+        maven { url "https://raw.githubusercontent.com/guardianproject/gpmaven/master" }
     }
 }
 


### PR DESCRIPTION
Closes #131

Changes:
 - Integrates TOR proxy and run it in a separate process. I think running it in a separate process should be fine as we are binding it forever from the main app process. However, if there are instances where it keeps getting killed by android system, we should move it to the main process.

TODO:
 - Use Tor config in wallet initialization. Currently, it's done in module but we will need to do it outside as we need hashed password of Tor, which will be available once Tor service starts and gets binded to app.