### PR TITLE
Ticket 267 (QA Notes)

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/activity/profile/WalletInfoActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/profile/WalletInfoActivity.kt
@@ -32,6 +32,10 @@
  */
 package com.tari.android.wallet.ui.activity.profile
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ValueAnimator
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Bundle
@@ -41,16 +45,22 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import butterknife.*
+import com.daasuu.ei.Ease
+import com.daasuu.ei.EasingInterpolator
 import com.tari.android.wallet.R
 import com.tari.android.wallet.extension.applyFontStyle
 import com.tari.android.wallet.ui.activity.BaseActivity
 import com.tari.android.wallet.ui.component.CustomFont
 import com.tari.android.wallet.ui.component.EmojiIdCopiedViewController
+import com.tari.android.wallet.ui.component.EmojiIdSummaryViewController
+import com.tari.android.wallet.ui.extension.gone
+import com.tari.android.wallet.ui.extension.invisible
+import com.tari.android.wallet.ui.extension.visible
 import com.tari.android.wallet.ui.util.UiUtil
+import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.EmojiUtil
 import com.tari.android.wallet.util.SharedPrefsWrapper
 import com.tari.android.wallet.util.WalletUtil
-import me.everything.android.ui.overscroll.OverScrollDecoratorHelper
 import org.matomo.sdk.Tracker
 import org.matomo.sdk.extra.TrackHelper
 import javax.inject.Inject
@@ -62,18 +72,10 @@ import javax.inject.Inject
  */
 internal class WalletInfoActivity : BaseActivity() {
 
-    @BindView(R.id.wallet_info_scroll_emoji_id)
-    lateinit var emojiIdScrollView: HorizontalScrollView
     @BindView(R.id.wallet_info_txt_share_emoji_id)
     lateinit var shareEmojiIdTextView: TextView
-    @BindView(R.id.wallet_info_txt_emoji_id)
-    lateinit var emojiIdTextView: TextView
     @BindView(R.id.wallet_info_img_qr)
     lateinit var qrCodeImageView: ImageView
-    @BindView(R.id.wallet_info_txt_copy_emoji_id)
-    lateinit var copyEmojiIdTextView: TextView
-    @BindView(R.id.wallet_info_vw_emoji_id_copied)
-    lateinit var emojiIdCopiedAnimView: View
 
     @BindString(R.string.wallet_info_share_your_emoji_id)
     lateinit var shareEmojiIdTitle: String
@@ -81,6 +83,41 @@ internal class WalletInfoActivity : BaseActivity() {
     lateinit var shareEmojiIdTitleBoldPart: String
     @BindString(R.string.emoji_id_chunk_separator)
     lateinit var emojiIdChunkSeparator: String
+
+    @BindView(R.id.wallet_info_emoji_id_container)
+    lateinit var emojiIdContainerView: View
+
+    @BindView(R.id.wallet_info_emoji_id_summary)
+    lateinit var emojiIdSummaryView: View
+
+    @BindView(R.id.wallet_info_emoji_id_copied)
+    lateinit var emojiIdCopiedAnimView: View
+
+    @BindView(R.id.wallet_info_full_emoji_id_container)
+    lateinit var fullEmojiIdContainerView: View
+
+    @BindView(R.id.wallet_info_scroll_full_emoji_id)
+    lateinit var fullEmojiIdScrollView: HorizontalScrollView
+
+    @BindView(R.id.wallet_info_txt_full_emoji_id)
+    lateinit var fullEmojiIdTextView: TextView
+
+    @BindView(R.id.wallet_info_emoji_id_summary_container)
+    lateinit var emojiIdSummaryContainerView: View
+
+    @BindView(R.id.wallet_info_copy_emoji_id_container)
+    lateinit var copyEmojiIdButtonContainerView: View
+
+    /**
+     * Dimmers.
+     */
+    @BindViews(
+        R.id.wallet_info_header_dimmer,
+        R.id.wallet_info_scroll_dimmer,
+        R.id.wallet_info_underscroll_dimmer,
+        R.id.wallet_info_qr_code_dimmer
+    )
+    lateinit var dimmerViews: List<@JvmSuppressWildcards View>
 
     @BindColor(R.color.black)
     @JvmField
@@ -93,14 +130,16 @@ internal class WalletInfoActivity : BaseActivity() {
     @JvmField
     var qrCodeImageSize = 0
 
+    @BindDimen(R.dimen.common_copy_emoji_id_button_visible_bottom_margin)
+    @JvmField
+    var copyEmojiIdButtonVisibleBottomMargin = 0
+
     @Inject
     lateinit var sharedPrefsWrapper: SharedPrefsWrapper
     @Inject
     lateinit var tracker: Tracker
 
-    /**
-     * Animates the emoji id "copied" text.
-     */
+    private lateinit var emojiIdSummaryController: EmojiIdSummaryViewController
     private lateinit var emojiIdCopiedViewController: EmojiIdCopiedViewController
 
     override val contentViewId = R.layout.activity_wallet_info
@@ -116,6 +155,10 @@ internal class WalletInfoActivity : BaseActivity() {
     }
 
     private fun setUpUi() {
+        val emojiId = sharedPrefsWrapper.emojiId!!
+        emojiIdSummaryController = EmojiIdSummaryViewController(emojiIdSummaryView)
+        emojiIdSummaryController.display(emojiId)
+        emojiIdCopiedViewController = EmojiIdCopiedViewController(emojiIdCopiedAnimView)
         // title
         val styledTitle = shareEmojiIdTitle.applyFontStyle(
             this,
@@ -126,41 +169,177 @@ internal class WalletInfoActivity : BaseActivity() {
         )
         shareEmojiIdTextView.text = styledTitle
 
-        emojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
-            sharedPrefsWrapper.emojiId!!,
-            emojiIdChunkSeparator,
-            blackColor,
-            lightGrayColor
-        )
-
-        val content = WalletUtil.getEmojiIdDeepLink(sharedPrefsWrapper.emojiId!!)
+        val content = WalletUtil.getEmojiIdDeepLink(emojiId)
         UiUtil.getQREncodedBitmap(content, qrCodeImageSize)?.let {
             qrCodeImageView.setImageBitmap(it)
         }
 
-        OverScrollDecoratorHelper.setUpOverScroll(emojiIdScrollView)
-
-        emojiIdCopiedViewController = EmojiIdCopiedViewController(emojiIdCopiedAnimView)
+        fullEmojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
+            emojiId,
+            emojiIdChunkSeparator,
+            blackColor,
+            lightGrayColor
+        )
     }
 
-    @OnClick(R.id.wallet_info_btn_close)
-    fun onCloseButtonClick() {
-        finish()
+    @OnClick(R.id.wallet_info_emoji_id_summary_container)
+    fun onEmojiSummaryClicked(view: View) {
+        UiUtil.temporarilyDisableClick(view)
+        showFullEmojiId()
     }
 
-    /*
-    * Copy user emoji id to the user's clipboard
-    */
-    @OnClick(R.id.wallet_info_txt_copy_emoji_id)
-    fun onCopyEmojiIdClick() {
-        UiUtil.temporarilyDisableClick(copyEmojiIdTextView)
+    private fun showFullEmojiId() {
+//         make dimmers non-clickable until the anim is over
+        dimmerViews.forEach { dimmerView -> dimmerView.isClickable = false }
+        // prepare views
+        emojiIdSummaryContainerView.invisible()
+        dimmerViews.forEach { dimmerView ->
+            dimmerView.alpha = 0f
+            dimmerView.visible()
+        }
+        val fullEmojiIdInitialWidth = emojiIdSummaryContainerView.width
+        val fullEmojiIdDeltaWidth = emojiIdContainerView.width - fullEmojiIdInitialWidth
+        UiUtil.setWidth(
+            fullEmojiIdContainerView,
+            fullEmojiIdInitialWidth
+        )
+        fullEmojiIdContainerView.alpha = 0f
+        fullEmojiIdContainerView.visible()
+        // scroll to end
+        fullEmojiIdScrollView.post {
+            fullEmojiIdScrollView.scrollTo(
+                fullEmojiIdTextView.width - fullEmojiIdScrollView.width,
+                0
+            )
+        }
+        // TODO
+        copyEmojiIdButtonContainerView.alpha = 0f
+        copyEmojiIdButtonContainerView.visible()
+        copyEmojiIdButtonContainerView.translationY = 0F
+        // animate full emoji id view
+        val emojiIdAnim = ValueAnimator.ofFloat(0f, 1f)
+        emojiIdAnim.addUpdateListener { valueAnimator: ValueAnimator ->
+            val value = valueAnimator.animatedValue as Float
+            // display overlay dimmers
+            dimmerViews.forEach { dimmerView ->
+                dimmerView.alpha = value * 0.6f
+            }
+//             container alpha & scale
+            fullEmojiIdContainerView.alpha = value
+            fullEmojiIdContainerView.scaleX = 1f + 0.2f * (1f - value)
+            fullEmojiIdContainerView.scaleY = 1f + 0.2f * (1f - value)
+            UiUtil.setWidth(
+                fullEmojiIdContainerView,
+                (fullEmojiIdInitialWidth + fullEmojiIdDeltaWidth * value).toInt()
+            )
+        }
+        emojiIdAnim.duration = Constants.UI.shortDurationMs
+        // copy emoji id button anim
+        //TODO
+        val copyEmojiIdButtonAnim = ValueAnimator.ofFloat(0f, 1f)
+        copyEmojiIdButtonAnim.addUpdateListener { valueAnimator: ValueAnimator ->
+            val value = valueAnimator.animatedValue as Float
+            copyEmojiIdButtonContainerView.alpha = value
+            copyEmojiIdButtonContainerView.translationY = -copyEmojiIdButtonVisibleBottomMargin * value
+        }
+        copyEmojiIdButtonAnim.duration = Constants.UI.shortDurationMs
+        copyEmojiIdButtonAnim.interpolator = EasingInterpolator(Ease.BACK_OUT)
+
+        // chain anim.s and start
+        val animSet = AnimatorSet()
+        animSet.playSequentially(emojiIdAnim , copyEmojiIdButtonAnim)
+        animSet.start()
+        animSet.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator?) {
+                dimmerViews.forEach { dimmerView -> dimmerView.isClickable = true }
+            }
+        })
+        // scroll animation
+        fullEmojiIdScrollView.postDelayed({
+            fullEmojiIdScrollView.smoothScrollTo(0, 0)
+        }, Constants.UI.shortDurationMs + 20)
+    }
+
+    private fun hideFullEmojiId(animateCopyEmojiIdButton: Boolean = true) {
+        fullEmojiIdScrollView.smoothScrollTo(0, 0)
+        emojiIdSummaryContainerView.visible()
+        // copy emoji id button anim
+        val copyEmojiIdButtonAnim = ValueAnimator.ofFloat(1f, 0f)
+        copyEmojiIdButtonAnim.addUpdateListener { valueAnimator: ValueAnimator ->
+            val value = valueAnimator.animatedValue as Float
+            copyEmojiIdButtonContainerView.alpha = value
+            copyEmojiIdButtonContainerView.translationY = -copyEmojiIdButtonVisibleBottomMargin * value
+        }
+        // emoji id anim
+        val fullEmojiIdInitialWidth = emojiIdContainerView.width
+        val fullEmojiIdDeltaWidth = emojiIdSummaryContainerView.width - emojiIdContainerView.width
+        val emojiIdAnim = ValueAnimator.ofFloat(0f, 1f)
+        emojiIdAnim.addUpdateListener { valueAnimator: ValueAnimator ->
+            val value = valueAnimator.animatedValue as Float
+            // hide overlay dimmers
+            dimmerViews.forEach { dimmerView ->
+                dimmerView.alpha = (1 - value) * 0.6f
+            }
+            // container alpha & scale
+            fullEmojiIdContainerView.alpha = (1 - value)
+            UiUtil.setWidth(
+                fullEmojiIdContainerView,
+                (fullEmojiIdInitialWidth + fullEmojiIdDeltaWidth * value).toInt()
+            )
+        }
+        // chain anim.s and start
+        val animSet = AnimatorSet()
+        if (animateCopyEmojiIdButton) {
+            animSet.playSequentially(copyEmojiIdButtonAnim, emojiIdAnim)
+        } else {
+            animSet.play(emojiIdAnim)
+        }
+        animSet.start()
+        animSet.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator?) {
+                dimmerViews.forEach { dimmerView ->
+                    dimmerView.gone()
+                }
+                fullEmojiIdContainerView.gone()
+                copyEmojiIdButtonContainerView.gone()
+            }
+        })
+    }
+
+    /**
+     * Dimmer clicked - hide dimmers.
+     */
+    @OnClick(
+        R.id.wallet_info_header_dimmer,
+        R.id.wallet_info_scroll_dimmer,
+        R.id.wallet_info_underscroll_dimmer,
+        R.id.wallet_info_qr_code_dimmer
+    )
+    fun onDimmerViewsClicked() {
+        hideFullEmojiId()
+    }
+
+    @OnClick(R.id.wallet_info_btn_copy_emoji_id)
+    fun onCopyEmojiIdButtonClicked(view: View) {
+        UiUtil.temporarilyDisableClick(view)
+        dimmerViews.forEach { dimmerView -> dimmerView.isClickable = false }
         val clipBoard = ContextCompat.getSystemService(this, ClipboardManager::class.java)
         val clipboardData = ClipData.newPlainText(
             "Tari Wallet Emoji Id",
             sharedPrefsWrapper.emojiId!!
         )
         clipBoard?.setPrimaryClip(clipboardData)
-        emojiIdCopiedViewController.showEmojiIdCopiedAnim(fadeOutOnEnd = true)
+        emojiIdCopiedViewController.showEmojiIdCopiedAnim(fadeOutOnEnd = true) {
+            hideFullEmojiId(animateCopyEmojiIdButton = false)
+        }
+        val copyEmojiIdButtonAnim = copyEmojiIdButtonContainerView.animate().alpha(0f)
+        copyEmojiIdButtonAnim.duration = Constants.UI.xShortDurationMs
+        copyEmojiIdButtonAnim.start()
+    }
+
+    @OnClick(R.id.wallet_info_btn_close)
+    fun onCloseButtonClick() {
+        finish()
     }
 
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/activity/send/SendTariActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/send/SendTariActivity.kt
@@ -32,19 +32,13 @@
  */
 package com.tari.android.wallet.ui.activity.send
 
-import android.app.Dialog
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.os.IBinder
-import android.view.Gravity
 import android.view.View
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import butterknife.BindColor
@@ -59,11 +53,12 @@ import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.service.TariWalletService
 import com.tari.android.wallet.service.WalletService
 import com.tari.android.wallet.ui.activity.BaseActivity
+import com.tari.android.wallet.ui.dialog.BottomSlideDialog
 import com.tari.android.wallet.ui.extension.showInternetConnectionErrorDialog
 import com.tari.android.wallet.ui.fragment.BaseFragment
-import com.tari.android.wallet.ui.fragment.send.AddRecipientFragment
 import com.tari.android.wallet.ui.fragment.send.AddAmountFragment
 import com.tari.android.wallet.ui.fragment.send.AddNoteFragment
+import com.tari.android.wallet.ui.fragment.send.AddRecipientFragment
 import com.tari.android.wallet.ui.fragment.send.FinalizeSendTxFragment
 import com.tari.android.wallet.ui.util.UiUtil
 import com.tari.android.wallet.util.Constants
@@ -83,12 +78,14 @@ internal class SendTariActivity : BaseActivity(),
 
     @BindView(R.id.send_tari_vw_root)
     lateinit var rootView: View
+
     @BindView(R.id.send_tari_vw_fragment_container)
     lateinit var fragmentContainerView: View
 
     @BindColor(R.color.white)
     @JvmField
     var whiteColor = 0
+
     @BindColor(R.color.black)
     @JvmField
     var blackColor = 0
@@ -230,21 +227,11 @@ internal class SendTariActivity : BaseActivity(),
      * Display "hold your horses" dialog.
      */
     override fun onAmountExceedsActualAvailableBalance(fragment: AddAmountFragment) {
-        Dialog(this, R.style.Theme_AppCompat_Dialog).apply {
-            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-            setContentView(R.layout.add_amount_dialog_actual_balance_exceeded)
-            setCancelable(true)
-            window?.setLayout(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
-            )
-            findViewById<TextView>(R.id.add_amount_dialog_btn_close)
-                .setOnClickListener {
-                    dismiss()
-                }
-            window?.setGravity(Gravity.BOTTOM)
-            show()
-        }
+        BottomSlideDialog(
+            context = this,
+            layoutId = R.layout.add_amount_dialog_actual_balance_exceeded,
+            dismissViewId = R.id.add_amount_dialog_btn_close
+        ).show()
     }
 
     // endregion

--- a/app/src/main/java/com/tari/android/wallet/ui/activity/tx/TxDetailActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/tx/TxDetailActivity.kt
@@ -37,16 +37,15 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
-import android.app.Dialog
 import android.content.*
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.os.IBinder
-import android.view.Gravity
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.widget.*
+import android.widget.HorizontalScrollView
+import android.widget.ImageView
+import android.widget.RelativeLayout
+import android.widget.TextView
 import androidx.constraintlayout.widget.Group
 import androidx.core.content.ContextCompat
 import butterknife.*
@@ -62,11 +61,8 @@ import com.tari.android.wallet.service.TariWalletService
 import com.tari.android.wallet.service.WalletService
 import com.tari.android.wallet.ui.activity.BaseActivity
 import com.tari.android.wallet.ui.component.*
+import com.tari.android.wallet.ui.dialog.BottomSlideDialog
 import com.tari.android.wallet.ui.extension.*
-import com.tari.android.wallet.ui.extension.getFirstChild
-import com.tari.android.wallet.ui.extension.getLastChild
-import com.tari.android.wallet.ui.extension.gone
-import com.tari.android.wallet.ui.extension.setTextSizePx
 import com.tari.android.wallet.ui.util.UiUtil
 import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.EmojiUtil
@@ -100,44 +96,64 @@ internal class TxDetailActivity :
 
     @BindView(R.id.tx_detail_txt_payment_state)
     lateinit var txPaymentStateTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_img_back_arrow)
     lateinit var backArrowImageView: ImageView
+
     @BindView(R.id.tx_detail_txt_date)
     lateinit var txDateTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_txt_amount)
     lateinit var txAmountTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_vw_amount_container)
     lateinit var amountContainer: RelativeLayout
+
     @BindView(R.id.tx_detail_img_amount_gem)
     lateinit var amountGemImageView: ImageView
+
     @BindView(R.id.tx_detail_txt_tx_fee)
     lateinit var txFeeTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_btn_add_contact)
     lateinit var addContactButton: CustomFontButton
+
     @BindView(R.id.tx_detail_txt_contact_name)
     lateinit var contactNameTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_edit_create_contact)
     lateinit var contactEditText: CustomFontEditText
+
     @BindView(R.id.tx_detail_txt_contact_label)
     lateinit var contactLabelTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_txt_edit_label)
     lateinit var editContactLabelTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_txt_tx_note)
     lateinit var txNoteTv: CustomFontTextView
+
     @BindView(R.id.tx_detail_txt_tx_id)
     lateinit var txIdTextView: CustomFontTextView
+
     @BindView(R.id.tx_detail_vw_contact_container)
     lateinit var contactContainerView: View
+
     @BindView(R.id.tx_detail_vw_emoji_id_summary_container)
     lateinit var emojiIdSummaryContainerView: View
+
     @BindView(R.id.tx_detail_vw_emoji_id_summary)
     lateinit var emojiIdSummaryView: View
+
     @BindView(R.id.tx_detail_txt_note_label)
     lateinit var noteLabelView: View
+
     @BindView(R.id.tx_detail_vw_tx_fee_group)
     lateinit var txFeeGroup: Group
+
     @BindView(R.id.tx_detail_txt_from)
     lateinit var fromTextView: CustomFontTextView
+
     /**
      * Dimmers.
      */
@@ -146,16 +162,22 @@ internal class TxDetailActivity :
         R.id.tx_detail_vw_bottom_dimmer
     )
     lateinit var dimmerViews: List<@JvmSuppressWildcards View>
+
     @BindView(R.id.tx_detail_vw_emoji_id_container)
     lateinit var emojiIdContainerView: View
+
     @BindView(R.id.tx_detail_vw_full_emoji_id_container)
     lateinit var fullEmojiIdContainerView: View
+
     @BindView(R.id.tx_detail_scroll_full_emoji_id)
     lateinit var fullEmojiIdScrollView: HorizontalScrollView
+
     @BindView(R.id.tx_detail_txt_full_emoji_id)
     lateinit var fullEmojiIdTextView: TextView
+
     @BindView(R.id.tx_detail_vw_copy_emoji_id_container)
     lateinit var copyEmojiIdButtonContainerView: View
+
     @BindView(R.id.tx_detail_vw_emoji_id_copied)
     lateinit var emojiIdCopiedAnimView: View
 
@@ -168,18 +190,23 @@ internal class TxDetailActivity :
     @JvmField
     @BindString(R.string.tx_detail_payment_received)
     var paymentReceived = ""
+
     @JvmField
     @BindString(R.string.tx_detail_payment_sent)
     var paymentSent = ""
+
     @JvmField
     @BindString(R.string.tx_detail_pending_payment_received)
     var pendingPaymentReceived = ""
+
     @JvmField
     @BindString(R.string.tx_detail_pending_payment_sent)
     var pendingPaymentSent = ""
+
     @JvmField
     @BindString(R.string.common_from)
     var paymentFrom = ""
+
     @JvmField
     @BindString(R.string.common_to)
     var paymentTo = ""
@@ -187,12 +214,15 @@ internal class TxDetailActivity :
     @JvmField
     @BindColor(R.color.tx_detail_contact_name_label_text)
     var contactLabelTxtGrayColor = 0
+
     @JvmField
     @BindColor(R.color.black)
     var contactLabelTxtBlackColor = 0
+
     @BindColor(R.color.black)
     @JvmField
     var blackColor = 0
+
     @BindColor(R.color.light_gray)
     @JvmField
     var lightGrayColor = 0
@@ -200,18 +230,22 @@ internal class TxDetailActivity :
     @BindDimen(R.dimen.add_amount_element_text_size)
     @JvmField
     var elementTextSize = 0f
+
     @BindDimen(R.dimen.add_amount_gem_size)
     @JvmField
     var amountGemSize = 0f
+
     @BindDimen(R.dimen.add_amount_leftmost_digit_margin_start)
     @JvmField
     var firstElementMarginStart = 0
+
     @BindDimen(R.dimen.common_copy_emoji_id_button_visible_bottom_margin)
     @JvmField
     var copyEmojiIdButtonVisibleBottomMargin = 0
 
     @Inject
     lateinit var tracker: Tracker
+
     @Inject
     lateinit var sharedPrefsWrapper: SharedPrefsWrapper
 
@@ -633,22 +667,11 @@ internal class TxDetailActivity :
     }
 
     private fun showTxFeeToolTip() {
-        Dialog(this, R.style.Theme_AppCompat_Dialog).apply {
-            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-            setContentView(R.layout.tx_fee_tooltip_dialog)
-            setCancelable(true)
-            setCanceledOnTouchOutside(true)
-            window?.setLayout(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
-            )
-            findViewById<TextView>(R.id.tx_fee_tooltip_dialog_txt_close)
-                .setOnClickListener {
-                    dismiss()
-                }
-
-            window?.setGravity(Gravity.BOTTOM)
-        }.show()
+        BottomSlideDialog(
+            context = this,
+            layoutId = R.layout.tx_fee_tooltip_dialog,
+            dismissViewId = R.id.tx_fee_tooltip_dialog_txt_close
+        ).show()
     }
 
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/BottomSlideDialog.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/BottomSlideDialog.kt
@@ -1,0 +1,40 @@
+package com.tari.android.wallet.ui.dialog
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import com.tari.android.wallet.R
+
+class BottomSlideDialog private constructor(private val dialog: Dialog) {
+
+    constructor(
+        context: Context,
+        layoutId: Int,
+        cancelable: Boolean = true,
+        canceledOnTouchOutside: Boolean = true,
+        dismissViewId: Int? = null
+    ) : this(
+        Dialog(context, R.style.BottomSlideDialog).apply {
+            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            setContentView(layoutId)
+            setCancelable(cancelable)
+            setCanceledOnTouchOutside(canceledOnTouchOutside)
+            window?.setLayout(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            window?.setGravity(Gravity.BOTTOM)
+            dismissViewId?.let { findViewById<View>(it).setOnClickListener { dismiss() } }
+        })
+
+    fun <T : View> findViewById(id: Int): T = dialog.findViewById(id)
+
+    fun show() = dialog.show()
+
+    fun dismiss() = dialog.dismiss()
+
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/extension/ViewExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/extension/ViewExtensions.kt
@@ -34,20 +34,17 @@ package com.tari.android.wallet.ui.extension
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.util.TypedValue
-import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import com.tari.android.wallet.R
+import com.tari.android.wallet.ui.dialog.BottomSlideDialog
 import com.tari.android.wallet.ui.util.UiUtil
 
 internal fun View.visible() {
@@ -66,42 +63,23 @@ internal fun View.gone() {
  * Given the context, displays the standard "no internet connection" dialog.
  */
 internal fun showInternetConnectionErrorDialog(context: Context) {
-    Dialog(context, R.style.Theme_AppCompat_Dialog).apply {
-        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        setContentView(R.layout.internet_connection_error_dialog)
-        setCancelable(true)
-        setCanceledOnTouchOutside(true)
-        window?.setLayout(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        )
-        findViewById<TextView>(R.id.internet_connection_error_dialog_txt_close)
-            .setOnClickListener {
-                dismiss()
-            }
-        window?.setGravity(Gravity.BOTTOM)
-    }.show()
+    BottomSlideDialog(
+        context = context,
+        layoutId = R.layout.internet_connection_error_dialog,
+        dismissViewId = R.id.internet_connection_error_dialog_txt_close
+    ).show()
 }
 
 /**
  * Given the context, displays the standard "it's not you, it's the network" dialog.
  */
+// TODO seems to be unused; should be removed?
 internal fun showTariNetworkConnectionErrorDialog(context: Context) {
-    Dialog(context, R.style.Theme_AppCompat_Dialog).apply {
-        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        setContentView(R.layout.tari_network_connection_error_dialog)
-        setCancelable(true)
-        setCanceledOnTouchOutside(true)
-        window?.setLayout(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        )
-        findViewById<TextView>(R.id.tari_network_connection_error_dialog_txt_close)
-            .setOnClickListener {
-                dismiss()
-            }
-        window?.setGravity(Gravity.BOTTOM)
-    }.show()
+    BottomSlideDialog(
+        context = context,
+        layoutId = R.layout.tari_network_connection_error_dialog,
+        dismissViewId = R.id.tari_network_connection_error_dialog_txt_close
+    ).show()
 }
 
 /**
@@ -204,6 +182,6 @@ internal fun ScrollView.scrollToTop() {
 internal fun ScrollView.scrollToBottom() {
     val lastChild = getChildAt(childCount - 1)
     val bottom = lastChild.bottom + paddingBottom
-    val delta = bottom - (scrollY+ height)
+    val delta = bottom - (scrollY + height)
     smoothScrollBy(0, delta)
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/CreateWalletFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/CreateWalletFragment.kt
@@ -277,7 +277,7 @@ internal class CreateWalletFragment : BaseFragment() {
                 0f
             )
         whiteBgViewAnim.duration = CreateEmojiId.whiteBgAnimDurationMs
-        whiteBgViewAnim.interpolator = EasingInterpolator(Ease.SINE_OUT)
+        whiteBgViewAnim.interpolator = EasingInterpolator(Ease.CIRC_IN_OUT)
         whiteBgViewAnim.addListener(object : AnimatorListenerAdapter() {
             override fun onAnimationEnd(animation: Animator?) {
                 super.onAnimationEnd(animation)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/IntroductionFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/IntroductionFragment.kt
@@ -276,10 +276,16 @@ internal class IntroductionFragment : BaseFragment() {
         UiUtil.temporarilyDisableClick(createWalletButton)
         createWalletButton.gone()
         progressBar.visible()
-        rootView.postDelayed(
-            { wr.get()?.startTariWalletViewAnimation() },
-            createWalletArtificalDelay
-        )
+        val animatorSet = UiUtil.animateViewClick(walletBtnLayout)
+        animatorSet.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator?) {
+                super.onAnimationEnd(animation)
+                rootView.postDelayed(
+                    { wr.get()?.startTariWalletViewAnimation() },
+                    createWalletArtificalDelay
+                )
+            }
+        })
     }
 
     private fun startTariWalletViewAnimation() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/LocalAuthFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/LocalAuthFragment.kt
@@ -44,6 +44,8 @@ import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import butterknife.*
+import com.daasuu.ei.Ease
+import com.daasuu.ei.EasingInterpolator
 import com.orhanobut.logger.Logger
 import com.tari.android.wallet.R
 import com.tari.android.wallet.application.WalletState
@@ -210,6 +212,7 @@ internal class LocalAuthFragment : BaseFragment() {
 
         val anim = AnimatorSet()
         anim.playTogether(titleTextAnim, buttonContainerViewAnim, fadeInAnim)
+        anim.interpolator = EasingInterpolator(Ease.QUINT_IN)
         anim.startDelay = Auth.localAuthAnimDurationMs
         anim.duration = Auth.localAuthAnimDurationMs
         anim.start()

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
@@ -34,12 +34,9 @@ package com.tari.android.wallet.ui.fragment.send
 
 import android.animation.*
 import android.annotation.SuppressLint
-import android.app.Dialog
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.AsyncTask
 import android.os.Bundle
 import android.os.Handler
@@ -51,21 +48,21 @@ import butterknife.*
 import com.daasuu.ei.Ease
 import com.daasuu.ei.EasingInterpolator
 import com.tari.android.wallet.R
+import com.tari.android.wallet.extension.remap
 import com.tari.android.wallet.model.*
 import com.tari.android.wallet.service.TariWalletService
+import com.tari.android.wallet.ui.component.EmojiIdCopiedViewController
 import com.tari.android.wallet.ui.component.EmojiIdSummaryViewController
+import com.tari.android.wallet.ui.dialog.BottomSlideDialog
+import com.tari.android.wallet.ui.extension.*
 import com.tari.android.wallet.ui.fragment.BaseFragment
 import com.tari.android.wallet.ui.util.UiUtil
 import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.EmojiUtil
 import com.tari.android.wallet.util.WalletUtil
-import com.tari.android.wallet.extension.remap
-import com.tari.android.wallet.ui.component.EmojiIdCopiedViewController
-import com.tari.android.wallet.ui.extension.*
 import me.everything.android.ui.overscroll.OverScrollDecoratorHelper
 import org.matomo.sdk.Tracker
 import org.matomo.sdk.extra.TrackHelper
-import java.lang.StringBuilder
 import java.lang.ref.WeakReference
 import java.math.BigInteger
 import javax.inject.Inject
@@ -80,53 +77,76 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
 
     @BindView(R.id.add_amount_vw_root)
     lateinit var rootView: View
+
     @BindView(R.id.add_amount_txt_title)
     lateinit var titleTextView: TextView
+
     @BindView(R.id.add_amount_btn_back)
     lateinit var backButton: ImageButton
+
     @BindView(R.id.add_amount_vw_emoji_id_summary_container)
     lateinit var emojiIdSummaryContainerView: View
+
     @BindView(R.id.add_amount_vw_emoji_id_summary)
     lateinit var emojiIdSummaryView: View
+
     @BindView(R.id.add_amount_vw_full_emoji_id_container)
     lateinit var fullEmojiIdContainerView: View
+
     @BindView(R.id.add_amount_scroll_full_emoji_id)
     lateinit var fullEmojiIdScrollView: HorizontalScrollView
+
     @BindView(R.id.add_amount_txt_full_emoji_id)
     lateinit var fullEmojiIdTextView: TextView
+
     @BindView(R.id.add_amount_vw_copy_emoji_id_container)
     lateinit var copyEmojiIdButtonContainerView: View
+
     @BindView(R.id.add_amount_vw_emoji_id_copied)
     lateinit var emojiIdCopiedAnimView: View
+
     @BindView(R.id.add_amount_vw_not_enough_balance)
     lateinit var notEnoughBalanceView: View
+
     @BindView(R.id.add_amount_vw_amount_outer_container)
     lateinit var elementOuterContainerView: ViewGroup
+
     @BindView(R.id.add_amount_vw_amount_element_container)
     lateinit var elementContainerView: ViewGroup
+
     @BindView(R.id.add_amount_txt_amount_element_0)
     lateinit var element0TextView: TextView
+
     @BindView(R.id.add_amount_img_amount_gem)
     lateinit var amountGemImageView: ImageView
+
     @BindView(R.id.add_amount_vw_amount_center_correction)
     lateinit var amountCenterCorrectionView: View
+
     @BindView(R.id.add_amount_txt_available_balance)
     lateinit var availableBalanceTextView: TextView
+
     @BindView(R.id.add_amount_vw_tx_fee_container)
     lateinit var txFeeContainerView: View
+
     @BindView(R.id.add_amount_txt_tx_fee)
     lateinit var txFeeTextView: TextView
+
     @BindView(R.id.add_amount_btn_continue_disabled)
     lateinit var disabledContinueButton: Button
+
     @BindView(R.id.add_amount_btn_continue)
     lateinit var continueButton: Button
+
     @BindView(R.id.add_amount_btn_decimal_point)
     lateinit var decimalSeparatorButton: Button
+
     /**
      * Overlay dimmer.
      */
     @BindView(R.id.add_amount_vw_dimmer)
     lateinit var dimmerView: View
+
     @BindView(R.id.add_amount_vw_full_emoji_id_bg_click_blocker)
     lateinit var fullEmojiIdBgClickBlockerView: View
 
@@ -136,21 +156,27 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
     @BindDimen(R.dimen.add_amount_element_text_size)
     @JvmField
     var elementTextSize = 0f
+
     @BindDimen(R.dimen.add_amount_element_container_translation_y)
     @JvmField
     var amountElementContainerTranslationY = 0
+
     @BindDimen(R.dimen.add_amount_gem_size)
     @JvmField
     var amountGemSize = 0f
+
     @BindDimen(R.dimen.add_amount_leftmost_digit_margin_start)
     @JvmField
     var firstElementMarginStart = 0
+
     @BindDimen(R.dimen.add_amount_available_balance_error_amount_nudge_distance)
     @JvmField
     var validationErrorNudgeDistance = 0
+
     @BindDimen(R.dimen.common_horizontal_margin)
     @JvmField
     var horizontalMargin = 0
+
     @BindDimen(R.dimen.common_copy_emoji_id_button_visible_bottom_margin)
     @JvmField
     var copyEmojiIdButtonVisibleBottomMargin = 0
@@ -158,6 +184,7 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
     @BindColor(R.color.black)
     @JvmField
     var blackColor = 0
+
     @BindColor(R.color.light_gray)
     @JvmField
     var lightGrayColor = 0
@@ -176,6 +203,7 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
      * corresponding TextViews.
      */
     private val elements = mutableListOf<Pair<String, TextView>>()
+
     /**
      * Values below are used for scaling up/down of the text size.
      */
@@ -187,11 +215,13 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
      * Whether digit entry animation is running.
      */
     private var digitAnimIsRunning = false
+
     /**
      * Minimum amount is micro Tari.
      */
     private val maxNoOfDecimalPlaces = 6
     private val thousandsGroupSize = 3
+
     /**
      * Wait this long before taking action (validation etc.) on the entered amount.
      */
@@ -220,6 +250,7 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
      * Formats the summarized emoji id.
      */
     private lateinit var emojiIdSummaryController: EmojiIdSummaryViewController
+
     /**
      * Animates the emoji id "copied" text.
      */
@@ -348,7 +379,8 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
         dimmerView.alpha = 0f
         dimmerView.visible()
         val fullEmojiIdInitialWidth = emojiIdSummaryContainerView.width
-        val fullEmojiIdDeltaWidth = (rootView.width - horizontalMargin * 2) - fullEmojiIdInitialWidth
+        val fullEmojiIdDeltaWidth =
+            (rootView.width - horizontalMargin * 2) - fullEmojiIdInitialWidth
         UiUtil.setWidth(
             fullEmojiIdContainerView,
             fullEmojiIdInitialWidth
@@ -434,7 +466,8 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
         }
         // emoji id anim
         val fullEmojiIdInitialWidth = fullEmojiIdContainerView.width
-        val fullEmojiIdDeltaWidth = emojiIdSummaryContainerView.width - fullEmojiIdContainerView.width
+        val fullEmojiIdDeltaWidth =
+            emojiIdSummaryContainerView.width - fullEmojiIdContainerView.width
         val emojiIdAnim = ValueAnimator.ofFloat(0f, 1f)
         emojiIdAnim.addUpdateListener { valueAnimator: ValueAnimator ->
             val value = valueAnimator.animatedValue as Float
@@ -500,23 +533,11 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
     }
 
     private fun showTxFeeToolTip() {
-        val mActivity = activity ?: return
-        Dialog(mActivity, R.style.Theme_AppCompat_Dialog).apply {
-            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-            setContentView(R.layout.tx_fee_tooltip_dialog)
-            setCancelable(true)
-            setCanceledOnTouchOutside(true)
-            window?.setLayout(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
-            )
-            findViewById<TextView>(R.id.tx_fee_tooltip_dialog_txt_close)
-                .setOnClickListener {
-                    dismiss()
-                }
-
-            window?.setGravity(Gravity.BOTTOM)
-        }.show()
+        BottomSlideDialog(
+            context = activity ?: return,
+            layoutId = R.layout.tx_fee_tooltip_dialog,
+            dismissViewId = R.id.tx_fee_tooltip_dialog_txt_close
+        ).show()
     }
 
     /**
@@ -1153,6 +1174,7 @@ class AddAmountFragment(private val walletService: TariWalletService) : BaseFrag
     interface Listener {
 
         fun onAmountExceedsActualAvailableBalance(fragment: AddAmountFragment)
+
         /**
          * Recipient is user.
          */

--- a/app/src/main/java/com/tari/android/wallet/ui/util/UiUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/util/UiUtil.kt
@@ -241,15 +241,20 @@ internal object UiUtil {
     /*
     * Animation for button click
     * */
-    fun animateButtonClick(button: Button): AnimatorSet {
+    fun animateButtonClick(button: Button): AnimatorSet = animateViewClick(button)
+
+    /*
+    * Animation for button click
+    * */
+    fun animateViewClick(view: View): AnimatorSet {
         val scaleDownBtnAnim = ValueAnimator.ofFloat(
             Constants.UI.Button.clickScaleAnimFullScale,
             Constants.UI.Button.clickScaleAnimSmallScale
         )
         scaleDownBtnAnim.addUpdateListener { valueAnimator: ValueAnimator ->
             val scale = valueAnimator.animatedValue as Float
-            button.scaleX = scale
-            button.scaleY = scale
+            view.scaleX = scale
+            view.scaleY = scale
         }
         scaleDownBtnAnim.duration = Constants.UI.Button.clickScaleAnimDurationMs
         scaleDownBtnAnim.startDelay = Constants.UI.Button.clickScaleAnimStartOffset
@@ -261,8 +266,8 @@ internal object UiUtil {
         )
         scaleUpBtnAnim.addUpdateListener { valueAnimator: ValueAnimator ->
             val scale = valueAnimator.animatedValue as Float
-            button.scaleX = scale
-            button.scaleY = scale
+            view.scaleX = scale
+            view.scaleY = scale
         }
         scaleUpBtnAnim.duration = Constants.UI.Button.clickScaleAnimReturnDurationMs
         scaleUpBtnAnim.startDelay = Constants.UI.Button.clickScaleAnimReturnStartOffset

--- a/app/src/main/java/com/tari/android/wallet/util/Constants.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/Constants.kt
@@ -33,7 +33,6 @@
 package com.tari.android.wallet.util
 
 import com.tari.android.wallet.application.Network
-import java.util.concurrent.TimeUnit
 
 /**
  * Contains application-wide constant values.

--- a/app/src/main/res/anim/dialog_slide_from_bottom.xml
+++ b/app/src/main/res/anim/dialog_slide_from_bottom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="400"
+    android:fromYDelta="120%"
+    android:toYDelta="0%"
+    android:interpolator="@android:anim/decelerate_interpolator" />

--- a/app/src/main/res/anim/dialog_slide_to_bottom.xml
+++ b/app/src/main/res/anim/dialog_slide_to_bottom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="400"
+    android:fromYDelta="0%"
+    android:toYDelta="120%"
+    android:interpolator="@android:anim/accelerate_interpolator" />

--- a/app/src/main/res/drawable/wallet_info_bg_qr_code_image_dimmer.xml
+++ b/app/src/main/res/drawable/wallet_info_bg_qr_code_image_dimmer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/black" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/activity_tx_detail.xml
+++ b/app/src/main/res/layout/activity_tx_detail.xml
@@ -44,10 +44,10 @@
             android:id="@+id/tx_detail_txt_payment_state"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:paddingHorizontal="50dp"
             android:text="@string/tx_detail_payment_received"
             android:textColor="@color/black"
-            android:paddingHorizontal="50dp"
-            android:ellipsize="middle"
             android:textSize="16sp"
             app:customFont="AVENIR_LT_STD_HEAVY"
             app:layout_constraintBottom_toBottomOf="@id/tx_detail_img_back_arrow"
@@ -141,7 +141,8 @@
             android:clickable="true"
             android:focusable="true"
             app:layout_constraintBottom_toTopOf="@id/tx_detail_vw_detail_container"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="gone" />
 
         <RelativeLayout
             android:id="@+id/tx_detail_vw_detail_container"
@@ -293,7 +294,8 @@
                 android:alpha="0.6"
                 android:background="@color/black"
                 android:clickable="true"
-                android:focusable="true" />
+                android:focusable="true"
+                tools:visibility="gone" />
 
             <!-- copy emoji id button -->
             <RelativeLayout
@@ -336,6 +338,7 @@
                     android:background="@color/transparent" />
             </RelativeLayout>
 
+            <!--Emoji ID View-->
             <RelativeLayout
                 android:id="@+id/tx_detail_vw_emoji_id_container"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_wallet_info.xml
+++ b/app/src/main/res/layout/activity_wallet_info.xml
@@ -1,36 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
     android:orientation="vertical">
 
-    <ImageButton
-        android:id="@+id/wallet_info_btn_close"
-        android:layout_width="@dimen/common_header_height"
-        android:layout_height="@dimen/common_header_height"
-        android:background="@color/transparent"
-        android:contentDescription="@null"
-        android:src="@drawable/close_icon"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/common_header_height">
+
+        <ImageButton
+            android:id="@+id/wallet_info_btn_close"
+            android:layout_width="@dimen/common_header_height"
+            android:layout_height="@dimen/common_header_height"
+            android:background="@color/transparent"
+            android:contentDescription="@null"
+            android:src="@drawable/close_icon"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/wallet_info_header_dimmer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:alpha="0.6"
+            android:background="@color/black"
+            android:clickable="true"
+            android:focusable="true"
+            android:visibility="gone" />
+    </FrameLayout>
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbars="vertical">
 
+        <!--android:clipChildren="false" is needed for correct elevation shadow rendering-->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:clipChildren="false">
 
             <com.tari.android.wallet.ui.component.CustomFontTextView
                 android:id="@+id/wallet_info_txt_share_emoji_id"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/common_horizontal_margin"
                 android:layout_marginTop="14dp"
@@ -41,88 +57,18 @@
                 android:textColor="@color/black"
                 android:textSize="18sp"
                 app:customFont="AVENIR_LT_STD_LIGHT"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
-
-            <RelativeLayout
-                android:id="@+id/wallet_info_vw_emoji_id_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/common_horizontal_margin"
-                android:layout_marginTop="20dp"
-                android:background="@drawable/emoji_id_bg"
-                android:elevation="@dimen/common_view_elevation"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/wallet_info_txt_share_emoji_id">
-
-                <HorizontalScrollView
-                    android:id="@+id/wallet_info_scroll_emoji_id"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:scrollbars="none">
-
-                    <TextView
-                        android:id="@+id/wallet_info_txt_emoji_id"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:letterSpacing="0.22"
-                        android:paddingHorizontal="14dp"
-                        android:paddingVertical="12dp"
-                        android:textAlignment="center"
-                        android:textColor="@color/black"
-                        android:textSize="16sp" />
-                </HorizontalScrollView>
-
-                <!-- white fader for emoji-id input -->
-                <View
-                    android:layout_width="30dp"
-                    android:layout_height="24dp"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:background="@drawable/emoji_id_end_fader" />
-
-                <FrameLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:layout_alignTop="@id/wallet_info_scroll_emoji_id"
-                    android:layout_alignBottom="@id/wallet_info_scroll_emoji_id">
-
-                    <include
-                        android:id="@+id/wallet_info_vw_emoji_id_copied"
-                        layout="@layout/emoji_id_copied_anim_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:visibility="visible" />
-                </FrameLayout>
-
-            </RelativeLayout>
-
-            <com.tari.android.wallet.ui.component.CustomFontTextView
-                android:id="@+id/wallet_info_txt_copy_emoji_id"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:gravity="center"
-                android:letterSpacing="0.02"
-                android:padding="10dp"
-                android:paddingStart="4dp"
-                android:paddingEnd="0dp"
-                android:text="@string/wallet_info_copy_emoji_id"
-                android:textColor="@color/purple"
-                android:textSize="12sp"
-                app:customFont="AVENIR_LT_STD_MEDIUM"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/wallet_info_vw_emoji_id_container" />
 
             <View
                 android:id="@+id/wallet_info_vw_divider"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_marginHorizontal="@dimen/common_horizontal_margin"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="23dp"
                 android:background="#20000000"
-                app:layout_constraintTop_toBottomOf="@id/wallet_info_txt_copy_emoji_id" />
+                app:layout_constraintTop_toBottomOf="@id/wallet_info_emoji_id_container" />
 
             <com.tari.android.wallet.ui.component.CustomFontTextView
                 android:id="@+id/wallet_info_txt_qr_code_desc"
@@ -137,20 +83,21 @@
                 android:textColor="@color/wallet_info_qr_code_desc"
                 android:textSize="14sp"
                 app:customFont="AVENIR_LT_STD_MEDIUM"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/wallet_info_vw_divider" />
 
             <FrameLayout
                 android:id="@+id/wallet_info_vw_qr_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="18dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="15dp"
                 android:background="@drawable/wallet_info_bg_qr_code_image"
                 android:elevation="@dimen/common_view_elevation"
                 android:padding="5dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/wallet_info_txt_qr_code_desc">
 
                 <ImageView
@@ -163,11 +110,185 @@
                     android:padding="2dp" />
             </FrameLayout>
 
-            <!-- bottom margin -->
             <View
-                android:layout_width="match_parent"
+                android:id="@+id/wallet_info_qr_code_dimmer"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:alpha="0.6"
+                android:background="@drawable/wallet_info_bg_qr_code_image_dimmer"
+                android:clickable="true"
+                android:focusable="true"
+                android:elevation="@dimen/common_view_elevation"
+                app:layout_constraintTop_toTopOf="@id/wallet_info_vw_qr_container"
+                app:layout_constraintStart_toStartOf="@id/wallet_info_vw_qr_container"
+                app:layout_constraintEnd_toEndOf="@id/wallet_info_vw_qr_container"
+                app:layout_constraintBottom_toBottomOf="@id/wallet_info_vw_qr_container"
+                android:visibility="gone"
+                tools:visibility="visible"/>
+
+            <!-- Bottom margin -->
+            <View
+                android:layout_width="0dp"
                 android:layout_height="40dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/wallet_info_vw_qr_container" />
+
+            <View
+                android:id="@+id/wallet_info_scroll_dimmer"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:alpha="0.6"
+                android:background="@color/black"
+                android:clickable="true"
+                android:focusable="true"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!--Emoji ID Copy Button-->
+            <RelativeLayout
+                android:id="@+id/wallet_info_copy_emoji_id_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="0dp"
+                android:visibility="gone"
+                android:elevation="@dimen/common_view_elevation"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/wallet_info_emoji_id_container"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/wallet_info_img_copy_emoji_id_notch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:contentDescription="@null"
+                    android:src="@drawable/speech_notch_up" />
+
+                <com.tari.android.wallet.ui.component.CustomFontTextView
+                    android:id="@+id/wallet_info_txt_copy_emoji_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/wallet_info_img_copy_emoji_id_notch"
+                    android:background="@drawable/copy_paste_emoji_id_button_bg"
+                    android:paddingHorizontal="20dp"
+                    android:paddingVertical="10dp"
+                    android:text="@string/copy_emoji_id"
+                    android:textColor="#9834F6"
+                    android:textSize="14sp"
+                    app:customFont="AVENIR_LT_STD_HEAVY" />
+
+                <Button
+                    android:id="@+id/wallet_info_btn_copy_emoji_id"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_alignStart="@id/wallet_info_txt_copy_emoji_id"
+                    android:layout_alignTop="@id/wallet_info_txt_copy_emoji_id"
+                    android:layout_alignEnd="@id/wallet_info_txt_copy_emoji_id"
+                    android:layout_alignBottom="@id/wallet_info_txt_copy_emoji_id"
+                    android:background="@color/transparent" />
+            </RelativeLayout>
+
+            <!--Emoji ID-->
+            <RelativeLayout
+                android:id="@+id/wallet_info_emoji_id_container"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="25dp"
+                android:layout_marginTop="18dp"
+                android:elevation="@dimen/common_view_elevation"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/wallet_info_txt_share_emoji_id">
+
+                <FrameLayout
+                    android:id="@+id/wallet_info_emoji_id_summary_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerInParent="true"
+                    android:background="@drawable/emoji_id_bg"
+                    android:clickable="true"
+                    android:elevation="@dimen/common_view_elevation"
+                    android:focusable="true"
+                    android:paddingHorizontal="@dimen/emoji_id_container_horizontal_padding"
+                    android:paddingVertical="@dimen/emoji_id_container_vertical_padding">
+
+                    <include
+                        android:id="@+id/wallet_info_emoji_id_summary"
+                        layout="@layout/emoji_id_summary"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center" />
+                </FrameLayout>
+
+                <RelativeLayout
+                    android:id="@+id/wallet_info_full_emoji_id_container"
+                    android:layout_width="300dp"
+                    android:layout_height="0dp"
+                    android:layout_alignTop="@id/wallet_info_emoji_id_summary_container"
+                    android:layout_alignBottom="@id/wallet_info_emoji_id_summary_container"
+                    android:layout_centerHorizontal="true"
+                    android:background="@drawable/emoji_id_bg"
+                    android:elevation="@dimen/common_view_elevation"
+                    android:visibility="gone">
+
+                    <HorizontalScrollView
+                        android:id="@+id/wallet_info_scroll_full_emoji_id"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scrollbars="none"
+                        tools:ignore="UselessParent">
+
+                        <TextView
+                            android:id="@+id/wallet_info_txt_full_emoji_id"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:gravity="center_vertical"
+                            android:letterSpacing="0.22"
+                            android:paddingHorizontal="12dp"
+                            android:textColor="@color/black"
+                            android:textSize="14sp" />
+                    </HorizontalScrollView>
+
+                    <!-- white fader for emoji-id -->
+                    <View
+                        android:id="@+id/wallet_info_full_emoji_id_fader"
+                        android:layout_width="26dp"
+                        android:layout_height="21dp"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true"
+                        android:background="@drawable/emoji_id_end_fader"
+                        android:translationZ="6dp" />
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:translationZ="7dp">
+
+                        <include
+                            android:id="@+id/wallet_info_emoji_id_copied"
+                            layout="@layout/emoji_id_copied_anim_view"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:visibility="visible" />
+                    </FrameLayout>
+                </RelativeLayout>
+            </RelativeLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
+
+    <View
+        android:id="@+id/wallet_info_underscroll_dimmer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0.6"
+        android:background="@color/black"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_add_amount.xml
+++ b/app/src/main/res/layout/fragment_add_amount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/add_amount_vw_root"
@@ -7,61 +7,71 @@
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <!-- header -->
-    <RelativeLayout
-        android:id="@+id/add_amount_vw_header"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/common_header_height"
-        android:layout_marginTop="0dp"
+    <!-- back -->
+    <ImageButton
+        android:id="@+id/add_amount_btn_back"
+        android:layout_width="@dimen/back_button_size"
+        android:layout_height="@dimen/back_button_size"
+        android:layout_marginTop="@dimen/header_top_inset"
         android:background="@color/white"
-        android:clipChildren="false">
+        android:contentDescription="@null"
+        android:src="@drawable/back_icon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- back -->
-        <ImageButton
-            android:id="@+id/add_amount_btn_back"
-            android:layout_width="50dp"
-            android:layout_height="match_parent"
-            android:background="@color/white"
-            android:contentDescription="@null"
-            android:src="@drawable/back_icon" />
-        <!-- contact alias -->
-        <com.tari.android.wallet.ui.component.CustomFontTextView
-            android:id="@+id/add_amount_txt_title"
+    <!-- contact alias -->
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/add_amount_txt_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_amount_under_construction"
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        app:customFont="AVENIR_LT_STD_HEAVY"
+        app:layout_constraintBottom_toBottomOf="@id/add_amount_btn_back"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/add_amount_btn_back" />
+
+    <!-- Recipient Emojix ID -->
+    <FrameLayout
+        android:id="@+id/add_amount_vw_emoji_id_summary_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/emoji_id_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:paddingStart="@dimen/emoji_id_container_horizontal_padding"
+        android:paddingTop="@dimen/emoji_id_container_vertical_padding"
+        android:paddingEnd="@dimen/emoji_id_container_horizontal_padding"
+        android:paddingBottom="@dimen/emoji_id_container_vertical_padding"
+        app:layout_constraintBottom_toBottomOf="@id/add_amount_btn_back"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/add_amount_btn_back">
+
+        <include
+            android:id="@+id/add_amount_vw_emoji_id_summary"
+            layout="@layout/emoji_id_summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/add_amount_under_construction"
-            android:textColor="@color/black"
-            android:textSize="16sp"
-            app:customFont="AVENIR_LT_STD_HEAVY" />
+            android:visibility="visible" />
+    </FrameLayout>
 
-        <FrameLayout
-            android:id="@+id/add_amount_vw_emoji_id_summary_container"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/emoji_id_bg"
-            android:clickable="true"
-            android:elevation="@dimen/common_view_elevation"
-            android:focusable="true"
-            android:paddingStart="@dimen/emoji_id_container_horizontal_padding"
-            android:paddingTop="@dimen/emoji_id_container_vertical_padding"
-            android:paddingEnd="@dimen/emoji_id_container_horizontal_padding"
-            android:paddingBottom="@dimen/emoji_id_container_vertical_padding">
-
-            <include
-                android:id="@+id/add_amount_vw_emoji_id_summary"
-                layout="@layout/emoji_id_summary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="visible" />
-        </FrameLayout>
-    </RelativeLayout>
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/add_amount_header_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="add_amount_btn_back,add_amount_txt_title,add_amount_vw_emoji_id_summary_container"/>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/add_amount_vw_header"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/add_amount_header_barrier"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:orientation="vertical">
 
         <!-- amount container -->
@@ -405,8 +415,13 @@
 
     <!-- full emoji id outer container -->
     <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="gone">
 
         <View
             android:id="@+id/add_amount_vw_full_emoji_id_bg_click_blocker"
@@ -522,4 +537,4 @@
         </RelativeLayout>
     </RelativeLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_note.xml
+++ b/app/src/main/res/layout/fragment_add_note.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/add_note_and_send_vw_root"
@@ -7,61 +7,72 @@
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <!-- header -->
-    <RelativeLayout
-        android:id="@+id/add_note_vw_header"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/common_header_height"
-        android:layout_marginTop="0dp"
-        android:background="@color/white">
+    <!-- back -->
+    <ImageButton
+        android:id="@+id/add_note_btn_back"
+        android:layout_width="@dimen/back_button_size"
+        android:layout_height="@dimen/back_button_size"
+        android:layout_marginTop="@dimen/header_top_inset"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:background="@color/white"
+        android:contentDescription="@null"
+        android:src="@drawable/back_icon" />
 
-        <!-- back -->
-        <ImageButton
-            android:id="@+id/add_note_btn_back"
-            android:layout_width="50dp"
-            android:layout_height="match_parent"
-            android:background="@color/white"
-            android:contentDescription="@null"
-            android:src="@drawable/back_icon" />
-        <!-- contact alias -->
-        <com.tari.android.wallet.ui.component.CustomFontTextView
-            android:id="@+id/add_note_txt_title"
+    <!-- contact alias -->
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/add_note_txt_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_amount_under_construction"
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        app:customFont="AVENIR_LT_STD_HEAVY"
+        app:layout_constraintBottom_toBottomOf="@id/add_note_btn_back"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/add_note_btn_back" />
+
+    <FrameLayout
+        android:id="@+id/add_note_vw_emoji_id_summary_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:background="@drawable/emoji_id_bg"
+        android:clickable="true"
+        android:elevation="@dimen/common_view_elevation"
+        android:focusable="true"
+        android:paddingStart="@dimen/emoji_id_container_horizontal_padding"
+        android:paddingTop="@dimen/emoji_id_container_vertical_padding"
+        android:paddingEnd="@dimen/emoji_id_container_horizontal_padding"
+        android:paddingBottom="@dimen/emoji_id_container_vertical_padding"
+        app:layout_constraintBottom_toBottomOf="@id/add_note_btn_back"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/add_note_btn_back">
+
+        <include
+            android:id="@+id/add_note_vw_emoji_id_summary"
+            layout="@layout/emoji_id_summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/add_amount_under_construction"
-            android:textColor="@color/black"
-            android:textSize="16sp"
-            app:customFont="AVENIR_LT_STD_HEAVY" />
+            android:visibility="visible" />
+    </FrameLayout>
 
-        <FrameLayout
-            android:id="@+id/add_note_vw_emoji_id_summary_container"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/emoji_id_bg"
-            android:clickable="true"
-            android:elevation="@dimen/common_view_elevation"
-            android:focusable="true"
-            android:paddingStart="@dimen/emoji_id_container_horizontal_padding"
-            android:paddingTop="@dimen/emoji_id_container_vertical_padding"
-            android:paddingEnd="@dimen/emoji_id_container_horizontal_padding"
-            android:paddingBottom="@dimen/emoji_id_container_vertical_padding">
-
-            <include
-                android:id="@+id/add_note_vw_emoji_id_summary"
-                layout="@layout/emoji_id_summary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="visible" />
-        </FrameLayout>
-
-    </RelativeLayout>
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/add_note_header_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="add_note_btn_back,add_note_txt_title,add_note_vw_emoji_id_summary_container"/>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/add_note_vw_header"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/add_note_header_barrier"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginStart="25dp"
         android:layout_marginTop="25dp"
         android:layout_marginEnd="25dp"
@@ -178,8 +189,13 @@
 
     <!-- full emoji id outer container -->
     <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="gone">
 
         <View
             android:id="@+id/add_note_vw_full_emoji_id_bg_click_blocker"
@@ -295,4 +311,4 @@
         </RelativeLayout>
     </RelativeLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_recipient.xml
+++ b/app/src/main/res/layout/fragment_add_recipient.xml
@@ -1,53 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/add_recipient_vw_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <!-- Transactions header -->
-    <RelativeLayout
-        android:id="@+id/add_recipient_vw_tx_list_header"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/common_header_height"
-        android:layout_marginTop="0dp"
-        android:background="@color/white">
+    <!-- back -->
+    <ImageButton
+        android:id="@+id/add_recipient_btn_back"
+        android:layout_width="@dimen/back_button_size"
+        android:layout_height="@dimen/back_button_size"
+        android:layout_marginTop="@dimen/header_top_inset"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:background="@color/white"
+        android:contentDescription="@null"
+        android:src="@drawable/back_icon" />
 
-        <!-- back -->
-        <ImageButton
-            android:id="@+id/add_recipient_btn_back"
-            android:layout_width="50dp"
-            android:layout_height="match_parent"
-            android:background="@color/white"
-            android:contentDescription="@null"
-            android:src="@drawable/back_icon" />
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/add_recipient_txt_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_recipient_title"
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@id/add_recipient_btn_back"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/add_recipient_btn_back"
+        app:customFont="AVENIR_LT_STD_HEAVY" />
 
-        <com.tari.android.wallet.ui.component.CustomFontTextView
-            android:id="@+id/add_recipient_txt_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/add_recipient_title"
-            android:textColor="@color/black"
-            android:textSize="16sp"
-            app:customFont="AVENIR_LT_STD_HEAVY" />
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/add_recipient_header_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="add_recipient_btn_back,add_recipient_txt_title"/>
 
-        <View
-            android:id="@+id/add_recipinet_vw_top_dimmer"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:alpha="0.6"
-            android:background="@color/black"
-            android:clickable="true"
-            android:focusable="true" />
-    </RelativeLayout>
+    <View
+        android:id="@+id/add_recipinet_vw_top_dimmer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/add_recipient_header_barrier"
+        android:alpha="0.6"
+        android:background="@color/black"
+        android:clickable="true"
+        android:focusable="true" />
 
     <RelativeLayout
         android:id="@+id/add_recipient_vw_search_container"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="@dimen/add_recipient_search_bar_container_height"
-        android:layout_below="@id/add_recipient_vw_tx_list_header"
+        app:layout_constraintTop_toBottomOf="@id/add_recipient_header_barrier"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:background="@color/white"
         android:gravity="center"
         android:orientation="horizontal">
@@ -115,8 +125,8 @@
             <View
                 android:layout_width="30dp"
                 android:layout_height="32dp"
-                android:layout_centerVertical="true"
                 android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
                 android:background="@drawable/emoji_id_end_fader" />
 
             <!-- QR code button -->
@@ -132,9 +142,12 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/add_recipient_vw_search_container">
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/add_recipient_vw_search_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <!-- list -->
         <androidx.recyclerview.widget.RecyclerView
@@ -251,9 +264,8 @@
 
     <com.tari.android.wallet.ui.component.CustomFontTextView
         android:id="@+id/add_recipient_txt_invalid_emoji_id"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="@dimen/add_recipient_search_text_view_height"
-        android:layout_below="@id/add_recipient_vw_search_container"
         android:layout_marginStart="25dp"
         android:layout_marginEnd="25dp"
         android:background="@drawable/validation_error_box_border_bg"
@@ -261,16 +273,18 @@
         android:text="@string/add_recipient_invalid_emoji_id"
         android:textColor="@color/common_error"
         android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@id/add_recipient_vw_search_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:customFont="AVENIR_LT_STD_HEAVY" />
 
     <com.tari.android.wallet.ui.component.CustomFontButton
         android:id="@+id/add_recipient_btn_continue"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="@dimen/common_action_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginStart="25dp"
-        android:layout_marginEnd="25dp"
+        android:layout_marginHorizontal="25dp"
         android:layout_marginBottom="40dp"
         android:background="@drawable/gradient_button_bg"
         android:ellipsize="middle"
@@ -279,6 +293,9 @@
         android:textAllCaps="false"
         android:textColor="@color/white"
         android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:customFont="AVENIR_LT_STD_HEAVY" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_create_wallet.xml
+++ b/app/src/main/res/layout/fragment_create_wallet.xml
@@ -362,6 +362,7 @@
 
         <com.tari.android.wallet.ui.component.CustomFontButton
             android:id="@+id/create_wallet_btn_continue"
+            style="?android:attr/borderlessButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="@dimen/common_action_button_height"
             android:layout_alignParentBottom="true"
@@ -379,6 +380,7 @@
 
         <com.tari.android.wallet.ui.component.CustomFontButton
             android:id="@+id/create_wallet_btn_create_emoji_id"
+            style="?android:attr/borderlessButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="@dimen/common_action_button_height"
             android:layout_alignParentBottom="true"

--- a/app/src/main/res/layout/fragment_introduction.xml
+++ b/app/src/main/res/layout/fragment_introduction.xml
@@ -22,7 +22,7 @@
         app:lottie_loop="false"
         app:lottie_rawRes="@raw/aurora_splash_anim"
         app:lottie_renderMode="automatic"
-        app:lottie_scale="0.8" />
+        app:lottie_scale="0.84" />
 
     <RelativeLayout
         android:id="@+id/introduction_vw_video_outer_container"

--- a/app/src/main/res/layout/fragment_local_auth.xml
+++ b/app/src/main/res/layout/fragment_local_auth.xml
@@ -99,6 +99,7 @@
 
         <com.tari.android.wallet.ui.component.CustomFontButton
             android:id="@+id/local_auth_btn_enable_auth"
+            style="?android:attr/borderlessButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="@dimen/common_action_button_height"
             android:layout_centerInParent="true"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -86,4 +86,6 @@
     <!-- wallet info -->
     <dimen name="wallet_info_container_qr_code_size">278dp</dimen>
     <dimen name="wallet_info_img_qr_code_size">400dp</dimen>
+    <dimen name="back_button_size">50dp</dimen>
+    <dimen name="header_top_inset">24dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,4 +21,17 @@
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
+<!--
+  Style that makes a dialog placed to the bottom slide from bottom on show and to bottom on hide.
+  Simply put - like on iOS.
+-->
+    <style name="BottomSlideDialog" parent="Theme.AppCompat.Dialog">
+        <item name="android:windowAnimationStyle">@style/BottomSlideDialogAnimation</item>
+    </style>
+
+    <style name="BottomSlideDialogAnimation">
+        <item name="android:windowEnterAnimation">@anim/dialog_slide_from_bottom</item>
+        <item name="android:windowExitAnimation">@anim/dialog_slide_to_bottom</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Add press animation to the wallet creation button
Set CIRC_IN_OUT interpolation for white background appearance
Remove shadow from "Create Your Emoji ID" button
Add QUINT_IN interpolation to the "Secure Your Wallet" scene
Remove dead imports from Constants.kt
Remove shadow from "Secure with ?" button
Add CIRC_IN_OUT easing to home page draggable view onboarding showup
Style "testtari received" dialog to slide from bottom to the target position
Lower the header with back button and text for Add Recipient, Add Amount, Add Note pages
Make store dialog appeared as sliding from bottom
Update all application bottom dialogs to slide from the bottom
Make `Continue` button visible after wallet creation borderless
Incorporate expandable/collapsible emoji id to the Wallet Info page