### PR TITLE
feat: min. valid FFI version to 1.0.0-rc.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
         buildConfigField("String", "YAT_ORGANIZATION_RETURN_URL", "\"${yatProperties.getProperty("yat.returnUrl")}\"")
         def dropboxProperties = loadDropboxProps()
         buildConfigField("String", "DROPBOX_ACCESS_TOKEN", "\"${dropboxProperties.getProperty("dropbox_key")}\"")
+        buildConfigField("String", "LIB_WALLET_MIN_VALID_VERSION", "\"$libwalletMinValidVersion\"")
     }
 
     flavorDimensions.add("privacy-mode")

--- a/app/src/main/java/com/tari/android/wallet/application/MigrationManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/MigrationManager.kt
@@ -1,6 +1,7 @@
 package com.tari.android.wallet.application
 
 import androidx.lifecycle.viewModelScope
+import com.tari.android.wallet.BuildConfig
 import com.tari.android.wallet.ui.common.SimpleViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -11,13 +12,12 @@ import javax.inject.Singleton
 @Singleton
 class MigrationManager @Inject constructor(private val manager: WalletManager) {
 
-    private val minValidVersion = DefaultArtifactVersion("v0.52.0")
     private val simpleViewModel = SimpleViewModel()
 
     fun validateVersion(onValid: () -> Unit, onError: () -> Unit) {
         val walletVersion = getCurrentWalletVersion()
 
-        if (walletVersion.isEmpty() || DefaultArtifactVersion(walletVersion) < minValidVersion) {
+        if (walletVersion.isEmpty() || DefaultArtifactVersion(walletVersion) < DefaultArtifactVersion(BuildConfig.LIB_WALLET_MIN_VALID_VERSION)) {
             simpleViewModel.viewModelScope.launch(Dispatchers.Main) { onError() }
         } else {
             simpleViewModel.viewModelScope.launch(Dispatchers.Main) { onValid() }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     // JNI libs
     ext.libwalletHostURL = "https://github.com/tari-project/tari/releases/download/"
     ext.libwalletVersion = "v1.0.0-rc.5"
+    ext.libwalletMinValidVersion = "v1.0.0-rc.5"
     ext.libwalletx64A = "libminotari_wallet_ffi.android_x86_64.a"
     ext.libwalletArmA = "libminotari_wallet_ffi.android_aarch64.a"
     ext.libwalletHeader = "libminotari_wallet_ffi.h"


### PR DESCRIPTION
- Added the `LIB_WALLET_MIN_VALID_VERSION` field in the BuildConfig
- Updated min. valid FFI version to 1.0.0-rc.5
