### PR TITLE
feat: Block Explorer per network

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkRepositoryImpl.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkRepositoryImpl.kt
@@ -9,9 +9,9 @@ import com.tari.android.wallet.util.DebugConfig
 
 class NetworkRepositoryImpl(sharedPrefs: SharedPreferences) : NetworkRepository {
 
-    override val defaultNetwork = if (DebugConfig.mockNetwork) NETWORK_ESMERALDA else NETWORK_STAGENET
+    override val defaultNetwork = if (DebugConfig.mockNetwork) NETWORK_NEXTNET else NETWORK_STAGENET
 
-    override var supportedNetworks: List<TariNetwork> = if (DebugConfig.mockNetwork) listOf(NETWORK_ESMERALDA) else listOf(NETWORK_STAGENET)
+    override var supportedNetworks: List<TariNetwork> = if (DebugConfig.mockNetwork) listOf(NETWORK_NEXTNET) else listOf(NETWORK_STAGENET)
 
     override var currentNetwork by SharedPrefGsonDelegate(
         prefs = sharedPrefs,
@@ -40,19 +40,23 @@ class NetworkRepositoryImpl(sharedPrefs: SharedPreferences) : NetworkRepository 
         private val NETWORK_STAGENET: TariNetwork = TariNetwork(
             network = Network.STAGENET,
             dnsPeer = "seeds.stagenet.tari.com",
+            blockExplorerUrl = null,
             ticker = TICKER_TESTNET,
             recommended = true,
         )
         private val NETWORK_NEXTNET: TariNetwork = TariNetwork(
             network = Network.NEXTNET,
             dnsPeer = "seeds.nextnet.tari.com",
+            blockExplorerUrl = "https://explore-nextnet.tari.com",
             ticker = TICKER_TESTNET,
+            recommended = false,
         )
         private val NETWORK_ESMERALDA: TariNetwork = TariNetwork(
             network = Network.ESMERALDA,
             dnsPeer = "seeds.esmeralda.tari.com",
+            blockExplorerUrl = null,
             ticker = TICKER_TESTNET,
-            recommended = true,
+            recommended = false,
         )
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/TariNetwork.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/TariNetwork.kt
@@ -6,5 +6,9 @@ data class TariNetwork(
     val network: Network,
     val dnsPeer: String,
     val ticker: String,
+    val blockExplorerUrl: String? = null,
     val recommended: Boolean = false,
-)
+) {
+    val isBlockExplorerAvailable: Boolean
+        get() = blockExplorerUrl != null
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
@@ -56,7 +56,6 @@ import com.tari.android.wallet.R.string.back_up_wallet_backup_status_outdated
 import com.tari.android.wallet.R.string.back_up_wallet_backup_status_up_to_date
 import com.tari.android.wallet.R.string.check_backup_storage_status_error_title
 import com.tari.android.wallet.R.string.disclaimer_url
-import com.tari.android.wallet.R.string.explorer_url
 import com.tari.android.wallet.R.string.github_repo_url
 import com.tari.android.wallet.R.string.privacy_policy_url
 import com.tari.android.wallet.R.string.tari_about_title
@@ -212,8 +211,8 @@ class AllSettingsViewModel : CommonViewModel() {
             },
             DividerViewHolderItem(),
             SettingsRowViewDto(resourceManager.getString(all_settings_explorer), vector_all_settings_block_explorer_icon) {
-                _openLink.postValue(resourceManager.getString(explorer_url))
-            },
+                _openLink.postValue(networkRepository.currentNetwork.blockExplorerUrl)
+            }.takeIf { networkRepository.currentNetwork.isBlockExplorerAvailable },
             SettingsTitleViewHolderItem(resourceManager.getString(all_settings_advanced_settings_label)),
             SettingsRowViewDto(resourceManager.getString(all_settings_select_theme), vector_all_settings_select_theme_icon) {
                 navigation.postValue(AllSettingsNavigation.ToThemeSelection)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
@@ -162,7 +162,9 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
         observe(cancellationReason) { setCancellationReason(it) }
 
         observe(explorerLink) { link ->
-            showExplorerLink(link)
+            if (networkRepository.currentNetwork.isBlockExplorerAvailable) {
+                showExplorerLink(link)
+            }
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
@@ -150,7 +150,14 @@ class TxDetailsViewModel : CommonViewModel() {
 
     private fun generateExplorerLink(tx: Tx) {
         (tx as? CompletedTx)?.txKernel?.let { txKernel ->
-            _explorerLink.postValue(resourceManager.getString(R.string.explorer_kernel_url, txKernel.publicNonce, txKernel.signature))
+            _explorerLink.postValue(
+                resourceManager.getString(
+                    R.string.explorer_kernel_url,
+                    networkRepository.currentNetwork.blockExplorerUrl.orEmpty(),
+                    txKernel.publicNonce,
+                    txKernel.signature,
+                )
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,7 @@
     <string name="user_agreement_url">https://www.tari.com/user_agreement/</string>
     <string name="privacy_policy_url">https://www.tari.com/privacy_policy/</string>
     <string name="disclaimer_url">https://www.tari.com/disclaimer/</string>
-    <string name="explorer_url">https://explore-nextnet.tari.com/</string>
-    <string name="explorer_kernel_url">https://explore-nextnet.tari.com/kernel_search?nonces=%s&amp;signatures=%s</string>
+    <string name="explorer_kernel_url">%s/kernel_search?nonces=%s&amp;signatures=%s</string>
     <string name="tor_bridges_url">https://bridges.torproject.org/bridges</string>
     <string name="tari_lab_university_url" translatable="false">https://tlu.tarilabs.com/</string>
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
 
     // JNI libs
     ext.libwalletHostURL = "https://github.com/tari-project/tari/releases/download/"
-    ext.libwalletVersion = "v1.0.0-alpha.1"
-    ext.libwalletMinValidVersion = "v1.0.0-alpha.1"
+    ext.libwalletVersion = "v1.0.0-alpha.2"
+    ext.libwalletMinValidVersion = "v1.0.0-alpha.2"
     ext.libwalletx64A = "libminotari_wallet_ffi.android_x86_64.a"
     ext.libwalletArmA = "libminotari_wallet_ffi.android_aarch64.a"
     ext.libwalletHeader = "libminotari_wallet_ffi.h"


### PR DESCRIPTION
[#1086](https://github.com/tari-project/wallet-android/issues/1086)

- Added the `blockExplorerUrl` field to the Network class and hide the Block Explorer feature if it's null for the selected network
- Updated the FFI lib version to `v1.0.0-alpha.2`