### PR TITLE
feat: staged security dialog fix

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/event/EffectChannelFlow.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EffectChannelFlow.kt
@@ -1,0 +1,14 @@
+package com.tari.android.wallet.event
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+class EffectChannelFlow<Effect : Any> {
+    private val channel: Channel<Effect> = Channel(Channel.CONFLATED)
+    val flow: Flow<Effect> = channel.receiveAsFlow()
+
+    suspend fun send(effect: Effect) {
+        channel.send(effect)
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
@@ -69,8 +69,6 @@ object EventBus : GeneralEventBus() {
 
     val walletRestorationState = BehaviorEventBus<WalletRestorationResult>()
 
-    val balanceUpdates = BehaviorEventBus<BalanceInfo>()
-
     init {
         baseNodeSyncState.post(BaseNodeSyncState.Syncing)
     }

--- a/app/src/main/java/com/tari/android/wallet/extension/AnyExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/AnyExtensions.kt
@@ -1,0 +1,12 @@
+package com.tari.android.wallet.extension
+
+/**
+ * These extensions can be used to write casts in a chained way.
+ * E.g. something.castTo<Other>().doSomething() instead of (something as Other).doSomething()
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> Any.castTo(): T = this as T
+
+// Simply returning `this as? T` does not work because the Kotlin compiler internally
+// then still just casts it to the other type without checks
+inline fun <reified T> Any.safeCastTo(): T? = if (this is T) this else null

--- a/app/src/main/java/com/tari/android/wallet/extension/DateExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/DateExtensions.kt
@@ -55,3 +55,7 @@ fun Date.txFormattedDate(): String {
     return SimpleDateFormat("MMMM d'$indicator' yyyy 'at' h:mm a", Locale.ENGLISH)
         .format(this)
 }
+
+fun Calendar.isAfterNow(): Boolean {
+    return this.after(Calendar.getInstance())
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupOnboarding/item/BackupOnboardingArgs.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupOnboarding/item/BackupOnboardingArgs.kt
@@ -3,7 +3,7 @@ package com.tari.android.wallet.ui.fragment.settings.backup.backupOnboarding.ite
 import android.graphics.Typeface
 import android.text.SpannableString
 import com.tari.android.wallet.R
-import com.tari.android.wallet.application.securityStage.StagedWalletSecurityManager
+import com.tari.android.wallet.application.securityStage.STAGE_TWO_THRESHOLD_BALANCE
 import com.tari.android.wallet.extension.applyCenterAlignment
 import com.tari.android.wallet.extension.applyColorStyle
 import com.tari.android.wallet.extension.applyTypefaceStyle
@@ -108,7 +108,7 @@ sealed class BackupOnboardingArgs(
                 0 -> resourceManager.getString(R.string.onboarding_staged_wallet_security_footer_part3_any_funds)
                 else -> resourceManager.getString(
                     R.string.onboarding_staged_wallet_security_footer_part3_threshold,
-                    StagedWalletSecurityManager.stageTwoThresholdBalance.formattedTariValue
+                    STAGE_TWO_THRESHOLD_BALANCE.formattedTariValue,
                 )
             }
             val spannable = SpannableString("$firstPart $highlighted$part3")

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
@@ -90,7 +90,6 @@ class HomeFragment : CommonFragment<FragmentHomeBinding, HomeFragmentViewModel>(
 
         viewModel.serviceConnection.reconnectToService()
 
-        subscribeVM(viewModel.stagedWalletSecurityManager)
         subscribeVM(deeplinkViewModel)
 
         checkPermission()

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragmentViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragmentViewModel.kt
@@ -1,6 +1,8 @@
 package com.tari.android.wallet.ui.fragment.tx
 
 
+import android.text.SpannableString
+import android.text.Spanned
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -12,12 +14,16 @@ import com.tari.android.wallet.R.string.error_no_connection_title
 import com.tari.android.wallet.R.string.error_node_unreachable_description
 import com.tari.android.wallet.R.string.error_node_unreachable_title
 import com.tari.android.wallet.application.securityStage.StagedWalletSecurityManager
+import com.tari.android.wallet.application.securityStage.StagedWalletSecurityManager.StagedSecurityEffect
 import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
+import com.tari.android.wallet.data.sharedPrefs.securityStages.WalletSecurityStage
+import com.tari.android.wallet.data.sharedPrefs.securityStages.modules.SecurityStageHeadModule
 import com.tari.android.wallet.data.sharedPrefs.sentry.SentryPrefRepository
 import com.tari.android.wallet.event.Event
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.addTo
 import com.tari.android.wallet.extension.getWithError
+import com.tari.android.wallet.extension.safeCastTo
 import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonViewModel
@@ -30,15 +36,19 @@ import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
+import com.tari.android.wallet.ui.dialog.modular.modules.space.SpaceModule
 import com.tari.android.wallet.ui.fragment.contact_book.data.ContactsRepository
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.send.finalize.TxFailureReason
+import com.tari.android.wallet.ui.fragment.settings.backup.backupOnboarding.item.BackupOnboardingArgs
+import com.tari.android.wallet.ui.fragment.settings.backup.backupOnboarding.module.BackupOnboardingFlowItemModule
 import com.tari.android.wallet.ui.fragment.settings.backup.data.BackupSettingsRepository
 import com.tari.android.wallet.ui.fragment.tx.adapter.TransactionItem
 import com.tari.android.wallet.util.extractEmojis
 import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import yat.android.ui.extension.HtmlHelper
 import javax.inject.Inject
 
 
@@ -62,7 +72,8 @@ class HomeFragmentViewModel : CommonViewModel() {
     @Inject
     lateinit var sentryPrefRepository: SentryPrefRepository
 
-    val stagedWalletSecurityManager = StagedWalletSecurityManager()
+    @Inject
+    lateinit var stagedWalletSecurityManager: StagedWalletSecurityManager
 
     private val _balanceInfo = MutableLiveData<BalanceInfo>()
     val balanceInfo: LiveData<BalanceInfo> = _balanceInfo
@@ -132,9 +143,19 @@ class HomeFragmentViewModel : CommonViewModel() {
     }
 
     private fun fetchBalanceInfoData() {
-        walletService.getWithError { error, service -> service.getBalanceInfo(error) }?.let {
-            EventBus.balanceUpdates.post(it)
-            _balanceInfo.postValue(it)
+        walletService.getWithError { error, service -> service.getBalanceInfo(error) }?.let { balanceInfo ->
+            _balanceInfo.postValue(balanceInfo)
+
+            stagedWalletSecurityManager.handleBalanceChange(balanceInfo)
+                .safeCastTo<StagedSecurityEffect.ShowStagedSecurityPopUp>()
+                ?.let { effect ->
+                    when (effect.stage) {
+                        WalletSecurityStage.Stage1A -> showStagePopUp1A()
+                        WalletSecurityStage.Stage1B -> showStagePopUp1B()
+                        WalletSecurityStage.Stage2 -> showStagePopUp2()
+                        WalletSecurityStage.Stage3 -> showStagePopUp3()
+                    }
+                }
         }
     }
 
@@ -193,6 +214,117 @@ class HomeFragmentViewModel : CommonViewModel() {
             resourceManager.getString(error_node_unreachable_description),
         )
         modularDialog.postValue(errorDialogArgs.getModular(resourceManager))
+    }
+
+    /**
+     * Show staged security popups
+     */
+
+    private fun showStagePopUp1A() {
+        showPopup(
+            stage = BackupOnboardingArgs.StageOne(resourceManager, this::openStage1),
+            titleEmoji = resourceManager.getString(R.string.staged_wallet_security_stages_1a_title),
+            title = resourceManager.getString(R.string.staged_wallet_security_stages_1a_subtitle),
+            body = null,
+            positiveButtonTitle = resourceManager.getString(R.string.staged_wallet_security_stages_1a_buttons_positive),
+            bodyHtml = HtmlHelper.getSpannedText(resourceManager.getString(R.string.staged_wallet_security_stages_1a_message)),
+            positiveAction = { openStage1() },
+        )
+    }
+
+    private fun showStagePopUp1B() {
+        showPopup(
+            stage = BackupOnboardingArgs.StageTwo(resourceManager, this::openStage1B),
+            titleEmoji = resourceManager.getString(R.string.staged_wallet_security_stages_1b_title),
+            title = resourceManager.getString(R.string.staged_wallet_security_stages_1b_subtitle),
+            body = resourceManager.getString(R.string.staged_wallet_security_stages_1b_message),
+            positiveButtonTitle = resourceManager.getString(R.string.staged_wallet_security_stages_1b_buttons_positive),
+            positiveAction = { openStage1() },
+        )
+    }
+
+    private fun showStagePopUp2() {
+        showPopup(
+            stage = BackupOnboardingArgs.StageThree(resourceManager, this::openStage2),
+            titleEmoji = resourceManager.getString(R.string.staged_wallet_security_stages_2_title),
+            title = resourceManager.getString(R.string.staged_wallet_security_stages_2_subtitle),
+            body = resourceManager.getString(R.string.staged_wallet_security_stages_2_message),
+            positiveButtonTitle = resourceManager.getString(R.string.staged_wallet_security_stages_2_buttons_positive),
+            positiveAction = { openStage2() },
+        )
+    }
+
+    private fun showStagePopUp3() {
+        showPopup(
+            stage = BackupOnboardingArgs.StageFour(resourceManager, this::openStage3),
+            titleEmoji = resourceManager.getString(R.string.staged_wallet_security_stages_3_title),
+            title = resourceManager.getString(R.string.staged_wallet_security_stages_3_subtitle),
+            body = resourceManager.getString(R.string.staged_wallet_security_stages_3_message),
+            positiveButtonTitle = resourceManager.getString(R.string.staged_wallet_security_stages_3_buttons_positive),
+            positiveAction = { openStage3() },
+        )
+    }
+
+    private fun openStage1() {
+        dismissDialog.postValue(Unit)
+        tariNavigator.let {
+            it.toAllSettings()
+            it.toBackupSettings(false)
+            it.toWalletBackupWithRecoveryPhrase()
+        }
+    }
+
+    private fun openStage1B() {
+        dismissDialog.postValue(Unit)
+        tariNavigator.let {
+            it.toAllSettings()
+            it.toBackupSettings(true)
+        }
+    }
+
+    private fun openStage2() {
+        dismissDialog.postValue(Unit)
+        tariNavigator.let {
+            it.toAllSettings()
+            it.toBackupSettings(false)
+            it.toChangePassword()
+        }
+    }
+
+    private fun openStage3() {
+        dismissDialog.postValue(Unit)
+        //todo for future
+    }
+
+    private fun showPopup(
+        stage: BackupOnboardingArgs,
+        titleEmoji: String,
+        title: String,
+        body: String?,
+        positiveButtonTitle: String,
+        bodyHtml: Spanned? = null,
+        positiveAction: () -> Unit = {},
+    ) {
+        val args = ModularDialogArgs(
+            DialogArgs(), listOf(
+                SecurityStageHeadModule(titleEmoji, title) { showBackupInfo(stage) },
+                BodyModule(body, bodyHtml?.let { SpannableString(it) }),
+                ButtonModule(positiveButtonTitle, ButtonStyle.Normal) { positiveAction.invoke() },
+                ButtonModule(resourceManager.getString(R.string.staged_wallet_security_buttons_remind_me_later), ButtonStyle.Close)
+            )
+        )
+        modularDialog.postValue(args)
+    }
+
+    private fun showBackupInfo(stage: BackupOnboardingArgs) {
+        modularDialog.postValue(
+            ModularDialogArgs(
+                DialogArgs(), listOf(
+                    BackupOnboardingFlowItemModule(stage),
+                    SpaceModule(20),
+                )
+            )
+        )
     }
 
     companion object {


### PR DESCRIPTION
Fix the multiple staged wallet security dialog bug
- Fix the wrong date comparison
- Fix the memory leak when `StagedWalletSecurityManager` held an instance of a balance check event subscription even when the app stops
- Make `StagedWalletSecurityManager` a singleton and move all display logic to the VM
- Got rid of the `balanceUpdates` event bus event
- Added a couple of useful utils
- Cleaned up the code