### PR TITLE
feat: release/0.25.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-sentry (1.17.0)
+    fastlane-plugin-sentry (1.19.0)
       os (~> 1.1, >= 1.1.4)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.54.0)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,8 +58,9 @@ android {
                 debugSymbolLevel "FULL"
             }
             sentry {
-                autoUpload.set(false)
-                autoUploadProguardMapping.set(false)
+                autoUpload.set(true)
+                uploadNativeSymbols.set(true)
+                includeNativeSources.set(true)
             }
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ android {
     flavorDimensions.add("privacy-mode")
 
     buildTypes {
+        loadSentryProps()
         def secretProperties = loadSecretProps()
 
         debug {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.lifecycle_version = '2.6.2'
 
     // build & version
-    ext.buildNumber = 287
-    ext.versionNumber = "0.25.1"
+    ext.buildNumber = 288
+    ext.versionNumber = "0.25.2"
 
     // JNI libs
     ext.libwalletHostURL = "https://github.com/tari-project/tari/releases/download/"


### PR DESCRIPTION
- returned the old way of uploading ProGuard mappings to Sentry