### PR TITLE
fix: lint new api problems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,10 @@ android {
                          'META-INF/ASL2.0']
         }
     }
+
+    lintOptions {
+        disable("NewApi")
+    }
 }
 
 Properties loadSecretProps() {


### PR DESCRIPTION
Description:

* Disabled lint checking for new api calls because bitrise has an old version of lint with a bug in this case. In fact on 24 and 29 versions all works the same