### PR TITLE
Backup & Restore UI fixes according to the Natasha's comment in tari-project/wallet-android#429

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/ChangeSecurePasswordFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/ChangeSecurePasswordFragment.kt
@@ -46,7 +46,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.EditText
 import android.widget.TextView
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
@@ -57,10 +56,6 @@ import com.tari.android.wallet.R.string.*
 import com.tari.android.wallet.databinding.FragmentChangeSecurePasswordBinding
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.infrastructure.backup.*
-import com.tari.android.wallet.infrastructure.backup.BackupManager
-import com.tari.android.wallet.infrastructure.backup.BackupOutOfDate
-import com.tari.android.wallet.infrastructure.backup.BackupState
-import com.tari.android.wallet.infrastructure.backup.BackupUpToDate
 import com.tari.android.wallet.ui.activity.settings.SettingsRouter
 import com.tari.android.wallet.ui.dialog.ErrorDialog
 import com.tari.android.wallet.ui.extension.*
@@ -173,23 +168,31 @@ framework for UI tree rebuild on configuration changes"""
         val passwordTextFieldListener = View.OnFocusChangeListener { _, _ ->
             // password
             if (!ui.enterPasswordEditText.hasFocus()
-                && !passwordIsLongEnough()) {
+                && !passwordIsLongEnough()
+            ) {
                 setPasswordTooShortErrorState()
             } else {
                 setPlainInputState(
                     ui.passwordTooShortLabelView,
-                    ui.enterPasswordEditText
+                    listOf(
+                        ui.enterPasswordEditText,
+                        ui.enterPasswordLabelTextView
+                    )
                 )
             }
             // confirm
             if (!ui.confirmPasswordEditText.hasFocus()
                 && passwordIsLongEnough()
-                && !doPasswordsMatch()) {
+                && !doPasswordsMatch()
+            ) {
                 setPasswordMatchErrorState()
             } else {
                 setPlainInputState(
                     ui.passwordsNotMatchLabelView,
-                    ui.confirmPasswordEditText
+                    listOf(
+                        ui.confirmPasswordEditText,
+                        ui.confirmPasswordLabelTextView
+                    )
                 )
             }
         }
@@ -210,18 +213,22 @@ framework for UI tree rebuild on configuration changes"""
         val passwordIsLongEnough = passwordIsLongEnough()
         val passwordsMatch = doPasswordsMatch()
         if (passwordsMatch || trigger.isNullOrEmpty()) {
-            val enabled = areTextFieldsFilled() && passwordIsLongEnough && passwordsMatch
-            setVerifyButtonState(
-                isEnabled = enabled
-            )
-            if (enabled) {
+            val canChangePassword = areTextFieldsFilled() && passwordIsLongEnough && passwordsMatch
+            setVerifyButtonState(isEnabled = canChangePassword)
+            if (canChangePassword) {
                 setPlainInputState(
                     ui.passwordTooShortLabelView,
-                    ui.enterPasswordEditText
+                    listOf(
+                        ui.enterPasswordEditText,
+                        ui.enterPasswordLabelTextView
+                    )
                 )
                 setPlainInputState(
                     ui.passwordsNotMatchLabelView,
-                    ui.confirmPasswordEditText
+                    listOf(
+                        ui.confirmPasswordEditText,
+                        ui.confirmPasswordLabelTextView
+                    )
                 )
             }
         } else if (errorCondition) {
@@ -238,18 +245,20 @@ framework for UI tree rebuild on configuration changes"""
     private fun doPasswordsMatch() =
         ui.confirmPasswordEditText.text?.toString() == ui.enterPasswordEditText.text?.toString()
 
-    private fun setPlainInputState(textView: TextView, editText: EditText) {
-        textView.gone()
-        editText.setTextColor(color(black))
+    private fun setPlainInputState(errorLabel: TextView, inputTextViews: Iterable<TextView>) {
+        errorLabel.gone()
+        inputTextViews.forEach { it.setTextColor(color(black)) }
     }
 
     private fun setPasswordTooShortErrorState() {
         ui.passwordTooShortLabelView.visible()
+        ui.enterPasswordLabelTextView.setTextColor(color(common_error))
         ui.enterPasswordEditText.setTextColor(color(common_error))
     }
 
     private fun setPasswordMatchErrorState() {
         ui.passwordsNotMatchLabelView.visible()
+        ui.confirmPasswordLabelTextView.setTextColor(color(common_error))
         ui.confirmPasswordEditText.setTextColor(color(common_error))
     }
 

--- a/app/src/main/res/layout/fragment_change_secure_password.xml
+++ b/app/src/main/res/layout/fragment_change_secure_password.xml
@@ -90,6 +90,7 @@
                     tools:text="@string/change_password_page_description_general_part" />
 
                 <com.tari.android.wallet.ui.component.CustomFontTextView
+                    android:id="@+id/enter_password_label_text_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="25dp"
@@ -133,6 +134,7 @@
                 </RelativeLayout>
 
                 <com.tari.android.wallet.ui.component.CustomFontTextView
+                    android:id="@+id/confirm_password_label_text_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="25dp"

--- a/app/src/main/res/layout/fragment_enter_restore_password.xml
+++ b/app/src/main/res/layout/fragment_enter_restore_password.xml
@@ -135,7 +135,7 @@
             android:layout_marginHorizontal="25dp"
             android:layout_marginTop="15dp"
             android:layout_marginBottom="15dp"
-            android:background="@drawable/gradient_button_bg"
+            android:background="@drawable/disableable_gradient_button_bg"
             tools:ignore="UselessParent">
 
             <com.tari.android.wallet.ui.component.CustomFontTextView
@@ -161,4 +161,3 @@
     </FrameLayout>
 
 </LinearLayout>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,7 +344,7 @@
     <string name="restore_with_cloud_page_title">Enter your backup password</string>
 
     <!--Change password-->
-    <string name="change_password_enter_password_label">Enter Password</string>
+    <string name="change_password_enter_password_label">Create Password</string>
     <string name="change_password_enter_password_hint">Make it a strong one!</string>
     <string name="change_password_confirm_password_label">Confirm Password</string>
     <string name="change_password_confirm_password_hint">Let’s see it again</string>

--- a/app/src/regular/res/values/strings.xml
+++ b/app/src/regular/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="back_up_wallet_set_backup_password_cta">Secure your Google Drive backup</string>
     <string name="back_up_wallet_restore">Restore with Google Drive</string>
     <!-- Backup password entry -->
-    <string name="change_password_page_title">Secure your Google Drive backup</string>
+    <string name="change_password_page_title">Password-protect your backups</string>
     <string name="change_password_page_description_general_part">Ensure your wallet is safe even if your Google Drive is compromised. Select a password you will remember or</string>
     <string name="change_password_page_description_highlight_part">you will not be able to recover your wallet</string>
     <!-- Enter existing password -->


### PR DESCRIPTION
Change strings for the backup settings entries

Disable restore wallet and verify current password buttons if input field is empty

Revert restore CTA disabling on empty text field as backup might not have a password

Make text labels denoting input fields on the ChangeSecurePasswordFragment red in case of error as well