### PR TITLE
feat: logger config

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/infrastructure/logging/LoggerAdapter.kt
+++ b/app/src/main/java/com/tari/android/wallet/infrastructure/logging/LoggerAdapter.kt
@@ -1,17 +1,27 @@
 package com.tari.android.wallet.infrastructure.logging
 
 import com.orhanobut.logger.AndroidLogAdapter
+import com.orhanobut.logger.FormatStrategy
 import com.orhanobut.logger.Logger
+import com.orhanobut.logger.PrettyFormatStrategy
 import com.tari.android.wallet.BuildConfig
 import com.tari.android.wallet.data.WalletConfig
 import com.tari.android.wallet.data.sharedPrefs.sentry.SentryPrefRepository
 import javax.inject.Inject
 import javax.inject.Singleton
 
+
 @Singleton
 class LoggerAdapter @Inject constructor(val walletConfig: WalletConfig, private val sentryPrefRepository: SentryPrefRepository) {
     fun init() {
-        Logger.addLogAdapter(AndroidLogAdapter())
+        val formatStrategy: FormatStrategy = PrettyFormatStrategy.newBuilder()
+            .showThreadInfo(false) // (Optional) Whether to show thread info or not. Default true
+            .methodCount(2) // (Optional) How many method line to show. Default 2
+            .methodOffset(5) // (Optional) Hides internal method calls up to offset. Default 5
+            .tag("") // (Optional) Global tag for every log. Default PRETTY_LOGGER
+            .build()
+
+        Logger.addLogAdapter(AndroidLogAdapter(formatStrategy))
         Logger.addLogAdapter(FFIFileAdapter())
         @Suppress("KotlinConstantConditions")
         if (BuildConfig.FLAVOR != "privacy") {


### PR DESCRIPTION
Add a FormatStrategy to the LoggerAdapter.
Logs are overfilled with text, this config reduces wording of the logs