### PR TITLE
Incompatible Emoji ID Warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,7 @@ Properties loadSecretProps() {
     return properties
 }
 
-preBuild.dependsOn("downloadJNIBinaries")
+// preBuild.dependsOn("downloadJNIBinaries")
 
 dependencies {
     // kotlin

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -64,5 +64,5 @@ target_link_libraries(
         android
         wallet
         ${log-lib}
+        "-Wl,--allow-multiple-definition"
 )
-

--- a/app/src/main/java/com/tari/android/wallet/application/WalletManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/WalletManager.kt
@@ -182,7 +182,7 @@ internal class WalletManager(
      * Returns the list of base nodes in the resource file base_nodes.txt as pairs of
      * ({public_key_hex}, {public_address}).
      */
-    private fun getBaseNodeList(): List<Pair<String, String>> {
+    private val baseNodeList by lazy {
         val fileContent = IOUtils.toString(
             context.resources.openRawResource(R.raw.base_nodes),
             "UTF-8"
@@ -198,15 +198,15 @@ internal class WalletManager(
                 )
             )
         }
-        return baseNodes
+        baseNodes
     }
 
     /**
      * Select a base node randomly from the list of base nodes in base_nodes.tx, and sets
      * the wallet and stored the values in shared prefs.
      */
-    private fun setBaseNode() {
-        val randomBaseNode = getBaseNodeList().random()
+    private fun setRandomBaseNode() {
+        val randomBaseNode = baseNodeList.random()
         val publicKeyHex = randomBaseNode.first
         val address = randomBaseNode.second
         sharedPrefsWrapper.baseNodePublicKeyHex = publicKeyHex
@@ -253,7 +253,7 @@ internal class WalletManager(
             FFIWallet.instance = wallet
             sharedPrefsWrapper.torIdentity = wallet.getTorIdentity()
             startLogFileObserver()
-            setBaseNode()
+            setRandomBaseNode()
             saveWalletPublicKeyHexToSharedPrefs()
         }
     }

--- a/app/src/main/res/layout/fragment_add_recipient.xml
+++ b/app/src/main/res/layout/fragment_add_recipient.xml
@@ -264,9 +264,12 @@
     <com.tari.android.wallet.ui.component.CustomFontTextView
         android:id="@+id/invalid_emoji_id_text_view"
         android:layout_width="0dp"
-        android:layout_height="@dimen/add_recipient_search_text_view_height"
+        android:layout_height="wrap_content"
         android:layout_marginStart="25dp"
         android:layout_marginEnd="25dp"
+        android:lineSpacingExtra="8dp"
+        android:paddingVertical="14dp"
+        android:paddingHorizontal="14dp"
         android:background="@drawable/validation_error_box_border_bg"
         android:gravity="center"
         android:text="@string/add_recipient_invalid_emoji_id"

--- a/app/src/main/res/layout/incompatible_emoji_id_dialog.xml
+++ b/app/src/main/res/layout/incompatible_emoji_id_dialog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/home_dialog_testnet_tari_dialog_margin"
+    android:layout_marginRight="@dimen/home_dialog_testnet_tari_dialog_margin"
+    android:layout_marginBottom="23dp"
+    android:background="@drawable/bottom_dialog_bg"
+    android:orientation="vertical">
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="40dp"
+        android:layout_marginBottom="16dp"
+        android:gravity="center"
+        android:text="@string/add_recipient_incompatible_emoji_id"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:customFont="AVENIR_LT_STD_LIGHT" />
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:letterSpacing="0.01"
+        android:lineSpacingExtra="10dp"
+        android:paddingLeft="32dp"
+        android:paddingRight="32dp"
+        android:text="@string/add_recipient_incompatible_emoji_id_desc"
+        android:textColor="@color/dark_gray"
+        android:textSize="14sp"
+        app:customFont="AVENIR_LT_STD_MEDIUM" />
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/incompatible_emoji_id_dialog_txt_close"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="20dp"
+        android:gravity="center"
+        android:padding="10dp"
+        android:layout_marginTop="14dp"
+        android:text="@string/common_close"
+        android:textColor="@color/dialog_cancel_action"
+        android:textSize="13sp"
+        app:customFont="AVENIR_LT_STD_HEAVY" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,10 @@
     <string name="add_recipient_scan_qr_description">Scan a Tari QR code\nto send tXTR to the recipient.</string>
     <string name="add_recipient_failed_init_camera_message">Failed to initialize Camera</string>
     <string name="add_recipient_camera_permission_denied_message">Camera permission denied</string>
+    <!-- incompatible emoji id dialog -->
+    <string name="add_recipient_incompatible_emoji_id">Incompatible Emoji Id</string>
+    <string name="add_recipient_incompatible_emoji_id_desc">Emoji ID in your clipboard is from an older version. Your recipient needs to upgrade to the latest version of Tari Aurora and copy their updated Emoji ID to transact with you.</string>
+    <string name="add_recipient_incompatible_emoji_id_desc_short">Your recipient needs to upgrade to the latest version of Tari Aurora and copy their updated Emoji ID to transact with you.</string>
 
     <!-- send tari - amount -->
     <string name="add_amount_under_construction">Under Construction</string>

--- a/download-jni-binaries.gradle
+++ b/download-jni-binaries.gradle
@@ -1,6 +1,6 @@
 ext {
     jniLibsVersion = "0.11.0"
-    jniLibsHostURL = "https://www.tari.com/binaries/"
+    jniLibsHostURL = "https://tari-binaries.s3.amazonaws.com/libwallet/"
     supportedABIs = ["arm64-v8a", "armeabi-v7a", "x86_64"]
 }
 
@@ -14,7 +14,7 @@ task downloadJNIBinaries  {
     doLast {
         logger.info("Downloading binaries with version $jniLibsVersion")
         final def binaryArchives = supportedABIs.collect {
-            "libwallet-${it}-${jniLibsVersion}.tar.gz"
+            "libwallet-${it}-libwallet-${jniLibsVersion}.tar.gz"
         }
         delete {
             delete fileTree(binariesDir)


### PR DESCRIPTION
Display warning when a user enters Add Recipient screen with an incompatible (i.e. old) emoji id in their clipboard, or when they paste an incompatible emoji id into the text field per tari-project/wallet-android#422.