### PR TITLE
Fix QR encoding bug

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/util/UiUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/util/UiUtil.kt
@@ -51,6 +51,7 @@ import androidx.annotation.NonNull
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import com.tari.android.wallet.util.Constants
 import java.lang.ref.WeakReference
@@ -274,10 +275,11 @@ internal object UiUtil {
     fun getQREncodedBitmap(content: String, size: Int): Bitmap? {
         try {
             val barcodeEncoder = BarcodeEncoder()
-            return barcodeEncoder.encodeBitmap(
-                content,
-                BarcodeFormat.QR_CODE, size, size
-            )
+            val hints: HashMap<EncodeHintType, String> = HashMap()
+            hints[EncodeHintType.CHARACTER_SET] = "UTF-8";
+
+            val map = barcodeEncoder.encode(content, BarcodeFormat.QR_CODE, size, size, hints)
+            return barcodeEncoder.createBitmap(map)
         } catch (e: Exception) {
         }
         return null


### PR DESCRIPTION
The QR encoding library uses ISO-8859-1 as the default character set,
which meant that emoji were encoded as "?" characters. This PR tells the
library to use UTF-8 as the character set so that emojis are encoded
correctly.