### PR TITLE
SSL Dependency

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -8,6 +8,29 @@ cmake_minimum_required(VERSION 3.4.1)
 set(libs_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../libwallet)
 
 add_library(
+        ssl_crypto
+        STATIC
+        IMPORTED
+)
+set_target_properties(
+        ssl_crypto
+        PROPERTIES
+        IMPORTED_LOCATION ${libs_DIR}/${ANDROID_ABI}/libcrypto.a
+)
+
+add_library(
+        ssl
+        STATIC
+        IMPORTED
+)
+set_target_properties(
+        ssl
+        PROPERTIES
+        IMPORTED_LOCATION ${libs_DIR}/${ANDROID_ABI}/libssl.a
+        IMPORTED_LINK_INTERFACE_LIBRARIES "ssl_crypto"
+)
+
+add_library(
         sqlite3
         STATIC
         IMPORTED
@@ -27,7 +50,7 @@ set_target_properties(
         wallet
         PROPERTIES
         IMPORTED_LOCATION ${libs_DIR}/${ANDROID_ABI}/libtari_wallet_ffi.a
-        IMPORTED_LINK_INTERFACE_LIBRARIES "sqlite3"
+        IMPORTED_LINK_INTERFACE_LIBRARIES "ssl;sqlite3"
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
Updates cmake to include OpenSSL libraries to be compatible with the latest wallet library.

Linked to PR https://github.com/tari-project/tari/pull/2461