### PR TITLE
Fix for a transaction list interaction bug.

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/activity/home/CustomScrollView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/home/CustomScrollView.kt
@@ -40,7 +40,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.ScrollView
 import androidx.core.animation.addListener
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import butterknife.BindDimen
 import butterknife.BindView
@@ -48,6 +47,7 @@ import butterknife.ButterKnife
 import com.daasuu.ei.Ease
 import com.daasuu.ei.EasingInterpolator
 import com.tari.android.wallet.R
+import com.tari.android.wallet.ui.extension.isScrolledToTop
 import com.tari.android.wallet.ui.util.UiUtil
 import com.tari.android.wallet.util.Constants
 import java.lang.ref.WeakReference
@@ -179,7 +179,7 @@ internal class CustomScrollView @JvmOverloads constructor(
                 }
             }
         } else if (deltaY < 0) {
-            if (target is RecyclerView && !isRvScrolledToTop(target)) {
+            if (target is RecyclerView && !target.isScrolledToTop()) {
                 lastDeltaY = deltaY
                 return
             } else if (canScrollVertically(deltaY)) {
@@ -253,7 +253,7 @@ internal class CustomScrollView @JvmOverloads constructor(
         }
         if (target is RecyclerView) {
             if (canScrollVertically(velocityY.toInt())) {
-                if (isRvScrolledToTop(target)) {
+                if (target.isScrolledToTop()) {
                     flingScroll(velocityY.toInt())
                     return true
                 }
@@ -262,12 +262,7 @@ internal class CustomScrollView @JvmOverloads constructor(
         return super.onNestedPreFling(target, velocityX, velocityY)
     }
 
-    private fun isRvScrolledToTop(recyclerView: RecyclerView): Boolean {
-        val layoutManager = recyclerView.layoutManager as LinearLayoutManager
-        if (layoutManager.childCount == 0) return true
-        return (layoutManager.findFirstVisibleItemPosition() == 0
-                && layoutManager.findViewByPosition(0)?.top == 0)
-    }
+
 
     fun beginUpdate() {
         if (isUpdating) return

--- a/app/src/main/java/com/tari/android/wallet/ui/activity/home/HomeActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/home/HomeActivity.kt
@@ -1233,8 +1233,12 @@ internal class HomeActivity : AppCompatActivity(),
                     isDragging = true
                 }
                 MotionEvent.ACTION_UP -> {
-                    if (isOnboarding && ui.scrollView.scrollY == 0) {
-                        endOnboarding()
+                    if (ui.scrollView.scrollY == 0 && !ui.txRecyclerView.isScrolledToTop()) {
+                        ui.txRecyclerView.smoothScrollToPosition(0)
+                        handler.postDelayed({
+                            recyclerViewScrollListener.reset()
+                            ui.headerElevationView.alpha = 0f
+                        }, Constants.UI.mediumDurationMs)
                     }
                     ui.scrollView.flingIsRunning = false
                     ui.scrollView.postDelayed({
@@ -1296,6 +1300,14 @@ internal class HomeActivity : AppCompatActivity(),
                     0f,
                     1f - ratio * grabberViewCornerRadiusScrollAnimCoefficient
                 ) * grabberCornerRadius
+
+                if (ratio == 0f && !isDragging && !ui.txRecyclerView.isScrolledToTop()) {
+                    ui.txRecyclerView.smoothScrollToPosition(0)
+                    handler.postDelayed({
+                        recyclerViewScrollListener.reset()
+                        ui.headerElevationView.alpha = 0f
+                    }, Constants.UI.mediumDurationMs)
+                }
             } else if (ratio == 0f && !isDragging) { // is onboarding
                 ui.scrollView.isScrollable = true
                 endOnboarding()

--- a/app/src/main/java/com/tari/android/wallet/ui/extension/ViewExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/extension/ViewExtensions.kt
@@ -44,9 +44,18 @@ import android.view.ViewTreeObserver
 import android.view.WindowManager
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.tari.android.wallet.R
 import com.tari.android.wallet.ui.dialog.BottomSlideDialog
 import com.tari.android.wallet.ui.util.UiUtil
+
+internal fun RecyclerView.isScrolledToTop(): Boolean {
+    val layoutManager = (layoutManager as? LinearLayoutManager) ?: return false
+    if (layoutManager.childCount == 0) return true
+    return (layoutManager.findFirstVisibleItemPosition() == 0
+            && layoutManager.findViewByPosition(0)?.top == 0)
+}
 
 internal fun View.visible() {
     this.visibility = View.VISIBLE
@@ -68,18 +77,6 @@ internal fun showInternetConnectionErrorDialog(context: Context) {
         context = context,
         layoutId = R.layout.internet_connection_error_dialog,
         dismissViewId = R.id.internet_connection_error_dialog_txt_close
-    ).show()
-}
-
-/**
- * Given the context, displays the standard "it's not you, it's the network" dialog.
- */
-// TODO seems to be unused; should be removed?
-internal fun showTariNetworkConnectionErrorDialog(context: Context) {
-    BottomSlideDialog(
-        context = context,
-        layoutId = R.layout.tari_network_connection_error_dialog,
-        dismissViewId = R.id.tari_network_connection_error_dialog_txt_close
     ).show()
 }
 


### PR DESCRIPTION
Steps to reproduce the issue that's fixed:

- On a transaction list that overflows the screen, first maximize the list.
- Make a fling scroll up.
- While the fling is running, tap on the list and scroll it down to minimized state (either complete the scroll or let the UI complete it).
- You'll find that the list remains scrolled and the elevation shadow remains.

Example:

![Screenshot_20200504-133754_Tari Aurora](https://user-images.githubusercontent.com/2969501/80957877-b7a4bd00-8e0c-11ea-94a3-09a0aae8075c.jpg)
