### PR TITLE
Separate log files for each run

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
@@ -43,6 +43,8 @@ import com.tari.android.wallet.ui.activity.onboarding.OnboardingFlowActivity
 import com.tari.android.wallet.ui.activity.profile.WalletInfoActivity
 import com.tari.android.wallet.ui.activity.send.SendTariActivity
 import com.tari.android.wallet.ui.activity.tx.TxDetailActivity
+import com.tari.android.wallet.ui.fragment.log.DebugLogFilePickerFragment
+import com.tari.android.wallet.ui.fragment.log.DebugLogFragment
 import com.tari.android.wallet.ui.fragment.onboarding.CreateWalletFragment
 import com.tari.android.wallet.ui.fragment.onboarding.IntroductionFragment
 import com.tari.android.wallet.ui.fragment.onboarding.LocalAuthFragment
@@ -79,6 +81,7 @@ internal interface ApplicationComponent {
      * Activities.
      */
     fun inject(activity: SplashActivity)
+
     fun inject(activity: OnboardingFlowActivity)
     fun inject(activity: AuthActivity)
     fun inject(activity: HomeActivity)
@@ -92,12 +95,16 @@ internal interface ApplicationComponent {
      * Fragments.
      */
     fun inject(fragment: IntroductionFragment)
+
     fun inject(fragment: CreateWalletFragment)
     fun inject(fragment: AddRecipientFragment)
     fun inject(fragment: AddAmountFragment)
     fun inject(fragment: AddNoteAndSendFragment)
     fun inject(fragment: SendTxSuccessfulFragment)
     fun inject(fragment: LocalAuthFragment)
+    fun inject(fragment: DebugLogFragment)
+    fun inject(fragment: DebugLogFilePickerFragment)
+
 
     /**
      * Service(s).

--- a/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
@@ -39,6 +39,8 @@ import com.tari.android.wallet.util.SharedPrefsWrapper
 import dagger.Module
 import dagger.Provides
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -55,7 +57,7 @@ internal class WalletModule {
         const val walletLogFilePath = "wallet_log_file_path"
     }
 
-    private val logFileName = "tari_wallet.log"
+    private val logFilePrefix = "tari_wallet_"
 
     /**
      * The directory in which the wallet files reside.
@@ -70,7 +72,10 @@ internal class WalletModule {
     @Provides
     @Named(FieldName.walletLogFilePath)
     internal fun provideWalletLogFilePath(@Named(FieldName.walletFilesDirPath) walletFilesDirPath: String): String {
-        return "$walletFilesDirPath/$logFileName"
+        val timeStamp = SimpleDateFormat("YYYYMMdd", Locale.getDefault()).format(Date()) +
+                "_${System.currentTimeMillis()}"
+
+        return "$walletFilesDirPath/$logFilePrefix$timeStamp.log"
     }
 
     /**

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/BaseFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/BaseFragment.kt
@@ -39,6 +39,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import butterknife.ButterKnife
 import com.tari.android.wallet.application.TariWalletApplication
+import com.tari.android.wallet.ui.fragment.log.DebugLogFilePickerFragment
+import com.tari.android.wallet.ui.fragment.log.DebugLogFragment
 import com.tari.android.wallet.ui.fragment.onboarding.CreateWalletFragment
 import com.tari.android.wallet.ui.fragment.onboarding.IntroductionFragment
 import com.tari.android.wallet.ui.fragment.onboarding.LocalAuthFragment
@@ -71,6 +73,9 @@ abstract class BaseFragment : Fragment() {
             is AddNoteAndSendFragment -> component.inject(this)
             is SendTxSuccessfulFragment -> component.inject(this)
             is LocalAuthFragment -> component.inject(this)
+            is DebugLogFragment -> component.inject(this)
+            is DebugLogFilePickerFragment -> component.inject(this)
+
         }
         // bind views
         val view = inflater.inflate(contentViewId, container, false)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/log/DebugLogFilePickerFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/log/DebugLogFilePickerFragment.kt
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.ui.fragment.log
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import butterknife.BindView
+import butterknife.OnClick
+import com.tari.android.wallet.R
+import com.tari.android.wallet.di.WalletModule
+import com.tari.android.wallet.ui.fragment.BaseFragment
+import com.tari.android.wallet.ui.util.UiUtil
+import com.tari.android.wallet.util.WalletUtil
+import java.io.File
+import java.util.*
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Debug: show list of log files.
+ *
+ * @author The Tari Development Team
+ */
+class DebugLogFilePickerFragment : BaseFragment() {
+
+    @BindView(R.id.log_file_vw_files_listview)
+    lateinit var logFileListView: ListView
+
+    @Inject
+    @Named(WalletModule.FieldName.walletFilesDirPath)
+    lateinit var walletFilesDirPath: String
+
+    private var listener: Listener? = null
+    override val contentViewId: Int
+        get() = R.layout.fragment_log_file_list
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (context is Listener) {
+            listener = context
+        } else {
+            throw AssertionError("Activity must implement listener")
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val fileList = WalletUtil.getLogFilesFromDirectory(walletFilesDirPath)
+        val adapter: ArrayAdapter<String> =
+            ArrayAdapter(
+                context!!,
+                android.R.layout.simple_list_item_1,
+                getFileNames(fileList)
+            )
+
+        logFileListView.adapter = adapter
+
+        logFileListView.setOnItemClickListener { _, _, position, _ ->
+            listener?.onLogFileSelected(position)
+        }
+    }
+
+    @OnClick(R.id.log_file_btn_back)
+    fun onBackButtonPressed(view: View) {
+        UiUtil.temporarilyDisableClick(view)
+        activity?.supportFragmentManager?.popBackStack()
+
+    }
+
+    private fun getFileNames(files: List<File>): List<String> {
+        val filesName = ArrayList<String>()
+        files.forEach { file -> filesName.add(file.name) }
+        return filesName
+    }
+
+    interface Listener {
+        fun onLogFileSelected(position: Int)
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/log/DebugLogFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/log/DebugLogFragment.kt
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.ui.fragment.log
+
+import android.content.Context
+import android.os.Bundle
+import android.text.method.ScrollingMovementMethod
+import android.view.View
+import android.widget.EditText
+import butterknife.BindView
+import butterknife.OnClick
+import com.tari.android.wallet.R
+import com.tari.android.wallet.di.WalletModule
+import com.tari.android.wallet.ui.fragment.BaseFragment
+import com.tari.android.wallet.ui.util.UiUtil
+import com.tari.android.wallet.util.WalletUtil
+import java.io.File
+import java.io.InputStream
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Debug: show logs from file.
+ *
+ * @author The Tari Development Team
+ */
+class DebugLogFragment : BaseFragment() {
+    override val contentViewId: Int
+        get() = R.layout.fragment_debug_log
+
+    @Inject
+    @Named(WalletModule.FieldName.walletFilesDirPath)
+    lateinit var walletFilesDirPath: String
+    @Inject
+    @Named(WalletModule.FieldName.walletLogFilePath)
+    internal lateinit var logFilePath: String
+
+    @BindView(R.id.debug_log_multiline_edit)
+    lateinit var multilineEdit: EditText
+
+    private var listener: DebugListener? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (context is DebugListener) {
+            listener = context
+        } else {
+            throw AssertionError("Activity must implement listener")
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupUi()
+    }
+
+    @OnClick(R.id.debug_log_img_btn_more_file_list)
+    fun onMoreLogsFileClick(view: View) {
+        UiUtil.temporarilyDisableClick(view)
+        listener?.onFilePickerClick()
+    }
+
+    @OnClick(R.id.debug_log_btn_back)
+    fun onBackButtonPressed(view: View) {
+        UiUtil.temporarilyDisableClick(view)
+        activity?.finish()
+        activity?.overridePendingTransition(R.anim.enter_from_left, R.anim.exit_to_right)
+    }
+
+    private fun setupUi() {
+        val files = WalletUtil.getLogFilesFromDirectory(walletFilesDirPath)
+        if (!files.isNullOrEmpty()) {
+            val logFile = files[0]
+            fetchLogFromFile(logFile)
+        }
+
+    }
+
+    private fun fetchLogFromFile(logFile: File) {
+        multilineEdit.text.clear()
+        multilineEdit.setHorizontallyScrolling(true)
+        multilineEdit.movementMethod = ScrollingMovementMethod()
+
+        val lineList = mutableListOf<String>()
+
+        if (logFile.exists()) {
+            val inputStream: InputStream = logFile.inputStream()
+            inputStream.bufferedReader()
+                .useLines { lines -> lines.forEach { lineList.add(it) } }
+        } else {
+            lineList.add("No log available")
+        }
+        lineList.forEach { multilineEdit.append(it + "\n") }
+    }
+
+    fun refreshLogs(position: Int) {
+        val files = WalletUtil.getLogFilesFromDirectory(walletFilesDirPath)
+        fetchLogFromFile(files[position])
+    }
+
+    interface DebugListener {
+        fun onFilePickerClick()
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
@@ -37,9 +37,9 @@ import com.tari.android.wallet.extension.toMicroTari
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.QRScanData
 import java.io.File
-import java.math.BigInteger
 import java.math.RoundingMode
 import java.text.DecimalFormat
+import java.util.*
 
 /**
  * Wallet utility functions.
@@ -106,5 +106,13 @@ internal object WalletUtil {
         val emojiId = url.getQueryParameter("emoji_id") ?: ""
 
         return QRScanData(publickKey, emojiId)
+    }
+
+    fun getLogFilesFromDirectory(dirPath: String): List<File> {
+        val root = File(dirPath)
+        val files: MutableList<File>? = root.listFiles()?.toMutableList()
+        val filteredFile = files?.filter { it.extension == "log" }?.toMutableList()
+        filteredFile?.sortByDescending { it.lastModified() }
+        return filteredFile ?: Collections.emptyList()
     }
 }

--- a/app/src/main/res/drawable/ic_more_vert_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_more_vert_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/layout/activity_debug_log.xml
+++ b/app/src/main/res/layout/activity_debug_log.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/debug_frame_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_debug_log.xml
+++ b/app/src/main/res/layout/fragment_debug_log.xml
@@ -32,21 +32,31 @@
             android:textColor="@color/black"
             android:textSize="16sp"
             app:customFont="AVENIR_LT_STD_HEAVY" />
+
+        <!-- more -->
+        <ImageView
+            android:id="@+id/debug_log_img_btn_more_file_list"
+            android:layout_width="50dp"
+            android:padding="12dp"
+            android:layout_height="match_parent"
+            android:layout_alignParentRight="true"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_more_vert_black_24dp" />
     </RelativeLayout>
-        <EditText
-            android:id="@+id/debug_log_multiline_edit"
-            android:textColor="@color/terminal_green"
-            android:textSize="12sp"
-            android:background="@color/black"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:gravity="start|top"
-            android:inputType="textMultiLine"
-            android:importantForAutofill="no"
-            android:hint="@string/debug_log_title"
-            android:labelFor="@id/debug_log_txt_title"
-            android:focusable="false"
-            android:clickable="false"
-            />
+
+    <EditText
+        android:id="@+id/debug_log_multiline_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/black"
+        android:clickable="false"
+        android:ems="10"
+        android:focusable="false"
+        android:gravity="start|top"
+        android:hint="@string/debug_log_title"
+        android:importantForAutofill="no"
+        android:inputType="textMultiLine"
+        android:labelFor="@id/debug_log_txt_title"
+        android:textColor="@color/terminal_green"
+        android:textSize="12sp" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_log_file_list.xml
+++ b/app/src/main/res/layout/fragment_log_file_list.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <!-- Log header -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/common_header_height"
+        android:layout_marginTop="0dp"
+        android:background="@color/white">
+
+        <!-- back -->
+        <ImageButton
+            android:id="@+id/log_file_btn_back"
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/white"
+            android:contentDescription="@null"
+            android:src="@drawable/back_icon" />
+
+        <com.tari.android.wallet.ui.component.CustomFontTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/debug_log_file_list_log_title"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:customFont="AVENIR_LT_STD_HEAVY" />
+    </RelativeLayout>
+
+    <!-- listview -->
+    <ListView
+        android:layout_width="match_parent"
+        android:id="@+id/log_file_vw_files_listview"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,5 +159,6 @@
     <string name="auth_prompt_button_text">Enable your %1s</string>
     <string name="auth_prompt_touch_id_desc">We recommend using Touch ID to access your\nTari wallet for security and ease of use.</string>
     <string name="auth_prompt_pin_desc">We recommend using your device PIN to access your\nTari wallet for security and ease of use.</string>
+    <string name="debug_log_file_list_log_title">Log Files</string>
 
 </resources>


### PR DESCRIPTION
Closes #139

Changes:
 - Save each app run logs in a different file
 - Add log display fragment
 - Add log picker fragment