### PR TITLE
Added confirmation settings

### DIFF
--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -1246,4 +1246,41 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniRemoveKeyValue(
     return result;
 }
 
+extern "C"
+JNIEXPORT jbyteArray JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniGetConfirmations(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jobject error) {
+    int i = 0;
+    int *r = &i;
+    jlong lWallet = GetPointerField(jEnv, jThis);
+    auto *pWallet = reinterpret_cast<TariWallet *>(lWallet);
+    jbyteArray result = getBytesFromUnsignedLongLong(
+            jEnv,
+            wallet_get_num_confirmations_required(pWallet, r)
+            );
+    setErrorCode(jEnv, error, i);
+    return result;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniSetConfirmations(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jstring jNumber,
+        jobject error) {
+    int i = 0;
+    int *r = &i;
+    jlong lWallet = GetPointerField(jEnv, jThis);
+    auto *pWallet = reinterpret_cast<TariWallet *>(lWallet);
+    const char *nativeString = jEnv->GetStringUTFChars(jNumber, JNI_FALSE);
+    char *pEnd;
+    unsigned long long number = strtoull(nativeString, &pEnd, 10);
+    wallet_set_num_confirmations_required(pWallet, number, r);
+    jEnv->ReleaseStringUTFChars(jNumber, nativeString);
+    setErrorCode(jEnv, error, i);
+}
+
 //endregion

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -240,6 +240,15 @@ internal class FFIWallet(
         libError: FFIError
     ): Boolean
 
+    private external fun jniGetConfirmations(
+        libError: FFIError
+    ): ByteArray
+
+    private external fun jniSetConfirmations(
+        number: String,
+        libError: FFIError
+    )
+
     private external fun jniDestroy()
 
     // endregion
@@ -799,6 +808,24 @@ internal class FFIWallet(
 
     fun logMessage(message: String) {
         jniLogMessage(message)
+    }
+
+    fun getConfirmations(): BigInteger {
+        val error = FFIError()
+        val bytes = jniGetConfirmations(
+            error
+        )
+        throwIf(error)
+        return BigInteger(1, bytes)
+    }
+
+    fun setConfirmations(number: BigInteger) {
+        val error = FFIError()
+        val bytes = jniSetConfirmations(
+            number.toString(),
+            error
+        )
+        throwIf(error)
     }
 
     override fun destroy() {


### PR DESCRIPTION
Added jniMethods to get and set the number of required confirmations for the wallet.
Added methods to the wallet class to expose this functionality to Kotlin from the JNI.

Linked to PR:
https://github.com/tari-project/tari/pull/2624/