### PR TITLE
fix: fixed sentry proguard vs gradle 7.0 problem

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ android {
 //            PRIVATE BUILD: comment (add two slashes at the start of each line) all the `sentry`
 //            block for private release builds support
             sentry { // https://docs.sentry.io/platforms/android/#gradle-configuration
-                autoProguardConfig true
+                autoProguardConfig false
                 autoUpload true
                 uploadNativeSymbols true
                 includeNativeSources true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,10 +60,9 @@ android {
 //            PRIVATE BUILD: comment (add two slashes at the start of each line) all the `sentry`
 //            block for private release builds support
             sentry { // https://docs.sentry.io/platforms/android/#gradle-configuration
-                autoProguardConfig false
-                autoUpload true
-                uploadNativeSymbols true
-                includeNativeSources true
+                autoUpload.set(true)
+                uploadNativeSymbols.set(true)
+                includeNativeSources.set(true)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = "1.6.10"
 
     // build & version
     ext.buildNumber = 185
@@ -21,7 +21,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "io.sentry:sentry-android-gradle-plugin:1.7.34"
+        classpath "io.sentry:sentry-android-gradle-plugin:2.1.5"
     }
 }
 


### PR DESCRIPTION
Description:

Fixed problem with sentry proguard which appears because of last gradle update

https://issueexplorer.com/issue/getsentry/sentry-android-gradle-plugin/70