### PR TITLE
Start the wallet service at OS boot time

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,16 +12,17 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".application.TariWalletApplication"
         android:allowBackup="true"
+        android:extractNativeLibs="true"
         android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:extractNativeLibs="true"
         android:theme="@style/AppTheme"
         tools:replace="android:allowBackup">
 
@@ -122,6 +123,17 @@
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme"
             android:windowSoftInputMode="adjustPan|stateAlwaysHidden" />
+
+        <!-- This receiver is responsible for starting the service after boot finish.-->
+        <receiver
+            android:name=".service.BootDeviceReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
@@ -33,6 +33,7 @@
 package com.tari.android.wallet.di
 
 import com.tari.android.wallet.application.TariWalletApplication
+import com.tari.android.wallet.service.BootDeviceReceiver
 import com.tari.android.wallet.service.WalletService
 import com.tari.android.wallet.ui.activity.AuthActivity
 import com.tari.android.wallet.ui.activity.QRScannerActivity
@@ -106,10 +107,14 @@ internal interface ApplicationComponent {
     fun inject(fragment: DebugLogFragment)
     fun inject(fragment: DebugLogFilePickerFragment)
 
-
     /**
      * Service(s).
      */
     fun inject(service: WalletService)
+
+    /*
+    * Broadcast receiver
+    * */
+    fun inject(receiver: BootDeviceReceiver)
 
 }

--- a/app/src/main/java/com/tari/android/wallet/service/BootDeviceReceiver.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/BootDeviceReceiver.kt
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 The Tari Project
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of
+ * its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tari.android.wallet.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import com.orhanobut.logger.Logger
+import com.tari.android.wallet.application.TariWalletApplication
+import com.tari.android.wallet.di.WalletModule
+import com.tari.android.wallet.util.SharedPrefsWrapper
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * This receiver is responsible for starting the service after boot finish.
+ *
+ * @author The Tari Development Team
+ */
+class BootDeviceReceiver : BroadcastReceiver() {
+
+    @Inject
+    @Named(WalletModule.FieldName.walletFilesDirPath)
+    lateinit var walletFilesDirPath: String
+    @Inject
+    internal lateinit var sharedPrefsWrapper: SharedPrefsWrapper
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context == null || intent == null) return
+        Logger.d("Boot device broadcast received.")
+
+        (context.applicationContext as TariWalletApplication).appComponent.inject(this)
+
+        val walletExists = File(walletFilesDirPath).list()!!.isNotEmpty()
+        if (walletExists && sharedPrefsWrapper.onboardingAuthSetupCompleted && Intent.ACTION_BOOT_COMPLETED == intent.action) {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, WalletService::class.java)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #136 

Changes:
 - Add boot event receiver and start wallet service on boot event callback.