### PR TITLE
feat: fix invalid amount to send on sending money using QR code

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/keyboard/KeyboardController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/keyboard/KeyboardController.kt
@@ -293,6 +293,7 @@ class KeyboardController {
     ): TextView {
         val inflater = LayoutInflater.from(context)
         return if (enteringFirstDigit) { // first digit :: use the existing view
+            elements[0] = elements[0].copy(first = digit)
             elements[0].second
         } else { // inflate text view
             val textView = inflater.inflate(


### PR DESCRIPTION
#1042 
- Fixed issue when the first number of an entered amount was skipped