### PR TITLE
feat: refactor backup related code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ apply plugin: "kotlin-android"
 apply plugin: "kotlin-kapt"
 apply from: "../download-libwallet.gradle"
 apply plugin: "io.sentry.android.gradle"
+apply plugin: 'kotlin-parcelize'
 
 android {
     namespace "com.tari.android.wallet"

--- a/app/src/main/java/com/tari/android/wallet/application/securityStage/StagedWalletSecurityManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/securityStage/StagedWalletSecurityManager.kt
@@ -44,7 +44,7 @@ class StagedWalletSecurityManager : CommonViewModel() {
         get() = tariSettingsSharedRepository.hasVerifiedSeedWords
 
     val isBackupOn
-        get() = backupPrefsRepository.getOptionList.any { it.isEnable }
+        get() = backupPrefsRepository.optionList.any { it.isEnabled }
 
     val isBackupPasswordSet
         get() = !backupPrefsRepository.backupPassword.isNullOrEmpty()
@@ -117,7 +117,7 @@ class StagedWalletSecurityManager : CommonViewModel() {
 
     private fun openStage1() {
         dismissDialog.postValue(Unit)
-        tariNavigator?.let {
+        tariNavigator.let {
             it.toAllSettings()
             it.toBackupSettings(false)
             it.toWalletBackupWithRecoveryPhrase()
@@ -136,7 +136,7 @@ class StagedWalletSecurityManager : CommonViewModel() {
 
     private fun openStage1B() {
         dismissDialog.postValue(Unit)
-        tariNavigator?.let {
+        tariNavigator.let {
             it.toAllSettings()
             it.toBackupSettings(true)
         }
@@ -154,7 +154,7 @@ class StagedWalletSecurityManager : CommonViewModel() {
 
     private fun openStage2() {
         dismissDialog.postValue(Unit)
-        tariNavigator?.let {
+        tariNavigator.let {
             it.toAllSettings()
             it.toBackupSettings(false)
             it.toChangePassword()

--- a/app/src/main/java/com/tari/android/wallet/event/EffectChannelFlow.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EffectChannelFlow.kt
@@ -1,0 +1,14 @@
+package com.tari.android.wallet.event
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+class EffectChannelFlow<Effect : Any> {
+    private val channel: Channel<Effect> = Channel(Channel.CONFLATED)
+    val flow: Flow<Effect> = channel.receiveAsFlow()
+
+    suspend fun send(effect: Effect) {
+        channel.send(effect)
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
@@ -1,0 +1,13 @@
+package com.tari.android.wallet.extension
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+inline fun LifecycleOwner.launchAndRepeatOnLifecycle(
+    state: Lifecycle.State,
+    crossinline block: suspend CoroutineScope.() -> Unit,
+) = lifecycleScope.launch { repeatOnLifecycle(state) { block() } }

--- a/app/src/main/java/com/tari/android/wallet/infrastructure/backup/BackupsState.kt
+++ b/app/src/main/java/com/tari/android/wallet/infrastructure/backup/BackupsState.kt
@@ -1,8 +1,8 @@
 package com.tari.android.wallet.infrastructure.backup
 
-import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptions
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 
-data class BackupsState(val backupsStates: Map<BackupOptions, BackupState>) {
+data class BackupsState(val backupsStates: Map<BackupOptionType, BackupState>) {
 
     val backupsState: BackupState
         get() {

--- a/app/src/main/java/com/tari/android/wallet/ui/extension/FragmentExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/extension/FragmentExtensions.kt
@@ -38,6 +38,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 
 fun Fragment.string(@StringRes id: Int): String = requireContext().string(id)
@@ -54,3 +55,8 @@ fun Fragment.dimenPx(@DimenRes id: Int): Int = requireContext().dimenPx(id)
 fun Fragment.dimen(@DimenRes id: Int): Float = requireContext().dimen(id)
 
 fun Fragment.drawable(@DrawableRes id: Int): Drawable? = requireContext().drawable(id)
+
+inline fun <reified T : Fragment> T.withArgs(vararg pairs: Pair<String, Any?>): T {
+    arguments = bundleOf(*pairs)
+    return this
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/Navigation.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/Navigation.kt
@@ -8,6 +8,7 @@ import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.ContactDto
 import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.YatDto
 import com.tari.android.wallet.ui.fragment.pinCode.PinCodeScreenBehavior
 import com.tari.android.wallet.ui.fragment.send.common.TransactionData
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 
 sealed class Navigation {
 
@@ -111,7 +112,7 @@ sealed class Navigation {
     }
 
     sealed class ChooseRestoreOptionNavigation : Navigation() {
-        object ToEnterRestorePassword : ChooseRestoreOptionNavigation()
+        data class ToEnterRestorePassword(val optionType: BackupOptionType) : ChooseRestoreOptionNavigation()
 
         object ToRestoreWithRecoveryPhrase : ChooseRestoreOptionNavigation()
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
@@ -68,6 +68,7 @@ import com.tari.android.wallet.ui.fragment.settings.backgroundService.Background
 import com.tari.android.wallet.ui.fragment.settings.backup.backupOnboarding.BackupOnboardingFlowFragment
 import com.tari.android.wallet.ui.fragment.settings.backup.backupSettings.BackupSettingsFragment
 import com.tari.android.wallet.ui.fragment.settings.backup.changeSecurePassword.ChangeSecurePasswordFragment
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 import com.tari.android.wallet.ui.fragment.settings.backup.enterCurrentPassword.EnterCurrentPasswordFragment
 import com.tari.android.wallet.ui.fragment.settings.backup.verifySeedPhrase.VerifySeedPhraseFragment
 import com.tari.android.wallet.ui.fragment.settings.backup.writeDownSeedWords.WriteDownSeedPhraseFragment
@@ -110,7 +111,7 @@ class TariNavigator @Inject constructor(val prefs: SharedPrefsRepository, val ta
             is ContactBookNavigation.ToContactTransactionHistory -> toContactTransactionHistory(navigation.contact)
             is ContactBookNavigation.ToAddPhoneContact -> toAddPhoneContact()
             is ContactBookNavigation.ToSelectTariUser -> addFragment(SelectUserContactFragment.newInstance())
-            Navigation.ChooseRestoreOptionNavigation.ToEnterRestorePassword -> toEnterRestorePassword()
+            is Navigation.ChooseRestoreOptionNavigation.ToEnterRestorePassword -> toEnterRestorePassword(navigation.optionType)
             Navigation.ChooseRestoreOptionNavigation.OnRestoreCompleted -> onRestoreCompleted()
             Navigation.ChooseRestoreOptionNavigation.ToRestoreWithRecoveryPhrase -> toRestoreWithRecoveryPhrase()
             AllSettingsNavigation.ToBugReporting -> DebugActivity.launch(activity, DebugNavigation.BugReport)
@@ -165,7 +166,6 @@ class TariNavigator @Inject constructor(val prefs: SharedPrefsRepository, val ta
             }
 
             Navigation.ChatNavigation.ToAddChat -> addFragment(AddChatFragment())
-            else -> Unit
         }
     }
 
@@ -181,7 +181,7 @@ class TariNavigator @Inject constructor(val prefs: SharedPrefsRepository, val ta
         activity.startActivity(intent)
     }
 
-    fun toEnterRestorePassword() = addFragment(EnterRestorationPasswordFragment.newInstance())
+    fun toEnterRestorePassword(optionType: BackupOptionType) = addFragment(EnterRestorationPasswordFragment.newInstance(optionType))
 
     fun toRestoreWithRecoveryPhrase() = addFragment(InputSeedWordsFragment.newInstance())
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/ChooseRestoreOptionModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/ChooseRestoreOptionModel.kt
@@ -1,0 +1,19 @@
+package com.tari.android.wallet.ui.fragment.restore.chooseRestoreOption
+
+import com.tari.android.wallet.infrastructure.backup.BackupManager
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionDto
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
+
+object ChooseRestoreOptionModel {
+
+    data class UiState(
+        val selectedOption: BackupOptionType? = null,
+        val options: List<BackupOptionDto> = emptyList(),
+    )
+
+    sealed interface Effect {
+        data class BeginProgress(val optionType: BackupOptionType) : Effect
+        data class EndProgress(val optionType: BackupOptionType) : Effect
+        data class SetupStorage(val backupManager: BackupManager, val optionType: BackupOptionType) : Effect
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/ChooseRestoreOptionState.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/ChooseRestoreOptionState.kt
@@ -1,9 +1,0 @@
-package com.tari.android.wallet.ui.fragment.restore.chooseRestoreOption
-
-import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptions
-
-sealed class ChooseRestoreOptionState(val backupOptions: BackupOptions) {
-    class BeginProgress(backupOptions: BackupOptions) : ChooseRestoreOptionState(backupOptions)
-
-    class EndProgress(backupOptions: BackupOptions) : ChooseRestoreOptionState(backupOptions)
-}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/option/RecoveryOptionView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/option/RecoveryOptionView.kt
@@ -9,7 +9,7 @@ import com.tari.android.wallet.databinding.ViewRestoreOptionBinding
 import com.tari.android.wallet.ui.component.common.CommonView
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.setVisible
-import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptions
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 
 class RecoveryOptionView : CommonView<RecoveryOptionViewModel, ViewRestoreOptionBinding> {
 
@@ -26,11 +26,11 @@ class RecoveryOptionView : CommonView<RecoveryOptionViewModel, ViewRestoreOption
         defStyleAttr
     )
 
-    fun init(option: BackupOptions) {
+    fun init(option: BackupOptionType) {
         val text = when(option) {
-            BackupOptions.Google -> R.string.back_up_wallet_restore_with_google_drive
-            BackupOptions.Local -> R.string.back_up_wallet_restore_with_local_files
-            BackupOptions.Dropbox -> R.string.back_up_wallet_restore_with_dropbox
+            BackupOptionType.Google -> R.string.back_up_wallet_restore_with_google_drive
+            BackupOptionType.Local -> R.string.back_up_wallet_restore_with_local_files
+            BackupOptionType.Dropbox -> R.string.back_up_wallet_restore_with_dropbox
         }
         ui.title.text = context.getString(text)
         bindViewModel(RecoveryOptionViewModel().apply { this.option = option })

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/option/RecoveryOptionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/chooseRestoreOption/option/RecoveryOptionViewModel.kt
@@ -1,9 +1,9 @@
 package com.tari.android.wallet.ui.fragment.restore.chooseRestoreOption.option
 
 import com.tari.android.wallet.ui.common.CommonViewModel
-import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptions
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 
 class RecoveryOptionViewModel : CommonViewModel() {
 
-    var option: BackupOptions? = null
+    var option: BackupOptionType? = null
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordFragment.kt
@@ -52,10 +52,14 @@ import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.extension.colorFromAttribute
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.hideKeyboard
+import com.tari.android.wallet.ui.extension.parcelable
 import com.tari.android.wallet.ui.extension.setOnThrottledClickListener
 import com.tari.android.wallet.ui.extension.showKeyboard
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.visible
+import com.tari.android.wallet.ui.extension.withArgs
+import com.tari.android.wallet.ui.fragment.restore.enterRestorationPassword.EnterRestorationPasswordModel.Parameters
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
 
 class EnterRestorationPasswordFragment : CommonFragment<FragmentEnterRestorePasswordBinding, EnterRestorationPasswordViewModel>() {
 
@@ -67,6 +71,7 @@ class EnterRestorationPasswordFragment : CommonFragment<FragmentEnterRestorePass
 
         val viewModel: EnterRestorationPasswordViewModel by viewModels()
         bindViewModel(viewModel)
+        viewModel.assignParameters(savedInstanceState?.parcelable(EXTRA_PARAMETERS_KEY)!!)
 
         setupUI()
 
@@ -144,6 +149,10 @@ class EnterRestorationPasswordFragment : CommonFragment<FragmentEnterRestorePass
     }
 
     companion object {
-        fun newInstance() = EnterRestorationPasswordFragment()
+        fun newInstance(optionType: BackupOptionType) = EnterRestorationPasswordFragment().withArgs(
+            EXTRA_PARAMETERS_KEY to Parameters(
+                selectedOptionType = optionType,
+            )
+        )
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordModel.kt
@@ -1,0 +1,12 @@
+package com.tari.android.wallet.ui.fragment.restore.enterRestorationPassword
+
+import android.os.Parcelable
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
+import kotlinx.parcelize.Parcelize
+
+internal const val EXTRA_PARAMETERS_KEY = "EXTRA_PARAMETERS_KEY"
+
+object EnterRestorationPasswordModel {
+    @Parcelize
+    data class Parameters(val selectedOptionType: BackupOptionType) : Parcelable
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
@@ -82,7 +82,6 @@ import com.tari.android.wallet.ui.fragment.settings.allSettings.button.ButtonVie
 import com.tari.android.wallet.ui.fragment.settings.allSettings.myProfile.MyProfileViewHolderItem
 import com.tari.android.wallet.ui.fragment.settings.allSettings.title.SettingsTitleViewHolderItem
 import com.tari.android.wallet.ui.fragment.settings.allSettings.version.SettingsVersionViewHolderItem
-import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupSettingsRepository
 import com.tari.android.wallet.ui.fragment.settings.userAutorization.BiometricAuthenticationViewModel
 import com.tari.android.wallet.yat.YatAdapter
 import com.tari.android.wallet.yat.YatSharedRepository
@@ -98,9 +97,6 @@ class AllSettingsViewModel : CommonViewModel() {
 
     @Inject
     lateinit var yatAdapter: YatAdapter
-
-    @Inject
-    lateinit var backupSettingsRepository: BackupSettingsRepository
 
     @Inject
     lateinit var backupManager: BackupManager

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/BackupSettingsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/BackupSettingsFragment.kt
@@ -98,7 +98,7 @@ class BackupSettingsFragment : CommonFragment<FragmentWalletBackupSettingsBindin
 
         observe(setPasswordVisible) { ui.updatePasswordCtaView.setVisible(it) }
 
-        observe(options) { initBackupOptions(it) }
+        observe(optionViewModels) { initBackupOptions(it) }
     }
 
     private fun initBackupOptions(options: List<BackupOptionViewModel>) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/option/BackupOptionModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/option/BackupOptionModel.kt
@@ -1,0 +1,30 @@
+package com.tari.android.wallet.ui.fragment.settings.backup.backupSettings.option
+
+import com.tari.android.wallet.infrastructure.backup.BackupManager
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionDto
+import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupOptionType
+
+object BackupOptionModel {
+    data class UiState(
+        val option: BackupOptionDto,
+        val switchChecked: Boolean,
+        val loading: Boolean = false,
+        val lastSuccessDate: String? = null,
+    ) {
+        constructor(option: BackupOptionDto) : this(
+            option = option,
+            switchChecked = option.isEnabled,
+        )
+
+        fun startLoading() = this.copy(loading = true)
+        fun stopLoading() = this.copy(loading = false)
+        fun switchOn() = this.copy(switchChecked = true)
+        fun switchOff() = this.copy(switchChecked = false)
+        fun switch(value: Boolean) = this.copy(switchChecked = value)
+    }
+
+
+    sealed interface Effect {
+        data class SetupStorage(val backupManager: BackupManager, val optionType: BackupOptionType) : Effect
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/option/BackupOptionView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/option/BackupOptionView.kt
@@ -6,14 +6,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.coroutineScope
 import com.tari.android.wallet.databinding.ViewBackupOptionBinding
-import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.ui.component.common.CommonView
 import com.tari.android.wallet.ui.extension.setVisible
+import com.tari.android.wallet.ui.fragment.settings.backup.backupSettings.option.BackupOptionModel.Effect
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 
-class BackupOptionView : CommonView<BackupOptionViewModel, ViewBackupOptionBinding> {
+class BackupOptionView : CommonView<BackupOptionViewModel, ViewBackupOptionBinding>, LifecycleObserver {
 
     private lateinit var fragment: Fragment
+    private lateinit var lifecycleScope: LifecycleCoroutineScope
 
     override fun bindingInflate(layoutInflater: LayoutInflater, parent: ViewGroup?, attachToRoot: Boolean):
             ViewBackupOptionBinding = ViewBackupOptionBinding.inflate(layoutInflater, parent, attachToRoot)
@@ -30,20 +36,28 @@ class BackupOptionView : CommonView<BackupOptionViewModel, ViewBackupOptionBindi
 
     fun init(fragment: Fragment, backupOptionViewModel: BackupOptionViewModel) {
         this.fragment = fragment
+        fragment.lifecycle.addObserver(this)
+        lifecycleScope = fragment.lifecycle.coroutineScope
         bindViewModel(backupOptionViewModel)
         ui.title.text = context.getString(backupOptionViewModel.title)
         setPermissionSwitchListener()
         observeViewModel()
     }
 
-    private fun observeViewModel() = with(viewModel) {
-        observe(switchChecked) { setSwitchCheck(it) }
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    is Effect.SetupStorage -> effect.backupManager.setupStorage(effect.optionType, fragment)
+                }
+            }
 
-        observe(inProgress) { onChangeInProgress(it) }
-
-        observe(openFolderSelection) { backupManager.setupStorage(viewModel.option.value!!.type, fragment) }
-
-        observe(lastSuccessDate) { updateLastSuccessDate(it) }
+            viewModel.uiState.filterNotNull().collect { state ->
+                setSwitchCheck(state.switchChecked)
+                onChangeInProgress(state.loading)
+                updateLastSuccessDate(state.lastSuccessDate)
+            }
+        }
     }
 
     private fun setSwitchCheck(isChecked: Boolean) = with(ui) {
@@ -61,8 +75,8 @@ class BackupOptionView : CommonView<BackupOptionViewModel, ViewBackupOptionBindi
         ui.backupSwitch.setOnCheckedChangeListener { _, isChecked -> viewModel.onBackupSwitchChecked(isChecked) }
     }
 
-    private fun updateLastSuccessDate(date: String) {
-        ui.lastBackupTimeTextView.setVisible(date.isNotBlank(), View.GONE)
+    private fun updateLastSuccessDate(date: String?) {
+        ui.lastBackupTimeTextView.setVisible(!date.isNullOrBlank(), View.GONE)
         ui.lastBackupTimeTextView.text = date
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/data/BackupOptionDto.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/data/BackupOptionDto.kt
@@ -4,8 +4,8 @@ import com.tari.android.wallet.data.sharedPrefs.delegates.SerializableTime
 import java.io.Serializable
 
 data class BackupOptionDto(
-    val type: BackupOptions,
-    val isEnable: Boolean = false,
+    val type: BackupOptionType,
+    val isEnabled: Boolean = false,
     val lastSuccessDate: SerializableTime? = null,
     val lastFailureDate: SerializableTime? = null
 ) : Serializable

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/data/BackupOptionType.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/data/BackupOptionType.kt
@@ -1,6 +1,6 @@
 package com.tari.android.wallet.ui.fragment.settings.backup.data
 
-enum class BackupOptions {
+enum class BackupOptionType {
     Google,
     Dropbox,
     Local


### PR DESCRIPTION
The first iteration of the fix of the Backup feature.
I prepared code for further refactoring and bug fixing:
- Moved domain logic out from views to viewModels
- Made classes more stateless by passing required inputs as arguments instead of storing them in third-party classes

And also made some enhancements:
- Added some useful extension functions
- Renamed some classes and variables meaningfully (e.g. `BackupOptions` -> `BackupOptionType` because it is an enum with possible option types)
- Made log messages more informative
- Made some nullable values null-safe
- Moved view state variables to separate immutable UiState classes

Notes:
- I left some TODOs required for continuation of my work