### PR TITLE
Home page wallet backup prompts on TX recieve

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -152,7 +152,7 @@
         <activity
             android:name=".ui.activity.settings.SettingsActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:parentActivityName=".ui.activity.home.HomeActivity"
+            android:parentActivityName=".ui.activity.profile.WalletInfoActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme"
             android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />

--- a/app/src/main/java/com/tari/android/wallet/ui/activity/home/HomeActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/home/HomeActivity.kt
@@ -47,6 +47,9 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.Spanned
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
@@ -66,6 +69,7 @@ import com.daasuu.ei.EasingInterpolator
 import com.orhanobut.logger.Logger
 import com.squareup.seismic.ShakeDetector
 import com.tari.android.wallet.R
+import com.tari.android.wallet.R.string.*
 import com.tari.android.wallet.application.DeepLink
 import com.tari.android.wallet.databinding.ActivityHomeBinding
 import com.tari.android.wallet.event.Event
@@ -83,8 +87,10 @@ import com.tari.android.wallet.ui.activity.debug.DebugActivity
 import com.tari.android.wallet.ui.activity.home.adapter.TxListAdapter
 import com.tari.android.wallet.ui.activity.profile.WalletInfoActivity
 import com.tari.android.wallet.ui.activity.send.SendTariActivity
+import com.tari.android.wallet.ui.activity.settings.SettingsActivity
 import com.tari.android.wallet.ui.activity.tx.TxDetailActivity
 import com.tari.android.wallet.ui.component.CustomFont
+import com.tari.android.wallet.ui.component.CustomTypefaceSpan
 import com.tari.android.wallet.ui.dialog.BottomSlideDialog
 import com.tari.android.wallet.ui.extension.*
 import com.tari.android.wallet.ui.fragment.send.FinalizeSendTxFragment
@@ -96,7 +102,9 @@ import com.tari.android.wallet.util.SharedPrefsWrapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
+import java.math.BigDecimal
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import kotlin.math.max
@@ -437,10 +445,76 @@ internal class HomeActivity : AppCompatActivity(),
         // update balance
         lifecycleScope.launch(Dispatchers.IO) {
             updateBalanceInfoData()
-            handler?.post { updateBalanceInfoUI(restart = false) }
+            withContext(Dispatchers.Main) {
+                updateBalanceInfoUI(restart = false)
+                showWalletBackupPromptIfNecessary()
+            }
         }
         // update tx list UI
         handler?.post { updateTxListUI() }
+    }
+
+    private fun showWalletBackupPromptIfNecessary() {
+        if (!sharedPrefsWrapper.backupIsEnabled || sharedPrefsWrapper.backupPassword == null) {
+            val inboundNonFaucetTransactionsCount = countInboundNonFaucetTransaction()
+            val tarisAmount =
+                balanceInfo.availableBalance.tariValue + balanceInfo.pendingIncomingBalance.tariValue
+            when {
+                inboundNonFaucetTransactionsCount >= 5
+                        && tarisAmount > BigDecimal("25000")
+                        && sharedPrefsWrapper.backupIsEnabled
+                        && sharedPrefsWrapper.backupPassword == null -> showSecureYourBackupsDialog()
+                inboundNonFaucetTransactionsCount >= 4
+                        && tarisAmount > BigDecimal("8000")
+                        && !sharedPrefsWrapper.backupIsEnabled -> showRepeatedBackUpPrompt()
+                inboundNonFaucetTransactionsCount >= 3
+                        && !sharedPrefsWrapper.backupIsEnabled -> showInitialBackupPrompt()
+            }
+        }
+    }
+
+    private fun countInboundNonFaucetTransaction(): Int {
+        val completedInboundNonFaucetTxs = completedTxs
+            .filter { it.direction == Tx.Direction.INBOUND }
+            .filterNot { it.status == TxStatus.IMPORTED }
+            .count()
+        return completedInboundNonFaucetTxs + pendingInboundTxs.size
+    }
+
+    private fun showInitialBackupPrompt() {
+        BackupWalletPrompt(
+            context = this,
+            regularTitlePart = string(home_back_up_wallet_initial_title_regular_part),
+            highlightedTitlePart = string(home_back_up_wallet_initial_title_highlighted_part),
+            description = string(home_back_up_wallet_initial_description)
+        ).asAndroidDialog()
+            .apply(::replaceDialog)
+    }
+
+    private fun showRepeatedBackUpPrompt() {
+        BackupWalletPrompt(
+            context = this,
+            regularTitlePart = string(home_back_up_wallet_repeated_title_regular_part),
+            highlightedTitlePart = string(home_back_up_wallet_repeated_title_highlighted_part),
+            description = string(home_back_up_wallet_repeated_description)
+        ).asAndroidDialog()
+            .apply(::replaceDialog)
+    }
+
+    private fun showSecureYourBackupsDialog() {
+        BackupWalletPrompt(
+            context = this,
+            title = string(home_back_up_wallet_encrypt_title),
+            description = string(home_back_up_wallet_encrypt_description),
+            ctaText = string(home_back_up_wallet_encrypt_cta),
+            dismissText = string(home_back_up_wallet_delay_encrypt_cta)
+        ).asAndroidDialog()
+            .apply(::replaceDialog)
+    }
+
+    private fun replaceDialog(dialog: Dialog) {
+        currentDialog?.dismiss()
+        currentDialog = dialog.also { it.show() }
     }
 
     private fun onTxReplyReceived(tx: CompletedTx) {
@@ -778,7 +852,7 @@ internal class HomeActivity : AppCompatActivity(),
     private fun testnetTariRequestSuccessful() {
         val error = WalletError()
         val importedTx =
-            walletService!!.importTestnetUTXO(string(R.string.first_testnet_utxo_tx_message), error)
+            walletService!!.importTestnetUTXO(string(first_testnet_utxo_tx_message), error)
         if (error.code != WalletErrorCode.NO_ERROR) {
             TODO("Unhandled wallet error: ${error.code}")
         }
@@ -814,10 +888,10 @@ internal class HomeActivity : AppCompatActivity(),
             canceledOnTouchOutside = false
         ).apply {
             findViewById<TextView>(R.id.home_testnet_tari_received_dlg_txt_title).text =
-                string(R.string.home_tari_bot_you_got_tari_dlg_title).applyFontStyle(
+                string(home_tari_bot_you_got_tari_dlg_title).applyFontStyle(
                     this@HomeActivity,
                     CustomFont.AVENIR_LT_STD_LIGHT,
-                    string(R.string.home_tari_bot_you_got_tari_dlg_title_bold_part),
+                    string(home_tari_bot_you_got_tari_dlg_title_bold_part),
                     CustomFont.AVENIR_LT_STD_BLACK
                 )
             findViewById<TextView>(R.id.home_tari_bot_dialog_txt_try_later)
@@ -849,10 +923,10 @@ internal class HomeActivity : AppCompatActivity(),
             layoutId = R.layout.home_dialog_ttl_store
         ).apply {
             findViewById<TextView>(R.id.home_ttl_store_dialog_txt_title).text =
-                string(R.string.home_ttl_store_dlg_title).applyFontStyle(
+                string(home_ttl_store_dlg_title).applyFontStyle(
                     this@HomeActivity,
                     CustomFont.AVENIR_LT_STD_LIGHT,
-                    string(R.string.home_ttl_store_dlg_title_bold_part),
+                    string(home_ttl_store_dlg_title_bold_part),
                     CustomFont.AVENIR_LT_STD_BLACK
                 )
             findViewById<View>(R.id.home_ttl_store_dialog_btn_later)
@@ -1016,7 +1090,7 @@ internal class HomeActivity : AppCompatActivity(),
     private fun importSecondUTXO() {
         val error = WalletError()
         val importedTx = walletService!!.importTestnetUTXO(
-            string(R.string.second_testnet_utxo_tx_message),
+            string(second_testnet_utxo_tx_message),
             error
         )
         if (error.code != WalletErrorCode.NO_ERROR) {
@@ -1171,19 +1245,19 @@ internal class HomeActivity : AppCompatActivity(),
 
     override fun updateHasCompleted(
         source: UpdateProgressViewController,
-        updateDataAndUI: Boolean
+        receivedTxCount: Int,
+        cancelledTxCount: Int
     ) {
-        handler?.post {
-            ui.scrollView.finishUpdate()
-        }
-        if (updateDataAndUI) {
+        handler?.post { ui.scrollView.finishUpdate() }
+        if (receivedTxCount > 0 || cancelledTxCount > 0) {
             lifecycleScope.launch(Dispatchers.IO) {
                 updateTxListData()
-                if (isActive) {
-                    updateBalanceInfoData()
-                    handler?.post {
-                        updateBalanceInfoUI(restart = false)
-                        updateTxListUI()
+                updateBalanceInfoData()
+                withContext(Dispatchers.Main) {
+                    updateBalanceInfoUI(restart = false)
+                    updateTxListUI()
+                    if (receivedTxCount > 0) {
+                        showWalletBackupPromptIfNecessary()
                     }
                 }
             }
@@ -1198,9 +1272,9 @@ internal class HomeActivity : AppCompatActivity(),
             dismissViewId = R.id.tx_failed_dialog_txt_close
         ).apply {
             val titleTextView = findViewById<TextView>(R.id.tx_failed_dialog_txt_title)
-            titleTextView.text = string(R.string.error_no_connection_title)
+            titleTextView.text = string(error_no_connection_title)
             val descriptionTextView = findViewById<TextView>(R.id.tx_failed_dialog_txt_description)
-            descriptionTextView.text = string(R.string.error_no_connection_description)
+            descriptionTextView.text = string(error_no_connection_description)
             // set text
         }.apply { show() }
             .asAndroidDialog()
@@ -1215,9 +1289,9 @@ internal class HomeActivity : AppCompatActivity(),
             dismissViewId = R.id.tx_failed_dialog_txt_close
         ).apply {
             val titleTextView = findViewById<TextView>(R.id.tx_failed_dialog_txt_title)
-            titleTextView.text = string(R.string.error_node_unreachable_title)
+            titleTextView.text = string(error_node_unreachable_title)
             val descriptionTextView = findViewById<TextView>(R.id.tx_failed_dialog_txt_description)
-            descriptionTextView.text = string(R.string.error_node_unreachable_description)
+            descriptionTextView.text = string(error_node_unreachable_description)
             // set text
         }.apply { show() }
             .asAndroidDialog()
@@ -1397,5 +1471,71 @@ internal class HomeActivity : AppCompatActivity(),
     }
 
     // endregion
+
+    class BackupWalletPrompt private constructor(private val dialog: Dialog) {
+
+        constructor(
+            context: Context,
+            title: CharSequence,
+            description: CharSequence,
+            ctaText: CharSequence = context.string(home_back_up_wallet_back_up_cta),
+            dismissText: CharSequence = context.string(home_back_up_wallet_delay_back_up_cta)
+        ) : this(
+            BottomSlideDialog(
+                context,
+                R.layout.dialog_backup_wallet_prompt,
+                canceledOnTouchOutside = false,
+                dismissViewId = R.id.home_backup_wallet_prompt_dismiss_cta_view
+            ).apply {
+                findViewById<TextView>(R.id.home_backup_wallet_prompt_title_text_view).text = title
+                findViewById<TextView>(R.id.home_backup_wallet_prompt_description_text_view).text =
+                    description
+                findViewById<TextView>(R.id.home_backup_wallet_prompt_dismiss_cta_view).text =
+                    dismissText
+                val backupCta =
+                    findViewById<TextView>(R.id.home_backup_wallet_prompt_backup_cta_view)
+                backupCta.text = ctaText
+                backupCta.setOnClickListener {
+                    context.startActivities(
+                        arrayOf(
+                            Intent(context, WalletInfoActivity::class.java),
+                            Intent(context, SettingsActivity::class.java)
+                                .apply { putExtra(SettingsActivity.KEY_SHOW_BACKUP_SETTINGS, true) }
+                        )
+                    )
+                    dismiss()
+                }
+            }.asAndroidDialog()
+        )
+
+        constructor(
+            context: Context,
+            regularTitlePart: CharSequence,
+            highlightedTitlePart: CharSequence,
+            description: CharSequence,
+            ctaText: CharSequence = context.string(home_back_up_wallet_back_up_cta),
+            dismissText: CharSequence = context.string(home_back_up_wallet_delay_back_up_cta)
+        ) : this(
+            context,
+            SpannableStringBuilder().apply {
+                val highlightedPart = SpannableString(highlightedTitlePart)
+                highlightedPart.setSpan(
+                    CustomTypefaceSpan("", CustomFont.AVENIR_LT_STD_HEAVY.asTypeface(context)),
+                    0,
+                    highlightedPart.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                insert(0, regularTitlePart)
+                insert(regularTitlePart.length, " ")
+                insert(regularTitlePart.length + 1, highlightedPart)
+            },
+            description,
+            ctaText,
+            dismissText
+        )
+
+        fun asAndroidDialog() = dialog
+
+    }
 
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/activity/home/UpdateProgressViewController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/activity/home/UpdateProgressViewController.kt
@@ -73,7 +73,7 @@ import kotlin.coroutines.CoroutineContext
 internal class UpdateProgressViewController(
     private val view: View,
     listener: Listener
-): CoroutineScope {
+) : CoroutineScope {
 
     private val mJob = Job()
     override val coroutineContext: CoroutineContext
@@ -353,8 +353,8 @@ internal class UpdateProgressViewController(
         state = State.IDLE
         listenerWeakReference.get()?.updateHasCompleted(
             this,
-            // only update UI if there's a visible change
-            (numberOfReceivedTxs + numberOfCancelledTxs) > 0
+            numberOfReceivedTxs,
+            numberOfCancelledTxs
         )
     }
 
@@ -416,7 +416,8 @@ internal class UpdateProgressViewController(
 
         fun updateHasCompleted(
             source: UpdateProgressViewController,
-            updateDataAndUI: Boolean
+            receivedTxCount: Int,
+            cancelledTxCount: Int
         )
 
     }

--- a/app/src/main/res/layout/dialog_backup_wallet_prompt.xml
+++ b/app/src/main/res/layout/dialog_backup_wallet_prompt.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="14dp"
+    android:layout_marginBottom="23dp"
+    android:background="@drawable/bottom_dialog_bg"
+    android:orientation="vertical">
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/home_backup_wallet_prompt_title_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="30dp"
+        android:gravity="center"
+        android:lineSpacingExtra="8dp"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:customFont="AVENIR_LT_STD_LIGHT"
+        tools:text="@string/home_back_up_wallet_encrypt_title" />
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/home_backup_wallet_prompt_description_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="18dp"
+        android:gravity="center"
+        android:letterSpacing="0.01"
+        android:lineSpacingExtra="10dp"
+        android:textColor="@color/dark_gray"
+        android:textSize="14sp"
+        app:customFont="AVENIR_LT_STD_MEDIUM"
+        tools:text="@string/home_back_up_wallet_encrypt_description" />
+
+    <com.tari.android.wallet.ui.component.CustomFontButton
+        android:id="@+id/home_backup_wallet_prompt_backup_cta_view"
+        android:layout_width="@dimen/home_backup_prompt_cta_width"
+        android:layout_height="@dimen/home_backup_prompt_cta_height"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="30dp"
+        android:background="@drawable/gradient_button_bg"
+        android:paddingHorizontal="10dp"
+        android:textAllCaps="false"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:customFont="AVENIR_LT_STD_HEAVY"
+        tools:text="@string/home_back_up_wallet_encrypt_cta" />
+
+    <com.tari.android.wallet.ui.component.CustomFontTextView
+        android:id="@+id/home_backup_wallet_prompt_dismiss_cta_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="22dp"
+        android:layout_marginBottom="30dp"
+        android:background="@color/transparent"
+        android:paddingHorizontal="10dp"
+        android:textAllCaps="false"
+        android:textColor="@color/dialog_cancel_action"
+        android:textSize="13sp"
+        app:customFont="AVENIR_LT_STD_HEAVY"
+        tools:text="@string/home_back_up_wallet_delay_encrypt_cta" />
+
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -60,6 +60,8 @@
     <dimen name="home_main_content_top_margin">6dp</dimen>
     <dimen name="home_dialog_testnet_tari_dialog_margin">14dp</dimen>
     <dimen name="home_wallet_info_button_initial_top_margin">40dp</dimen>
+    <dimen name="home_backup_prompt_cta_width">209dp</dimen>
+    <dimen name="home_backup_prompt_cta_height">53dp</dimen>
 
     <!-- home swipe refresh -->
     <dimen name="home_swipe_refresh_max_scroll_y">180dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,19 @@
     <string name="home_store_and_forward_progress_completing_txs">Completing your transactions</string>
     <string name="home_store_and_forward_progress_updating_txs">Updating your transactions</string>
     <string name="home_store_and_forward_progress_up_to_date">You are up to date!</string>
+    <!--backup wallet prompt-->
+    <string name="home_back_up_wallet_initial_title_regular_part">Want to</string>
+    <string name="home_back_up_wallet_initial_title_highlighted_part">back up your wallet?</string>
+    <string name="home_back_up_wallet_initial_description">You can back up your wallet so that you don’t lose your tXTR if your phone is lost or broken. You can configure this in Settings anytime.</string>
+    <string name="home_back_up_wallet_repeated_title_regular_part">It\'s time to</string>
+    <string name="home_back_up_wallet_repeated_title_highlighted_part">back up your wallet</string>
+    <string name="home_back_up_wallet_repeated_description">You have quite a bit of tXTR. You should back up your wallet now so that you don\’t lose it all if your phone is lost or broken.</string>
+    <string name="home_back_up_wallet_back_up_cta">Back Up Wallet</string>
+    <string name="home_back_up_wallet_delay_back_up_cta">I\'ll do it later</string>
+    <string name="home_back_up_wallet_encrypt_title">Further secure your backups</string>
+    <string name="home_back_up_wallet_encrypt_description">Given the amount of money in your wallet, you should password-protect your backups so they\'re safe even if your Google Drive is compromised.</string>
+    <string name="home_back_up_wallet_encrypt_cta">Secure Backups</string>
+    <string name="home_back_up_wallet_delay_encrypt_cta">Not now</string>
 
     <!-- send tari - add recipient -->
     <string name="add_recipient_title">Send To</string>


### PR DESCRIPTION
tari-project/wallet-android#408

Implement wallet backup prompts on the home page

Fix the all settings -> backup settings fragments as well as activities' issue

Set explicit dialog buttons' height

Fix layout for backup prompts and title spanning

Allow state loss for after-auth fragments