### PR TITLE
FFI 0.16.2 update & fixed Tor port 

### DIFF
--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -235,6 +235,8 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniCreate(
         jobject jThis,
         jobject jpWalletConfig,
         jstring jLogPath,
+        jint maxNumberOfRollingLogFiles,
+        jint rollingLogFileMaxSizeBytes,
         jstring callback_received_tx,
         jstring callback_received_tx_sig,
         jstring callback_received_tx_reply,
@@ -402,6 +404,8 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniCreate(
         pWallet = wallet_create(
                 pWalletConfig,
                 nullptr,
+                static_cast<unsigned int>(maxNumberOfRollingLogFiles),
+                static_cast<unsigned int>(rollingLogFileMaxSizeBytes),
                 nullptr,
                 ReceivedCallback,
                 ReplyCallback,
@@ -417,6 +421,8 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniCreate(
         pWallet = wallet_create(
                 pWalletConfig,
                 pLogPath,
+                static_cast<unsigned int>(maxNumberOfRollingLogFiles),
+                static_cast<unsigned int>(rollingLogFileMaxSizeBytes),
                 nullptr,
                 ReceivedCallback,
                 ReplyCallback,

--- a/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
@@ -36,6 +36,7 @@ import android.content.Context
 import com.tari.android.wallet.tor.TorConfig
 import com.tari.android.wallet.tor.TorProxyManager
 import com.tari.android.wallet.tor.TorProxyMonitor
+import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.SharedPrefsWrapper
 import dagger.Module
 import dagger.Provides
@@ -69,12 +70,7 @@ class TorModule {
     @Provides
     @Named(FieldName.torConnectionPort)
     @Singleton
-    internal fun provideConnectionPort(): Int {
-        val socket = ServerSocket(0)
-        val port = socket.localPort
-        socket.close()
-        return port
-    }
+    internal fun provideConnectionPort() = Constants.Wallet.torPort
 
     /**
      * Provides a port for Tor proxy.

--- a/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/WalletModule.kt
@@ -44,8 +44,6 @@ import com.tari.android.wallet.util.SharedPrefsWrapper
 import dagger.Module
 import dagger.Provides
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.*
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -65,8 +63,8 @@ internal class WalletModule {
         const val walletTempDirPath = "wallet_temp_dir_path"
     }
 
-    private val logFilePrefix = "tari_wallet_"
-    private val logFileExtension = ".log"
+    private val logFilePrefix = "tari_aurora"
+    private val logFileExtension = "log"
     private val logFilesDirName = "tari_logs"
 
     /**
@@ -89,6 +87,9 @@ internal class WalletModule {
         val logFilesDir = File(walletFilesDirPath, logFilesDirName)
         if (!logFilesDir.exists()) {
             logFilesDir.mkdir()
+        } else { // delete older log files
+            val files = logFilesDir.listFiles()?.filter { !it.name.contains(logFilePrefix) }
+            files?.forEach { it.delete() }
         }
         return logFilesDir.absolutePath
     }
@@ -100,9 +101,7 @@ internal class WalletModule {
     @Named(FieldName.walletLogFilePath)
     @Singleton
     fun provideWalletLogFilePath(@Named(FieldName.walletLogFilesDirPath) logFilesDirPath: String): String {
-        val timeStamp = SimpleDateFormat("YYYYMMdd", Locale.getDefault()).format(Date()) +
-                "_${System.currentTimeMillis()}"
-        val logFileName = "$logFilePrefix$timeStamp$logFileExtension"
+        val logFileName = "$logFilePrefix.$logFileExtension"
         val logFile = File(logFilesDirPath, logFileName)
         if (!logFile.exists()) {
             logFile.createNewFile()
@@ -136,7 +135,6 @@ internal class WalletModule {
         context: Context,
         @Named(FieldName.walletFilesDirPath) walletFilesDirPath: String,
         @Named(FieldName.walletLogFilePath) walletLogFilePath: String,
-        @Named(FieldName.walletLogFilesDirPath) walletLogsDirPath: String,
         torConfig: TorConfig,
         torProxyManager: TorProxyManager,
         torProxyMonitor: TorProxyMonitor,
@@ -145,7 +143,6 @@ internal class WalletModule {
         context,
         walletFilesDirPath,
         walletLogFilePath,
-        File(walletLogsDirPath),
         torProxyManager,
         torProxyMonitor,
         sharedPrefsWrapper,

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -34,6 +34,7 @@ package com.tari.android.wallet.ffi
 
 import com.orhanobut.logger.Logger
 import com.tari.android.wallet.model.*
+import com.tari.android.wallet.util.Constants
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.math.BigInteger
@@ -62,6 +63,8 @@ internal class FFIWallet(
     private external fun jniCreate(
         commsConfig: FFICommsConfig,
         logPath: String,
+        maxNumberOfRollingLogFiles: Int,
+        rollingLogFileMaxSizeBytes: Int,
         callbackReceivedTx: String,
         callbackReceivedTxSig: String,
         callbackReceivedTxReply: String,
@@ -232,7 +235,10 @@ internal class FFIWallet(
             val error = FFIError()
             Logger.i("Pre jniCreate.")
             jniCreate(
-                commsConfig, logPath,
+                commsConfig,
+                logPath,
+                Constants.Wallet.maxNumberOfRollingLogFiles,
+                Constants.Wallet.rollingLogFileMaxSizeBytes,
                 this::onTxReceived.name, "(J)V",
                 this::onTxReplyReceived.name, "(J)V",
                 this::onTxFinalized.name, "(J)V",

--- a/app/src/main/java/com/tari/android/wallet/infrastructure/BugReportingService.kt
+++ b/app/src/main/java/com/tari/android/wallet/infrastructure/BugReportingService.kt
@@ -54,7 +54,6 @@ internal class BugReportingService(private val sharedPrefsWrapper: SharedPrefsWr
 
     class BugReportFileSizeLimitExceededException: Exception()
 
-    private val numberOfLogsFilesToShare = 2
     private val maxLogZipFileSizeBytes = 25 * 1024 * 1024
 
     fun shareBugReport(context: Context) {
@@ -70,9 +69,8 @@ internal class BugReportingService(private val sharedPrefsWrapper: SharedPrefsWr
         val fileOutStream = FileOutputStream(zipFile)
         // zip!
         val allLogFiles = WalletUtil.getLogFilesFromDirectory(logFilesDirPath)
-        val logFilesToShare = allLogFiles.take(numberOfLogsFilesToShare)
         ZipOutputStream(BufferedOutputStream(fileOutStream)).use { out ->
-            for (file in logFilesToShare) {
+            for (file in allLogFiles) {
                 FileInputStream(file).use { inputStream ->
                     BufferedInputStream(inputStream).use { origin ->
                         val entry = ZipEntry(file.name)

--- a/app/src/main/java/com/tari/android/wallet/util/Constants.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/Constants.kt
@@ -134,6 +134,9 @@ internal object Constants {
      */
     object Wallet {
         val network = Network.TESTNET_1
+        const val torPort = 18101
+        const val maxNumberOfRollingLogFiles = 2
+        const val rollingLogFileMaxSizeBytes = 10 * 1024 * 1024
         const val discoveryTimeoutSec = 20L
         const val emojiIdLength = 33
         const val emojiFormatterChunkSize = 3

--- a/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
@@ -99,10 +99,17 @@ internal object WalletUtil {
 
     fun getLogFilesFromDirectory(dirPath: String): List<File> {
         val root = File(dirPath)
-        val files: MutableList<File>? = root.listFiles()?.toMutableList()
-        val filteredFile = files?.filter { it.extension == "log" }?.toMutableList()
-        filteredFile?.sortByDescending { it.lastModified() }
-        return filteredFile ?: Collections.emptyList()
+        if (!root.isDirectory) return Collections.emptyList()
+        val files = root.listFiles()!!.toMutableList()
+        val filteredFiles = files.filter { it.extension == "log" }.toMutableList()
+        filteredFiles.sortBy { it.name }
+        // actual log file will be at the end of the sorted list due to the log file rolling
+        // naming convention, move it to the top
+        if (filteredFiles.size > 1) {
+            val currentLogFile = filteredFiles.removeAt(filteredFiles.size - 1)
+            filteredFiles.add(0, currentLogFile)
+        }
+        return filteredFiles
     }
 
     fun walletExists(applicationContext: Context): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,7 +275,7 @@
     <!-- logs -->
     <string name="debug_log_files_title">Logs</string>
     <string name="debug_log_share_dialog_title">Share</string>
-    <string name="debug_log_share_dialog_content">Please confirm to compress and e-mail your last two FFI log files.</string>
+    <string name="debug_log_share_dialog_content">Please confirm to compress and e-mail your wallet log files.</string>
     <string name="debug_log_file_size_limit_exceeded_dialog_title">File Size Error</string>
     <string name="debug_log_file_size_limit_exceeded_dialog_content">Cannot send: zipped file is over 25MB.</string>
     <!-- base node config -->

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ buildscript {
     ext.kotlin_version = '1.3.72'
 
     // build & version
-    ext.buildNumber = 133
-    ext.versionNumber = "0.4.0"
+    ext.buildNumber = 134
+    ext.versionNumber = "0.4.1"
 
     // JNI libs
-    ext.jniLibsVersion = "0.16.0"
+    ext.jniLibsVersion = "0.16.2"
     ext.jniLibsHostURL = "https://tari-binaries.s3.amazonaws.com/libwallet/"
     ext.supportedABIs = ["arm64-v8a", "armeabi-v7a", "x86_64"]
 


### PR DESCRIPTION
Updates to FFI lib `0.16.1`, which introduces rolling log files. Fixes Tor port to `18101`. Bump build and version numbers.