### PR TITLE
Fix regression: display contact name for a cancelled tx with a contact.

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
@@ -375,6 +375,7 @@ internal class WalletService : Service(), FFIWalletListenerAdapter, LifecycleObs
 
     override fun onTxCancelled(cancelledTx: CancelledTx) {
         Logger.d("Tx cancelled: $cancelledTx")
+        cancelledTx.user = getUserByPublicKey(cancelledTx.user.publicKey)
         // post event to bus
         EventBus.post(Event.Wallet.TxCancelled(cancelledTx))
         // notify external listeners

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
 
     // build & version
-    ext.buildNumber = 127
+    ext.buildNumber = 128
     ext.versionNumber = "0.3.0"
 
     // JNI libs


### PR DESCRIPTION
Fixes a regression where a cancelled transaction with a contact did not display contact's name but just the emoji id.