### PR TITLE
Update jniWallet.cpp

### DIFF
--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -80,6 +80,9 @@ JNIEnv *getJNIEnv() {
         case JNI_EDETACHED: {
             if (g_vm->AttachCurrentThread(&jniEnv, nullptr) != 0) {
                 LOGE("VM failed to attach.");
+            } else
+            {
+                result = jniEnv;
             }
             break;
         }


### PR DESCRIPTION
jniEnv address was not being returned if AttachCurrentThread was successful.