### PR TITLE
Wallet Library - Estimate tx fee

### DIFF
--- a/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
@@ -53,6 +53,8 @@ interface TariWalletService {
 
     BalanceInfo getBalanceInfo(out WalletError error);
 
+    MicroTari estimateTxFee(in MicroTari amount, in MicroTari gramFee, in byte[] kernels, in byte[] outputs, out WalletError error);
+
     List<Contact> getContacts(out WalletError error);
 
     List<User> getRecentTxUsers(int maxCount, out WalletError error);

--- a/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
@@ -53,7 +53,7 @@ interface TariWalletService {
 
     BalanceInfo getBalanceInfo(out WalletError error);
 
-    MicroTari estimateTxFee(in MicroTari amount, in MicroTari gramFee, in byte[] kernels, in byte[] outputs, out WalletError error);
+    MicroTari estimateTxFee(in MicroTari amount, out WalletError error);
 
     List<Contact> getContacts(out WalletError error);
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.2)
 
 set(libs_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../libwallet)
 

--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -940,6 +940,45 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniSendTx(
 
 extern "C"
 JNIEXPORT jbyteArray JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniEstimateTxFee(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jstring jamount,
+        jstring jgramFee,
+        jstring jkernelCount,
+        jstring joutputCount,
+        jobject error) {
+    int i = 0;
+    int *r = &i;
+    jlong lWallet = GetPointerField(jEnv, jThis);
+    auto *pWallet = reinterpret_cast<TariWallet *>(lWallet);
+    const char *nativeAmount = jEnv->GetStringUTFChars(jamount, JNI_FALSE);
+    const char *nativeGramFee = jEnv->GetStringUTFChars(jgramFee, JNI_FALSE);
+    const char *nativeKernels = jEnv->GetStringUTFChars(jkernelCount, JNI_FALSE);
+    const char *nativeOutputs = jEnv->GetStringUTFChars(joutputCount, JNI_FALSE);
+    char *pAmountEnd;
+    char *pGramFeeEnd;
+    char *pKernelsEnd;
+    char *pOutputsEnd;
+
+    unsigned long long amount = strtoull(nativeAmount, &pAmountEnd, 10);
+    unsigned long long gramFee = strtoull(nativeGramFee, &pGramFeeEnd, 10);
+    unsigned long long kernels = strtoull(nativeKernels, &pKernelsEnd, 10);
+    unsigned long long outputs = strtoull(nativeOutputs, &pOutputsEnd, 10);
+
+    jbyteArray result = getBytesFromUnsignedLongLong(
+            jEnv,
+            wallet_get_fee_estimate(pWallet, amount, gramFee, kernels, outputs, r));
+    setErrorCode(jEnv, error, i);
+    jEnv->ReleaseStringUTFChars(jamount, nativeAmount);
+    jEnv->ReleaseStringUTFChars(jgramFee, nativeGramFee);
+    jEnv->ReleaseStringUTFChars(jkernelCount, nativeKernels);
+    jEnv->ReleaseStringUTFChars(joutputCount, nativeOutputs);
+    return result;
+}
+
+extern "C"
+JNIEXPORT jbyteArray JNICALL
 Java_com_tari_android_wallet_ffi_FFIWallet_jniCoinSplit(
         JNIEnv *jEnv,
         jobject jThis,

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -611,6 +611,33 @@ internal class FFIWallet(
         else -> TxStatus.UNKNOWN
     }
 
+    private external fun jniEstimateTxFee(
+        amount: String,
+        gramFee: String,
+        kernelCount: String,
+        outputCount: String,
+        libError: FFIError
+    ): ByteArray
+
+    fun estimateTxFee(
+        amount: BigInteger,
+        gramFee: BigInteger,
+        kernelCount: BigInteger,
+        outputCount: BigInteger
+    ): BigInteger {
+        val error = FFIError()
+        val bytes = jniEstimateTxFee(
+            amount.toString(),
+            gramFee.toString(),
+            kernelCount.toString(),
+            outputCount.toString(),
+            error
+        )
+        Logger.d("Send status code (0 means ok): %d", error.code)
+        throwIf(error)
+        return BigInteger(1, bytes)
+    }
+
     fun sendTx(
         destination: FFIPublicKey,
         amount: BigInteger,

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -633,7 +633,7 @@ internal class FFIWallet(
             outputCount.toString(),
             error
         )
-        Logger.d("Send status code (0 means ok): %d", error.code)
+        Logger.d("Tx fee estimate status code (0 means ok): %d", error.code)
         throwIf(error)
         return BigInteger(1, bytes)
     }

--- a/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
@@ -647,18 +647,18 @@ internal class WalletService : Service(), FFIWalletListener, LifecycleObserver {
 
         override fun estimateTxFee(
             amount: MicroTari,
-            gramFee: MicroTari,
-            kernels: ByteArray,
-            outputs: ByteArray,
             error: WalletError
         ): MicroTari? {
+            val defaultGramFee = BigInteger("100")
+            val defaultKernelCount = BigInteger("1")
+            val defaultOutputCount = BigInteger("2")
             return try {
                 MicroTari(
                     wallet.estimateTxFee(
                         amount.value,
-                        gramFee.value,
-                        kernelCount = BigInteger(1, kernels),
-                        outputCount = BigInteger(1, outputs)
+                        defaultGramFee,
+                        defaultKernelCount,
+                        defaultOutputCount
                     )
                 )
             } catch (throwable: Throwable) {

--- a/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/WalletService.kt
@@ -72,7 +72,6 @@ import kotlinx.coroutines.launch
 import org.joda.time.DateTime
 import org.joda.time.Hours
 import org.joda.time.Minutes
-import java.lang.RuntimeException
 import java.math.BigInteger
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -639,6 +638,28 @@ internal class WalletService : Service(), FFIWalletListener, LifecycleObserver {
                     MicroTari(wallet.getAvailableBalance()),
                     MicroTari(wallet.getPendingInboundBalance()),
                     MicroTari(wallet.getPendingOutboundBalance())
+                )
+            } catch (throwable: Throwable) {
+                mapThrowableIntoError(throwable, error)
+                null
+            }
+        }
+
+        override fun estimateTxFee(
+            amount: MicroTari,
+            gramFee: MicroTari,
+            kernels: ByteArray,
+            outputs: ByteArray,
+            error: WalletError
+        ): MicroTari? {
+            return try {
+                MicroTari(
+                    wallet.estimateTxFee(
+                        amount.value,
+                        gramFee.value,
+                        kernelCount = BigInteger(1, kernels),
+                        outputCount = BigInteger(1, outputs)
+                    )
                 )
             } catch (throwable: Throwable) {
                 mapThrowableIntoError(throwable, error)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
@@ -928,17 +928,9 @@ class AddAmountFragment : Fragment(), ServiceConnection {
     }
 
     private fun continueToNote() {
-        val gramstringbuilder = StringBuilder()
-        gramstringbuilder.append(100)
-        val gramFee = MicroTari(BigInteger(gramstringbuilder.toString()))
-        val kernels = BigInteger("1")
-        val outputs = BigInteger("1")
         val error = WalletError()
         val fee = walletService.estimateTxFee(
             currentAmount,
-            gramFee,
-            kernels.toByteArray(),
-            outputs.toByteArray(),
             error
         )
         if (error.code != WalletErrorCode.NO_ERROR) {
@@ -976,16 +968,8 @@ class AddAmountFragment : Fragment(), ServiceConnection {
                 TODO("Unhandled wallet error: ${error.code}")
             }
             // update fee
-            val gramStringBuilder = StringBuilder()
-            gramStringBuilder.append(100)
-            val gramFee = MicroTari(BigInteger(gramStringBuilder.toString()))
-            val kernels = BigInteger("1")
-            val outputs = BigInteger("1")
             val fee = walletService.estimateTxFee(
                 currentAmount,
-                gramFee,
-                kernels.toByteArray(),
-                outputs.toByteArray(),
                 error
             )
             if (error.code != WalletErrorCode.NO_ERROR

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/AddAmountFragment.kt
@@ -690,7 +690,10 @@ class AddAmountFragment : Fragment(), ServiceConnection {
             (currentFirstElementMarginStart * scaleFactor).toInt()
 
         // adjust gem size
-        ui.amountGemImageView.setLayoutSize(currentAmountGemSize.toInt(), currentAmountGemSize.toInt())
+        ui.amountGemImageView.setLayoutSize(
+            currentAmountGemSize.toInt(),
+            currentAmountGemSize.toInt()
+        )
         // adjust first element margin
         elements[0].second.setStartMargin(currentFirstElementMarginStart)
         // set center correction view width
@@ -841,7 +844,10 @@ class AddAmountFragment : Fragment(), ServiceConnection {
         }
 
         // adjust gem size
-        ui.amountGemImageView.setLayoutSize(currentAmountGemSize.toInt(), currentAmountGemSize.toInt())
+        ui.amountGemImageView.setLayoutSize(
+            currentAmountGemSize.toInt(),
+            currentAmountGemSize.toInt()
+        )
         // adjust first element margin
         elements[0].second.setStartMargin(
             currentFirstElementMarginStart
@@ -922,7 +928,22 @@ class AddAmountFragment : Fragment(), ServiceConnection {
     }
 
     private fun continueToNote() {
-        val fee = WalletUtil.calculateTxFee()
+        val gramstringbuilder = StringBuilder()
+        gramstringbuilder.append(100)
+        val gramFee = MicroTari(BigInteger(gramstringbuilder.toString()))
+        val kernels = BigInteger("1")
+        val outputs = BigInteger("1")
+        val error = WalletError()
+        val fee = walletService.estimateTxFee(
+            currentAmount,
+            gramFee,
+            kernels.toByteArray(),
+            outputs.toByteArray(),
+            error
+        )
+        if (error.code != WalletErrorCode.NO_ERROR) {
+            TODO("Unhandled wallet error: ${error.code}")
+        }
         listenerWR.get()?.continueToAddNote(
             this,
             recipientUser,
@@ -955,12 +976,26 @@ class AddAmountFragment : Fragment(), ServiceConnection {
                 TODO("Unhandled wallet error: ${error.code}")
             }
             // update fee
-            val fee = WalletUtil.calculateTxFee()
+            val gramstringbuilder = StringBuilder()
+            gramstringbuilder.append(100)
+            val gramFee = MicroTari(BigInteger(gramstringbuilder.toString()))
+            val kernels = BigInteger("1")
+            val outputs = BigInteger("1")
+            val fee = walletService.estimateTxFee(
+                currentAmount,
+                gramFee,
+                kernels.toByteArray(),
+                outputs.toByteArray(),
+                error
+            )
+            if (error.code != WalletErrorCode.NO_ERROR) {
+                TODO("Unhandled wallet error: ${error.code}")
+            }
             ui.txFeeTextView.text = "+${WalletUtil.feeFormatter.format(fee.tariValue)}"
             // check balance
             val availableBalance =
                 balanceInfo.availableBalance + balanceInfo.pendingIncomingBalance
-            if ((currentAmount + WalletUtil.calculateTxFee()) > availableBalance) {
+            if ((currentAmount + fee) > availableBalance) {
                 ui.availableBalanceTextView.text =
                     WalletUtil.amountFormatter.format(availableBalance.tariValue)
                 displayAvailableBalanceError()

--- a/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/WalletUtil.kt
@@ -57,20 +57,6 @@ internal object WalletUtil {
     }
 
     /**
-     * Calculates transaction fee.
-     * See https://github.com/tari-project/tari/issues/1058.
-     */
-    fun calculateTxFee(
-        baseCost: Int = 500,
-        numInputs: Int = 1,
-        numOutputs: Int = 2,
-        r: Int = 250
-    ): MicroTari {
-        val fee = baseCost + (numInputs + 4 * numOutputs) * r
-        return fee.toMicroTari()
-    }
-
-    /**
      * Utility function to clear all previous wallet files.
      */
     fun clearWalletFiles(path: String): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.versionNumber = "0.5.3"
 
     // JNI libs
-    ext.libwalletVersion = "0.16.13"
+    ext.libwalletVersion = "0.16.14"
     ext.libwalletHostURL = "https://tari-binaries.s3.amazonaws.com/libwallet/"
     ext.supportedABIs = ["arm64-v8a", "armeabi-v7a", "x86_64"]
 


### PR DESCRIPTION
Added estimateTxFee to FFIWallet.
Added jniEstimateTxFee to FFIWallet private method linking to JNI.
Added jniEstimateTxFee to jniWallet.cpp.
Removed `walletutil.calculatetxfee`.
Added `walletservice.estimatetxfee`.
Updated AIDL.
Updated calculatetxfee with estimatetxfee where applicable.
Updated cmake minimum version.

Linked to PR:
Linked to PR: https://github.com/tari-project/tari/pull/2526