### PR TITLE
Library updates and build fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ import java.nio.file.Paths
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: "../download-libwallet.gradle"
 // PRIVATE BUILD: comment (add two slashes at the start) the following line for private release
@@ -12,7 +11,7 @@ apply plugin: 'io.sentry.android.gradle'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
         applicationId "com.tari.android.wallet"
@@ -103,8 +102,8 @@ android {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 
     packagingOptions {
@@ -147,7 +146,7 @@ preBuild.dependsOn("downloadLibwallet")
 
 repositories {
     maven {
-        url "http://giphy.bintray.com/giphy-sdk"
+        url "https://giphy.bintray.com/giphy-sdk"
     }
 }
 
@@ -161,10 +160,10 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
-    implementation 'androidx.fragment:fragment-ktx:1.3.5'
+    implementation 'androidx.fragment:fragment-ktx:1.3.6'
 
     // kotlin extensions
-    implementation 'androidx.core:core-ktx:1.5.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
     // android
     implementation 'androidx.appcompat:appcompat:1.3.0'
     // support lib
@@ -173,11 +172,11 @@ dependencies {
     // android jetpack
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
     // recycler view
-    implementation "androidx.recyclerview:recyclerview:1.2.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     // the new view pager
     implementation "androidx.viewpager2:viewpager2:1.0.0"
     // for tab layout
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     // flex layout
     implementation 'com.google.android:flexbox:2.0.1'
     // overscroll
@@ -206,8 +205,8 @@ dependencies {
     kapt 'org.parceler:parceler:1.1.13'
 
     // dagger - DI
-    implementation 'com.google.dagger:dagger:2.33'
-    kapt 'com.google.dagger:dagger-compiler:2.33'
+    implementation 'com.google.dagger:dagger:2.38'
+    kapt 'com.google.dagger:dagger-compiler:2.38'
 
     // rx
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
@@ -250,13 +249,13 @@ dependencies {
     // matomo - tracking
     regularImplementation 'org.matomo.sdk:tracker:4.1.2'
     // sentry - crash analytics
-    regularImplementation 'io.sentry:sentry-android:4.3.0'
+    regularImplementation 'io.sentry:sentry-android:5.0.1'
 
     // test
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.mockk:mockk:1.10.6'
     androidTestImplementation 'io.mockk:mockk-android:1.10.6'
-    androidTestImplementation 'androidx.test:core:1.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/regular/java/com/tari/android/wallet/di/BackupAndRestoreModule.kt
+++ b/app/src/regular/java/com/tari/android/wallet/di/BackupAndRestoreModule.kt
@@ -33,10 +33,10 @@
 package com.tari.android.wallet.di
 
 import android.content.Context
+import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
 import com.tari.android.wallet.infrastructure.backup.*
 import com.tari.android.wallet.infrastructure.backup.GoogleDriveBackupStorage
 import com.tari.android.wallet.notification.NotificationHelper
-import com.tari.android.wallet.util.SharedPrefsWrapper
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -48,7 +48,7 @@ internal class BackupAndRestoreModule {
     @Provides
     @Singleton
     fun provideBackupFileProcessor(
-        sharedPrefs: SharedPrefsWrapper,
+        sharedPrefs: SharedPrefsRepository,
         @Named(WalletModule.FieldName.walletFilesDirPath) walletFilesDirPath: String,
         @Named(WalletModule.FieldName.walletDatabaseFilePath) walletDatabaseFilePath: String,
         @Named(WalletModule.FieldName.walletTempDirPath) walletTempDirPath: String
@@ -63,7 +63,7 @@ internal class BackupAndRestoreModule {
     @Singleton
     fun provideBackupStorage(
         context: Context,
-        sharedPrefs: SharedPrefsWrapper,
+        sharedPrefs: SharedPrefsRepository,
         @Named(WalletModule.FieldName.walletTempDirPath) walletTempDirPath: String,
         backupFileProcessor: BackupFileProcessor
     ): BackupStorage = GoogleDriveBackupStorage(
@@ -77,7 +77,7 @@ internal class BackupAndRestoreModule {
     @Singleton
     fun provideBackupManager(
         context: Context,
-        sharedPrefs: SharedPrefsWrapper,
+        sharedPrefs: SharedPrefsRepository,
         backupStorage: BackupStorage,
         notificationHelper: NotificationHelper
     ): BackupManager = BackupManager(context, sharedPrefs, backupStorage, notificationHelper)

--- a/app/src/regular/java/com/tari/android/wallet/infrastructure/backup/GoogleDriveBackupStorage.kt
+++ b/app/src/regular/java/com/tari/android/wallet/infrastructure/backup/GoogleDriveBackupStorage.kt
@@ -52,8 +52,8 @@ import com.google.api.services.drive.DriveScopes
 import com.google.api.services.drive.model.FileList
 import com.orhanobut.logger.Logger
 import com.tari.android.wallet.R
+import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
 import com.tari.android.wallet.extension.getLastPathComponent
-import com.tari.android.wallet.util.SharedPrefsWrapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.joda.time.DateTime
@@ -64,7 +64,7 @@ import kotlin.coroutines.suspendCoroutine
 
 internal class GoogleDriveBackupStorage(
     private val context: Context,
-    private val sharedPrefs: SharedPrefsWrapper,
+    private val sharedPrefs: SharedPrefsRepository,
     private val walletTempDirPath: String,
     private val backupFileProcessor: BackupFileProcessor
 ) : BackupStorage {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext.kotlin_version = '1.5.21'
 
     // build & version
-    ext.buildNumber = 160
-    ext.versionNumber = "0.6.3"
+    ext.buildNumber = 161
+    ext.versionNumber = "0.6.4"
 
     // JNI libs
     ext.libwalletVersion = "0.16.27"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.21'
 
     // build & version
     ext.buildNumber = 160
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.sentry:sentry-android-gradle-plugin:1.7.34"
     }


### PR DESCRIPTION
1. Updated target build tools version up to 30
2. Fixed build warning related to viewBindings. The current way of the declaration was obsolete in the last version
3. Fixed build warning related to unsecured URL to maven
4. Updated UI libraries + dagger + tests + kotlin
5. Updated sentry library because it had an issue with showing a nice error message. It was caused impossible to find a build mistake.
6. Fixed regular flavor build
7. Bumped version number