### PR TITLE
CI Release Workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,127 @@
+name: Aurora Android Release Workflow
+on:
+  create:
+    tags:
+      - v*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-sign-generate-artifacts:
+    name: Build & Sign Bundles, Generate Artifacts & Upload
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Tag Name
+      uses: olegtarasov/get-tag@v2
+      id: tagName
+      with:
+        tagRegex: "v(.*)"
+        tagRegexGroup: 1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Install NDK
+      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.1.5948944" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: Create .properties Files # create local.properties, secret.properties and sentry.properties
+      env:
+        SENTRY_PROPERTIES: ${{ secrets.SENTRY_PROPERTIES }}
+        SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
+      run: |
+        rm -f local.properties
+        rm -f sentry.properties
+        rm -f secret.properties
+        touch local.properties
+        echo 'sdk.dir=/usr/local/lib/android/sdk' >> local.properties
+        echo 'ndk.dir=/usr/local/lib/android/sdk/ndk/20.1.5948944' >> local.properties
+        touch sentry.properties
+        echo "$SENTRY_PROPERTIES" >> sentry.properties
+        touch secret.properties
+        echo "$SECRET_PROPERTIES" >> secret.properties
+        echo ".properties files created."
+    - name: Build APKs and AAB
+      run: |
+        ./gradlew assemblePrivacyRelease 
+        ./gradlew assembleRegularRelease
+        ./gradlew bundleRegularRelease
+    - name: Sign Privacy APK
+      uses: r0adkll/sign-android-release@v1
+      with:
+        releaseDirectory: app/build/outputs/apk/privacy/release
+        signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+        alias: ${{ secrets.ALIAS }}
+        keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+        keyPassword: ${{ secrets.KEY_PASSWORD }}
+    - name: Sign Regular APK
+      uses: r0adkll/sign-android-release@v1
+      with:
+        releaseDirectory: app/build/outputs/apk/regular/release
+        signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+        alias: ${{ secrets.ALIAS }}
+        keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+        keyPassword: ${{ secrets.KEY_PASSWORD }}
+    - name: Sign Regular AAB
+      uses: r0adkll/sign-android-release@v1
+      with:
+        releaseDirectory: app/build/outputs/bundle/regularRelease/
+        signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+        alias: ${{ secrets.ALIAS }}
+        keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+        keyPassword: ${{ secrets.KEY_PASSWORD }}
+    - name: Rename Bundles
+      run: |
+        mv app/build/outputs/apk/privacy/release/app-privacy-release-unsigned.apk app/build/outputs/apk/privacy/release/Tari-Aurora-$GIT_TAG_NAME-Private.apk
+        mv app/build/outputs/apk/regular/release/app-regular-release-unsigned.apk app/build/outputs/apk/regular/release/Tari-Aurora-$GIT_TAG_NAME-Regular.apk
+        mv app/build/outputs/bundle/regularRelease/app-regular-release.aab app/build/outputs/bundle/regularRelease/Tari-Aurora-$GIT_TAG_NAME-Regular.aab
+    - name: Create Changelog
+      id: changelog
+      uses: metcalfc/changelog-generator@v0.4.1
+      with:
+        myToken: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create GitHub Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: v${{ steps.tagName.outputs.tag }}
+        body: ${{ steps.changelog.outputs.changelog }}
+        draft: false
+        prerelease: false
+    - name: Upload Privacy APK to the GitHub Release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: app/build/outputs/apk/privacy/release/Tari-Aurora-${{ steps.tagName.outputs.tag }}-Private.apk
+        asset_name: Tari-Aurora-${{ steps.tagName.outputs.tag }}-Private.apk
+        asset_content_type: application/vnd.android.package-archive
+    - name: Upload Regular APK to the GitHub Release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: app/build/outputs/apk/regular/release/Tari-Aurora-${{ steps.tagName.outputs.tag }}-Regular.apk
+        asset_name: Tari-Aurora-${{ steps.tagName.outputs.tag }}-Regular.apk
+        asset_content_type: application/vnd.android.package-archive
+    - name: Upload Regular AAB to Play Console
+      uses: r0adkll/upload-google-play@v1
+      with:
+        serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+        packageName: com.tari.android.wallet
+        releaseFile: app/build/outputs/bundle/regularRelease/Tari-Aurora-${{ steps.tagName.outputs.tag }}-Regular.aab
+        track: beta
+        whatsNewDirectory: distribution/
+    - name: Upload APKs to Browserstack
+      env:
+        BROWSERSTACK_SECRET: ${{ secrets.BROWSERSTACK_SECRET }}
+      run: |
+        curl -u "$BROWSERSTACK_SECRET" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@app/build/outputs/apk/regular/release/Tari-Aurora-$GIT_TAG_NAME-Regular.apk"
+        curl -u "$BROWSERSTACK_SECRET" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@app/build/outputs/apk/privacy/release/Tari-Aurora-$GIT_TAG_NAME-Private.apk"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     // kotlin extensions
-    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'androidx.core:core-ktx:1.3.1'
     // android
     implementation 'androidx.appcompat:appcompat:1.1.0'
     // support lib
@@ -204,7 +204,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
 
     // Google services & Google drive
-    regularImplementation 'com.google.android.gms:play-services-auth:18.0.0'
+    regularImplementation 'com.google.android.gms:play-services-auth:18.1.0'
     regularImplementation 'com.google.http-client:google-http-client-gson:1.35.0'
     regularImplementation('com.google.api-client:google-api-client-android:1.30.9') {
         exclude group: 'org.apache.httpcomponents'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
 
     // build & version
-    ext.buildNumber = 123
+    ext.buildNumber = 125
     ext.versionNumber = "0.3.0"
 
     // JNI libs
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.sentry:sentry-android-gradle-plugin:1.7.34"
     }

--- a/distribution/whatsnew-en-US
+++ b/distribution/whatsnew-en-US
@@ -1,0 +1,9 @@
+Girl, your tXTR look good (won’t you back that app up)
+You’se a big fine wallet (won’t you back that app up)
+We’ve launched automated backups after each transaction
+and password-encrypted backups (won’t you back that app up)
+
+Also:
+- Automatic prompts to back up your wallet triggered by your balance and transaction history
+- Report a bug via Settings screen
+- Base node syncing stability improvements


### PR DESCRIPTION
Adds the GitHub Actions workflow that builds bundles, signs them, creates the GitHub release, uploads APKs to browserstack and created a new Play Store beta release. Updates build number, adds release notes for v0.3.0. Some library updates. Distributes APK/AAB files per #368.