### PR TITLE
fix: tor crash

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/tor/TorProxyManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/tor/TorProxyManager.kt
@@ -174,7 +174,7 @@ internal class TorProxyManager(
         fun shutdownTor() {
             timerSubscription?.dispose()
             if (this::controlConnection.isInitialized) {
-                controlConnection.shutdownTor("SHUTDOWN")
+                runCatching { controlConnection.shutdownTor("SHUTDOWN") }
             }
         }
 


### PR DESCRIPTION
### Description:

Unexpected behavior on tor client. It's crashed when the connection is closing on android under 8.0. Higher is ok
Just muted IO exception because it's not useful here and consistent with flow logic