### PR TITLE
feat: Block Explorer per network

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
@@ -211,7 +211,7 @@ class AllSettingsViewModel : CommonViewModel() {
             },
             DividerViewHolderItem(),
             SettingsRowViewDto(resourceManager.getString(all_settings_explorer), vector_all_settings_block_explorer_icon) {
-                _openLink.postValue(networkRepository.currentNetwork.blockExplorerUrl)
+                _openLink.postValue(networkRepository.currentNetwork.blockExplorerUrl.orEmpty())
             }.takeIf { networkRepository.currentNetwork.isBlockExplorerAvailable },
             SettingsTitleViewHolderItem(resourceManager.getString(all_settings_advanced_settings_label)),
             SettingsRowViewDto(resourceManager.getString(all_settings_select_theme), vector_all_settings_select_theme_icon) {


### PR DESCRIPTION
[#1086](https://github.com/tari-project/wallet-android/issues/1086)

- Added the `blockExplorerUrl` field to the Network class and hide the Block Explorer feature if it's null for the selected network
- Updated the FFI lib version to `v1.0.0-alpha.2`
- Fixed the Bitrise lint issue