### PR TITLE
fix: test session fixes

### DIFF
--- a/app/src/androidTest/java/com/tari/android/wallet/FFIWalletTests.kt
+++ b/app/src/androidTest/java/com/tari/android/wallet/FFIWalletTests.kt
@@ -316,5 +316,8 @@ class FFIWalletTests {
 
         override fun onConnectivityStatus(status: Int) {
         }
+
+        override fun onBalanceUpdated(balanceInfo: BalanceInfo) {
+        }
     }
 }

--- a/app/src/main/aidl/com/tari/android/wallet/service/TariWalletServiceListener.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariWalletServiceListener.aidl
@@ -61,6 +61,8 @@ interface TariWalletServiceListener {
 
     oneway void onDirectSendResult(in TxId txId, in TransactionSendStatus status);
 
+    oneway void onBalanceUpdated(in BalanceInfo balanceInfo);
+
     oneway void onBaseNodeSyncComplete(in boolean success);
 
     oneway void onTestnetTariRequestSuccess();

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/SharedPrefsRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/SharedPrefsRepository.kt
@@ -134,7 +134,6 @@ class SharedPrefsRepository(
             val str = String(ByteArray(1) { nextByte }, charset)
             if (str.first() != utfErrorCode) {
                 generatedString += str
-                break
             }
         }
         return generatedString

--- a/app/src/main/java/com/tari/android/wallet/event/Event.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/Event.kt
@@ -49,6 +49,7 @@ object Event {
      * Wallet events.
      */
     object Transaction {
+        object Updated
         data class TxReceived(val tx: PendingInboundTx)
         data class TxReplyReceived(val tx: PendingOutboundTx)
         data class TxFinalized(val tx: PendingInboundTx)

--- a/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
@@ -34,6 +34,7 @@ package com.tari.android.wallet.event
 
 import com.tari.android.wallet.application.WalletState
 import com.tari.android.wallet.infrastructure.backup.BackupState
+import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.model.recovery.WalletRestorationResult
 import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.service.baseNode.BaseNodeState
@@ -53,6 +54,8 @@ object EventBus : GeneralEventBus() {
 
     //todo looks like better to have it into appropriate classes than here
     val torProxyState = BehaviorEventBus<TorProxyState>()
+
+    val balanceState = BehaviorEventBus<BalanceInfo>()
 
     val walletState = BehaviorEventBus<WalletState>()
 

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWalletListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWalletListener.kt
@@ -54,6 +54,7 @@ interface FFIWalletListener {
     fun onTxCancelled(cancelledTx: CancelledTx, rejectionReason: Int)
     fun onTXOValidationComplete(responseId: BigInteger, status: TXOValidationStatus)
     fun onTxValidationComplete(responseId: BigInteger, isSuccess: Boolean)
+    fun onBalanceUpdated(balanceInfo: BalanceInfo)
     fun onConnectivityStatus(status: Int)
     fun onWalletRestoration(result: WalletRestorationResult)
 }

--- a/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
@@ -187,6 +187,12 @@ class FFIWalletListenerImpl(
         }
     }
 
+    override fun onBalanceUpdated(balanceInfo: BalanceInfo) {
+        EventBus.balanceState.post(balanceInfo)
+        // notify external listeners
+        listeners.iterator().forEach { it.onBalanceUpdated(balanceInfo) }
+    }
+
     override fun onConnectivityStatus(status: Int) {
         when (status) {
             1 -> {

--- a/app/src/main/java/com/tari/android/wallet/service/service/WalletService.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/WalletService.kt
@@ -64,8 +64,6 @@ import com.tari.android.wallet.util.WalletUtil
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import org.joda.time.DateTime
 import org.joda.time.Hours
 import org.joda.time.Minutes
@@ -177,8 +175,6 @@ class WalletService : Service() {
         // stop wallet manager on a separate thread & unsubscribe from events
         EventBus.walletState.unsubscribe(this)
         lifecycleObserver?.let { ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
-        GlobalScope.launch { backupManager.turnOff(deleteExistingBackups = false) }
-        Thread(walletManager::stop).start()
     }
 
     private fun deleteWallet() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/InputSeedWordsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/InputSeedWordsFragment.kt
@@ -22,10 +22,12 @@ import com.tari.android.wallet.ui.fragment.restore.inputSeedWords.suggestions.Su
 import com.tari.android.wallet.ui.fragment.restore.inputSeedWords.suggestions.SuggestionsAdapter
 import com.tari.android.wallet.ui.fragment.restore.restore.WalletRestoreRouter
 import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent
+import net.yslibrary.android.keyboardvisibilityevent.Unregistrar
 
 class InputSeedWordsFragment : CommonFragment<FragmentWalletInputSeedWordsBinding, InputSeedWordsViewModel>() {
 
     private val suggestionsAdapter = SuggestionsAdapter()
+    private var keyboardRegistrar: Unregistrar? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         FragmentWalletInputSeedWordsBinding.inflate(inflater, container, false).also { ui = it }.root
@@ -41,6 +43,16 @@ class InputSeedWordsFragment : CommonFragment<FragmentWalletInputSeedWordsBindin
         subscribeUI()
 
         viewModel.getFocusToNextElement(-1)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        keyboardRegistrar?.unregister()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        keyboardRegistrar = KeyboardVisibilityEvent.registerEventListener(requireActivity()) { viewModel.setSuggestionState(it) }
     }
 
     private fun setupUI() = with(ui) {
@@ -64,12 +76,14 @@ class InputSeedWordsFragment : CommonFragment<FragmentWalletInputSeedWordsBindin
         suggestionsAdapter.setClickListener(CommonAdapter.ItemClickListener { viewModel.selectSuggestion(it) })
         suggestions.adapter = suggestionsAdapter
         suggestions.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
-
-        KeyboardVisibilityEvent.setEventListener(requireActivity()) { viewModel.setSuggestionState(it) }
     }
 
     private fun subscribeUI() = with(viewModel) {
-        observeOnLoad(words)
+        observe(words) {
+            if (ui.seedWordsFlexboxLayout.getChildAt(0) == null) {
+                it.forEach { word -> addWord(word) }
+            }
+        }
 
         observe(addedWord) { addWord(it) }
 
@@ -145,6 +159,7 @@ class InputSeedWordsFragment : CommonFragment<FragmentWalletInputSeedWordsBindin
                 updateState(hasFocus, word.isValid())
                 if (hasFocus) viewModel.getFocus(word.index.value!!, true)
             }
+            updateState(false, word.isValid())
             ui.text.setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_NEXT) {
                     viewModel.finishEntering(word.index.value!!, ui.text.text?.toString().orEmpty())

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/activity/SendTariActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/activity/SendTariActivity.kt
@@ -40,6 +40,7 @@ import com.tari.android.wallet.databinding.ActivitySendTariBinding
 import com.tari.android.wallet.di.DiContainer.appComponent
 import com.tari.android.wallet.event.Event
 import com.tari.android.wallet.event.EventBus
+import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.TxId
 import com.tari.android.wallet.model.User
 import com.tari.android.wallet.network.NetworkConnectionState
@@ -114,13 +115,16 @@ class SendTariActivity : CommonActivity<ActivitySendTariBinding, SendTariViewMod
         ui.rootView.postDelayed({ ui.rootView.setBackgroundColor(color(R.color.black)) }, 1000)
     }
 
-    override fun continueToAmount(user: User) {
+    override fun continueToAmount(user: User, amount: MicroTari?) {
         if (EventBus.networkConnectionState.publishSubject.value != NetworkConnectionState.CONNECTED) {
             showInternetConnectionErrorDialog(this)
             return
         }
         hideKeyboard()
-        val bundle = Bundle().apply { putParcelable("recipientUser", user) }
+        val bundle = Bundle().apply {
+            putParcelable(PARAMETER_USER, user)
+            putParcelable(PARAMETER_AMOUNT, amount)
+        }
         ui.rootView.postDelayed({ addFragment(AddAmountFragment(), bundle) }, Constants.UI.keyboardHideWaitMs)
     }
 
@@ -190,6 +194,7 @@ class SendTariActivity : CommonActivity<ActivitySendTariBinding, SendTariViewMod
     companion object {
         const val PARAMETER_NOTE = "note"
         const val PARAMETER_AMOUNT = "amount"
+        const val PARAMETER_USER = "recipientUser"
 
         var instance: WeakReference<SendTariActivity> = WeakReference(null)
             private set

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
@@ -118,9 +118,9 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
     }
 
     private fun setupUI() {
-        val amount = arguments?.getDouble(SendTariActivity.PARAMETER_AMOUNT, Double.MIN_VALUE)
-        keyboardController.setup(requireContext(), AmountCheckRunnable(), ui.numpad, ui.amount, amount)
-        recipientUser = arguments?.getParcelable("recipientUser")
+        val amount = arguments?.getParcelable<MicroTari>(SendTariActivity.PARAMETER_AMOUNT)
+        keyboardController.setup(requireContext(), AmountCheckRunnable(), ui.numpad, ui.amount, amount?.tariValue?.toDouble() ?: Double.MIN_VALUE)
+        recipientUser = arguments?.getParcelable(SendTariActivity.PARAMETER_USER)
         // hide tx fee
         ui.txFeeContainerView.invisible()
         // hide/disable continue button

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientFragment.kt
@@ -132,11 +132,8 @@ class AddRecipientFragment : CommonFragment<FragmentAddRecipientBinding, AddReci
     private val dimmerViews
         get() = arrayOf(ui.middleDimmerView, ui.bottomDimmerView)
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View = FragmentAddRecipientBinding.inflate(inflater, container, false).also { ui = it }.root
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        FragmentAddRecipientBinding.inflate(inflater, container, false).also { ui = it }.root
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -184,7 +181,7 @@ class AddRecipientFragment : CommonFragment<FragmentAddRecipientBinding, AddReci
         val listener = requireActivity() as AddRecipientListener
 
         when (navigation) {
-            is AddRecipientNavigation.ToAmount -> listener.continueToAmount(navigation.user)
+            is AddRecipientNavigation.ToAmount -> listener.continueToAmount(navigation.user, navigation.amount)
         }
     }
 
@@ -215,7 +212,7 @@ class AddRecipientFragment : CommonFragment<FragmentAddRecipientBinding, AddReci
     private fun setupUI() {
         ui.contactsListRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerViewAdapter.setClickListener(CommonAdapter.ItemClickListener {
-            (it as? RecipientViewHolderItem)?.user?.let { user -> (activity as? AddRecipientListener)?.continueToAmount(user) }
+            (it as? RecipientViewHolderItem)?.user?.let { user -> (activity as? AddRecipientListener)?.continueToAmount(user, null) }
         })
         ui.contactsListRecyclerView.adapter = recyclerViewAdapter
         ui.contactsListRecyclerView.addOnScrollListener(scrollListener)
@@ -424,6 +421,7 @@ class AddRecipientFragment : CommonFragment<FragmentAddRecipientBinding, AddReci
                     if (publicKey != null) {
                         ui.rootView.post { ui.searchEditText.setText(publicKey.emojiId, TextView.BufferType.EDITABLE) }
                         ui.searchEditText.postDelayed({ ui.searchEditTextScrollView.smoothScrollTo(0, 0) }, Constants.UI.mediumDurationMs)
+                        it.amount?.let { viewModel.setAmount(it) }
                     }
                 }
             }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientListener.kt
@@ -1,9 +1,10 @@
 package com.tari.android.wallet.ui.fragment.send.addRecepient
 
+import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.User
 
 interface AddRecipientListener {
 
-    fun continueToAmount(user: User)
+    fun continueToAmount(user: User, amount: MicroTari?)
 
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientNavigation.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientNavigation.kt
@@ -1,7 +1,8 @@
 package com.tari.android.wallet.ui.fragment.send.addRecepient
 
+import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.User
 
 sealed class AddRecipientNavigation {
-    class ToAmount(val user: User) : AddRecipientNavigation()
+    class ToAmount(val user: User, val amount: MicroTari?) : AddRecipientNavigation()
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addRecepient/AddRecipientViewModel.kt
@@ -12,10 +12,7 @@ import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
 import com.tari.android.wallet.extension.addTo
 import com.tari.android.wallet.extension.executeWithError
 import com.tari.android.wallet.extension.getWithError
-import com.tari.android.wallet.model.Contact
-import com.tari.android.wallet.model.PublicKey
-import com.tari.android.wallet.model.Tx
-import com.tari.android.wallet.model.User
+import com.tari.android.wallet.model.*
 import com.tari.android.wallet.service.connection.ServiceConnectionStatus
 import com.tari.android.wallet.service.connection.TariWalletServiceConnection
 import com.tari.android.wallet.ui.common.CommonViewModel
@@ -37,6 +34,7 @@ import javax.inject.Inject
 class AddRecipientViewModel : CommonViewModel() {
 
     var emojiIdPublicKey: PublicKey? = null
+    var amountFromDeeplink: MicroTari? = null
 
     private var searchingJob: Job? = null
     private var recentTxUsersLimit = 3
@@ -142,6 +140,10 @@ class AddRecipientViewModel : CommonViewModel() {
         }
     }
 
+    fun setAmount(amount: MicroTari) {
+        amountFromDeeplink = amount
+    }
+
     private fun fetchAllData() {
         walletService.executeWithError { error, wallet ->
             contacts = wallet.getContacts(error).orEmpty().toMutableList()
@@ -158,7 +160,7 @@ class AddRecipientViewModel : CommonViewModel() {
             val yatUserOptional = _foundYatUser.value
             val yatUser = if (yatUserOptional?.isPresent == true) yatUserOptional.get() else null
             val user = yatUser ?: contacts.firstOrNull { it.publicKey == emojiIdPublicKey } ?: User(emojiIdPublicKey!!)
-            _navigation.postValue(AddRecipientNavigation.ToAmount(user))
+            _navigation.postValue(AddRecipientNavigation.ToAmount(user, amountFromDeeplink))
         }
     }
 
@@ -215,8 +217,8 @@ class AddRecipientViewModel : CommonViewModel() {
         return false
     }
 
-    fun getPublicKeyFromHexString(publicKeyHex: String): PublicKey = walletService.getWithError { _, wallet -> wallet.getPublicKeyFromHexString(publicKeyHex) }
+    fun getPublicKeyFromHexString(publicKeyHex: String): PublicKey? = walletService.getWithError { _, wallet -> wallet.getPublicKeyFromHexString(publicKeyHex) }
 
-    fun getPublicKeyFromEmojiId(emojiId: String): PublicKey = walletService.getWithError { _, wallet -> wallet.getPublicKeyFromEmojiId(emojiId) }
+    fun getPublicKeyFromEmojiId(emojiId: String): PublicKey? = walletService.getWithError { _, wallet -> wallet.getPublicKeyFromEmojiId(emojiId) }
 }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
@@ -69,7 +69,6 @@ import com.tari.android.wallet.ui.extension.*
 import com.tari.android.wallet.ui.fragment.tx.details.gif.GIFView
 import com.tari.android.wallet.ui.fragment.tx.details.gif.GIFViewModel
 import com.tari.android.wallet.ui.fragment.tx.details.gif.TxState
-import com.tari.android.wallet.model.TxNote
 import com.tari.android.wallet.util.WalletUtil
 import java.util.*
 
@@ -258,7 +257,8 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
             tx is CancelledTx -> ""
             state == TxState(INBOUND, PENDING) -> string(tx_detail_waiting_for_sender_to_complete)
             state == TxState(OUTBOUND, PENDING) -> string(tx_detail_waiting_for_recipient)
-            state.status != MINED_CONFIRMED -> string(
+            state == TxState(INBOUND, FAUX_UNCONFIRMED) -> ""
+            state.status != MINED_CONFIRMED && state.status != COINBASE -> string(
                 tx_detail_completing_final_processing,
                 if (tx is CompletedTx) tx.confirmationCount.toInt() + 1 else 1,
                 viewModel.requiredConfirmationCount + 1

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
@@ -49,7 +49,7 @@ class TxDetailsViewModel : CommonViewModel() {
     }
 
     fun setTxArg(tx: Tx) {
-        _tx.postValue(tx)
+        _tx.value = tx
         _cancellationReason.postValue(getCancellationReason(tx))
         generateExplorerLink()
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/UtxosListViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/UtxosListViewModel.kt
@@ -3,6 +3,8 @@ package com.tari.android.wallet.ui.fragment.utxos.list
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import com.tari.android.wallet.R
+import com.tari.android.wallet.event.Event
+import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.addTo
 import com.tari.android.wallet.extension.getWithError
 import com.tari.android.wallet.service.TariWalletService
@@ -126,6 +128,7 @@ class UtxosListViewModel : CommonViewModel() {
                 wallet.joinUtxos(selectedUtxos, error)
                 _dismissDialog.postValue(Unit)
                 loadUtxosFromFFI()
+                EventBus.post(Event.Transaction.Updated)
                 showSuccessJoinDialog()
             }
         }
@@ -151,6 +154,7 @@ class UtxosListViewModel : CommonViewModel() {
                             wallet.splitUtxos(selectedUtxos, splitModule.count, error)
                             _dismissDialog.postValue(Unit)
                             loadUtxosFromFFI()
+                            EventBus.post(Event.Transaction.Updated)
                             showSuccessSplitDialog()
                         }
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = "1.6.21"
 
     // build & version
-    ext.buildNumber = 215
+    ext.buildNumber = 216
     ext.versionNumber = "0.16.0"
 
     // JNI libs


### PR DESCRIPTION
Description:

* Added balance update listener
* Fixed updating list itself and after splitting\breaking coins
* Moved faucet txs from completed to pending
* Fixed block explorer link
* Fixed "Completing final transactions **" label for one side payments and payments from the faucet
* Fixed keyboard on restoring from seed phrase
* Added passing value from requesting into the amount screen