### PR TITLE
feat: Coinbase maturity

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(
         jniTariCoinPreview.cpp
         jniTariWalletAddress.cpp
         jniTariUnblindedOutput.cpp
+        jniTariBaseNodeState.cpp
 )
 
 find_library(

--- a/app/src/main/cpp/jniTariBaseNodeState.cpp
+++ b/app/src/main/cpp/jniTariBaseNodeState.cpp
@@ -1,0 +1,16 @@
+#include <jni.h>
+#include "jniCommon.cpp"
+#include <wallet.h>
+
+
+extern "C"
+JNIEXPORT jbyteArray JNICALL
+Java_com_tari_android_wallet_ffi_FFITariBaseNodeState_jniGetHeightOfLongestChain(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jobject error) {
+    return ExecuteWithError<jbyteArray>(jEnv, error, [&](int *errorPointer) {
+        auto pTariBaseNodeState = GetPointerField<TariBaseNodeState *>(jEnv, jThis);
+        return getBytesFromUnsignedLongLong(jEnv, basenode_state_get_height_of_the_longest_chain(pTariBaseNodeState, errorPointer));
+    });
+}

--- a/app/src/main/cpp/jniTariUtxo.cpp
+++ b/app/src/main/cpp/jniTariUtxo.cpp
@@ -59,6 +59,10 @@ Java_com_tari_android_wallet_ffi_FFITariUtxo_jniLoadData(
     auto minedTimestamp = (long) (outputs->mined_timestamp);
     jEnv->SetLongField(jThis, minedTimestampField, minedTimestamp);
 
+    jfieldID lockHeightField = jEnv->GetFieldID(dataClass, "lockHeight", "J");
+    auto lockHeight = (long) (outputs->lock_height);
+    jEnv->SetLongField(jThis, lockHeightField, lockHeight);
+
     jfieldID statusField = jEnv->GetFieldID(dataClass, "status", "B");
     auto statusValue = (jbyte) (outputs->status);
     jEnv->SetByteField(jThis, statusField, statusValue);

--- a/app/src/main/java/com/tari/android/wallet/application/baseNodes/BaseNodesManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/baseNodes/BaseNodesManager.kt
@@ -14,6 +14,7 @@ import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.addTo
 import com.tari.android.wallet.extension.getWithError
 import com.tari.android.wallet.ffi.FFIPublicKey
+import com.tari.android.wallet.ffi.FFITariBaseNodeState
 import com.tari.android.wallet.ffi.FFIWallet
 import com.tari.android.wallet.ffi.HexString
 import com.tari.android.wallet.service.connection.ServiceConnectionStatus
@@ -21,6 +22,7 @@ import com.tari.android.wallet.service.connection.TariWalletServiceConnection
 import com.tari.android.wallet.util.DebugConfig
 import io.reactivex.disposables.CompositeDisposable
 import org.apache.commons.io.IOUtils
+import java.math.BigInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,6 +70,8 @@ class BaseNodesManager @Inject constructor(
             baseNodeSharedRepository.ffiBaseNodes
         }
 
+    val networkBlockHeight: BigInteger
+        get() = baseNodeSharedRepository.baseNodeHeightOfLongestChain
 
     /**
      * Select a base node randomly from the list of base nodes in base_nodes.tx, and sets
@@ -89,11 +93,21 @@ class BaseNodesManager @Inject constructor(
     }
 
     fun addUserBaseNode(baseNode: BaseNodeDto) {
-        baseNodeSharedRepository.addUserBaseNode(baseNode)
+        baseNodeSharedRepository.userBaseNodes.apply {
+            add(baseNode)
+            baseNodeSharedRepository.userBaseNodes = this
+        }
     }
 
     fun deleteUserBaseNode(baseNode: BaseNodeDto) {
-        baseNodeSharedRepository.deleteUserBaseNode(baseNode)
+        baseNodeSharedRepository.userBaseNodes.apply {
+            remove(baseNode)
+            baseNodeSharedRepository.userBaseNodes = this
+        }
+    }
+
+    fun saveBaseNodeState(baseNodeState: FFITariBaseNodeState) {
+        baseNodeSharedRepository.baseNodeHeightOfLongestChain = baseNodeState.getHeightOfLongestChain()
     }
 
     fun startSync() {

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/baseNode/BaseNodeSharedRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/baseNode/BaseNodeSharedRepository.kt
@@ -34,6 +34,7 @@ package com.tari.android.wallet.data.sharedPrefs.baseNode
 
 import android.content.SharedPreferences
 import com.tari.android.wallet.data.repository.CommonRepository
+import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefBigIntegerDelegate
 import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefBooleanNullableDelegate
 import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefGsonDelegate
 import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefGsonNullableDelegate
@@ -42,6 +43,7 @@ import com.tari.android.wallet.data.sharedPrefs.network.NetworkRepository
 import com.tari.android.wallet.data.sharedPrefs.network.formatKey
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.service.baseNode.BaseNodeState
+import java.math.BigInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -57,6 +59,7 @@ class BaseNodeSharedRepository @Inject constructor(
         const val BASE_NODE_STATE = "tari_wallet_user_base_node_state"
         const val BASE_NODE_LAST_SYNC_RESULT = "tari_wallet_base_node_last_sync_result"
         const val FFI_BASE_NODE_LIST = "FFI_BASE_NODE_LIST"
+        const val HEIGHT_OF_LONGEST_CHAIN = "HEIGHT_OF_LONGEST_CHAIN"
     }
 
     var currentBaseNode: BaseNodeDto? by SharedPrefGsonNullableDelegate(
@@ -100,23 +103,15 @@ class BaseNodeSharedRepository @Inject constructor(
             baseNodeStateOrdinal = value.ordinal
         }
 
+    var baseNodeHeightOfLongestChain: BigInteger by SharedPrefBigIntegerDelegate(
+        prefs = sharedPrefs,
+        commonRepository = this,
+        name = Key.HEIGHT_OF_LONGEST_CHAIN,
+        defValue = 0.toBigInteger(),
+    )
 
     init {
         EventBus.baseNodeState.post(baseNodeState)
-    }
-
-    fun deleteUserBaseNode(baseNodeDto: BaseNodeDto) {
-        userBaseNodes.apply {
-            remove(baseNodeDto)
-            userBaseNodes = this
-        }
-    }
-
-    fun addUserBaseNode(baseNodeDto: BaseNodeDto) {
-        userBaseNodes.apply {
-            add(baseNodeDto)
-            userBaseNodes = this
-        }
     }
 
     fun clear() {

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/delegates/SharedPrefBigIntegerDelegate.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/delegates/SharedPrefBigIntegerDelegate.kt
@@ -1,0 +1,28 @@
+package com.tari.android.wallet.data.sharedPrefs.delegates
+
+import android.content.SharedPreferences
+import com.tari.android.wallet.data.repository.CommonRepository
+import java.math.BigInteger
+import kotlin.reflect.KProperty
+
+class SharedPrefBigIntegerDelegate(
+    val prefs: SharedPreferences,
+    val commonRepository: CommonRepository,
+    val name: String,
+    val defValue: BigInteger,
+) {
+    init {
+        commonRepository.updateNotifier.onNext(Unit)
+    }
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): BigInteger =
+        prefs.getString(name, defValue.toString())?.run(::BigInteger) ?: defValue
+
+    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: BigInteger) =
+        prefs.edit().run {
+            putString(name, value.toString())
+            apply()
+            commonRepository.updateNotifier.onNext(Unit)
+        }
+}
+

--- a/app/src/main/java/com/tari/android/wallet/extension/NumericExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/NumericExtensions.kt
@@ -44,17 +44,8 @@ fun Float.remap(from1: Float, to1: Float, from2: Float, to2: Float): Float {
     return (this - from1) / (to1 - from1) * (to2 - from2) + from2
 }
 
-/**
- * Int to MicroTari.
- */
 fun Int.toMicroTari() = BigInteger.valueOf(this.toLong()).toMicroTari()
 
-/**
- * Long to MicroTari.
- */
 fun Long.toMicroTari() = BigInteger.valueOf(this).toMicroTari()
 
-/**
- * BigInteger to MicroTari.
- */
 fun BigInteger.toMicroTari() = MicroTari(this)

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITariBaseNodeState.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITariBaseNodeState.kt
@@ -1,0 +1,17 @@
+package com.tari.android.wallet.ffi
+
+import java.math.BigInteger
+
+class FFITariBaseNodeState() : FFIBase() {
+
+    private external fun jniGetHeightOfLongestChain(libError: FFIError): ByteArray
+
+    constructor(pointer: FFIPointer) : this() {
+        this.pointer = pointer
+    }
+
+    fun getHeightOfLongestChain(): BigInteger = runWithError { BigInteger(1, jniGetHeightOfLongestChain(it)) }
+
+    override fun destroy() { /* no-op, no method in FFI for destroy */
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITariUtxo.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITariUtxo.kt
@@ -6,6 +6,7 @@ class FFITariUtxo(pointer: FFIPointer) : FFIBase() {
     var value: Long = -1
     var minedHeight: Long = -1
     var minedTimestamp: Long = -1
+    var lockHeight: Long = -1
     var status: Byte = -1
 
     private external fun jniLoadData()

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITariVector.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITariVector.kt
@@ -14,10 +14,10 @@ class FFITariVector(pointer: FFIPointer) : FFIBase() {
     init {
         this.pointer = pointer
         jniLoadData()
-        val vectorTag = TariVectorTag.values().firstOrNull { it.value == tag }
+        val vectorTag = TariVectorTag.entries.firstOrNull { it.value == tag }
         for (i in 0 until len) {
             val newItemPointer = jniGetItemAt(i.toInt())
-            when(vectorTag) {
+            when (vectorTag) {
                 TariVectorTag.Utxo -> itemsList.add(FFITariUtxo(newItemPointer))
                 TariVectorTag.U64 -> longs.add(newItemPointer)
                 else -> Unit

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITxStatus.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITxStatus.kt
@@ -47,11 +47,12 @@ enum class FFITxStatus {
     COINBASE,
     MINED_CONFIRMED,
     REJECTED,
-    FAUX_UNCONFIRMED,
-    FAUX_CONFIRMED,
+    ONE_SIDED_UNCONFIRMED,
+    ONE_SIDED_CONFIRMED,
     QUEUED,
     COINBASE_UNCONFIRMED,
     COINBASE_CONFIRMED,
+    COINBASE_NOT_IN_BLOCKCHAIN,
     UNKNOWN;
 
     companion object {
@@ -66,12 +67,13 @@ enum class FFITxStatus {
                 5 -> COINBASE
                 6 -> MINED_CONFIRMED
                 7 -> REJECTED
-                8 -> FAUX_UNCONFIRMED
-                9 -> FAUX_CONFIRMED
+                8 -> ONE_SIDED_UNCONFIRMED
+                9 -> ONE_SIDED_CONFIRMED
                 10 -> QUEUED
                 11 -> COINBASE_UNCONFIRMED
                 12 -> COINBASE_CONFIRMED
-                13 -> UNKNOWN
+                13 -> COINBASE_NOT_IN_BLOCKCHAIN
+                14 -> UNKNOWN
                 else -> throw FFIException(message = "Unexpected status: $status")
             }
         }

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -36,11 +36,23 @@ import com.tari.android.wallet.BuildConfig
 import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
 import com.tari.android.wallet.data.sharedPrefs.network.NetworkRepository
 import com.tari.android.wallet.data.sharedPrefs.security.SecurityPrefRepository
-import com.tari.android.wallet.model.*
+import com.tari.android.wallet.model.BalanceInfo
+import com.tari.android.wallet.model.CancelledTx
+import com.tari.android.wallet.model.CompletedTx
+import com.tari.android.wallet.model.PendingInboundTx
+import com.tari.android.wallet.model.PendingOutboundTx
+import com.tari.android.wallet.model.PublicKey
+import com.tari.android.wallet.model.TariCoinPreview
+import com.tari.android.wallet.model.TariUnblindedOutput
+import com.tari.android.wallet.model.TariVector
+import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.recovery.WalletRestorationResult
 import com.tari.android.wallet.service.seedPhrase.SeedPhraseRepository
 import com.tari.android.wallet.util.Constants
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import java.math.BigInteger
 import java.util.concurrent.atomic.AtomicReference
 
@@ -50,6 +62,7 @@ import java.util.concurrent.atomic.AtomicReference
  * @author The Tari Development Team
  */
 
+@Suppress("MemberVisibilityCanBePrivate")
 class FFIWallet(
     private val sharedPrefsRepository: SharedPrefsRepository,
     private val securityPrefRepository: SecurityPrefRepository,
@@ -114,6 +127,8 @@ class FFIWallet(
         callbackTransactionValidationCompleteSig: String,
         callbackConnectivityStatus: String,
         callbackConnectivityStatusSig: String,
+        callbackBaseNodeStatusStatus: String,
+        callbackBaseNodeStatusSig: String,
         libError: FFIError
     )
 
@@ -269,6 +284,7 @@ class FFIWallet(
                 this::onBalanceUpdated.name, "(J)V",
                 this::onTxValidationComplete.name, "([B[B)V",
                 this::onConnectivityStatus.name, "([B)V",
+                this::onBaseNodeStatus.name, "(J)V",
                 error
             )
         } catch (e: Throwable) {
@@ -317,7 +333,6 @@ class FFIWallet(
 
     fun cancelPendingTx(id: BigInteger): Boolean = runWithError { jniCancelPendingTx(id.toString(), it) }
 
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxReceived(pendingInboundTxPtr: FFIPointer) {
         val tx = FFIPendingInboundTx(pendingInboundTxPtr)
         logger.i("Tx received ${tx.getId()}")
@@ -328,7 +343,6 @@ class FFIWallet(
     /**
      * This callback function cannot be private due to JNI behaviour
      */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxReplyReceived(txPointer: FFIPointer) {
         val tx = FFICompletedTx(txPointer)
         logger.i("Tx reply received ${tx.getId()}")
@@ -336,10 +350,6 @@ class FFIWallet(
         localScope.launch { listener?.onTxReplyReceived(pendingOutboundTx) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxFinalized(completedTx: FFIPointer) {
         val tx = FFICompletedTx(completedTx)
         logger.i("Tx finalized ${tx.getId()}")
@@ -347,10 +357,6 @@ class FFIWallet(
         localScope.launch { listener?.onTxFinalized(pendingInboundTx) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxBroadcast(completedTxPtr: FFIPointer) {
         val tx = FFICompletedTx(completedTxPtr)
         logger.i("Tx broadcast ${tx.getId()}")
@@ -367,20 +373,12 @@ class FFIWallet(
         }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxMined(completedTxPtr: FFIPointer) {
         val completed = CompletedTx(completedTxPtr)
         logger.i("Tx mined & confirmed ${completed.id}")
         localScope.launch { listener?.onTxMined(completed) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxMinedUnconfirmed(completedTxPtr: FFIPointer, confirmationCountBytes: ByteArray) {
         val confirmationCount = BigInteger(1, confirmationCountBytes).toInt()
         val completed = CompletedTx(completedTxPtr)
@@ -388,20 +386,18 @@ class FFIWallet(
         localScope.launch { listener?.onTxMinedUnconfirmed(completed, confirmationCount) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxFauxConfirmed(completedTxPtr: FFIPointer) {
         val completed = CompletedTx(completedTxPtr)
         logger.i("Tx faux confirmed ${completed.id}")
         localScope.launch { listener?.onTxMined(completed) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
+    fun onBaseNodeStatus(baseNodeStatePointer: FFIPointer) {
+        val baseNodeState = FFITariBaseNodeState(baseNodeStatePointer)
+        logger.i("Base node state updated (height of the longest chain is ${baseNodeState.getHeightOfLongestChain()})")
+        localScope.launch { listener?.onBaseNodeStateChanged(baseNodeState) }
+    }
+
     fun onTxFauxUnconfirmed(completedTxPtr: FFIPointer, confirmationCountBytes: ByteArray) {
         val confirmationCount = BigInteger(1, confirmationCountBytes).toInt()
         val completed = CompletedTx(completedTxPtr)
@@ -409,20 +405,12 @@ class FFIWallet(
         localScope.launch { listener?.onTxMinedUnconfirmed(completed, confirmationCount) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onDirectSendResult(bytes: ByteArray, pointer: FFIPointer) {
         val txId = BigInteger(1, bytes)
         logger.i("Tx direct send result $txId")
         localScope.launch { listener?.onDirectSendResult(txId, FFITransactionSendStatus(pointer).getStatus()) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxCancelled(completedTx: FFIPointer, rejectionReason: ByteArray) {
         val rejectionReasonInt = BigInteger(1, rejectionReason).toInt()
         val tx = FFICompletedTx(completedTx)
@@ -433,53 +421,34 @@ class FFIWallet(
         }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onConnectivityStatus(bytes: ByteArray) {
         val connectivityStatus = BigInteger(1, bytes)
         localScope.launch { listener?.onConnectivityStatus(connectivityStatus.toInt()) }
         logger.i("ConnectivityStatus is [$connectivityStatus]")
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onBalanceUpdated(ptr: FFIPointer) {
         logger.i("Balance Updated")
         val balance = FFIBalance(ptr).runWithDestroy { BalanceInfo(it.getAvailable(), it.getIncoming(), it.getOutgoing(), it.getTimeLocked()) }
         localScope.launch { listener?.onBalanceUpdated(balance) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTXOValidationComplete(bytes: ByteArray, statusBytes: ByteArray) {
         val requestId = BigInteger(1, bytes)
         val statusInteger = BigInteger(1, statusBytes).toInt()
-        val status = TransactionValidationStatus.values().firstOrNull { it.value == statusInteger } ?: return
+        val status = TransactionValidationStatus.entries.firstOrNull { it.value == statusInteger } ?: return
         logger.i("TXO validation [$requestId] complete. Result: $status")
         localScope.launch { listener?.onTXOValidationComplete(requestId, status) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onTxValidationComplete(requestIdBytes: ByteArray, statusBytes: ByteArray) {
         val requestId = BigInteger(1, requestIdBytes)
         val statusInteger = BigInteger(1, statusBytes).toInt()
-        val status = TransactionValidationStatus.values().firstOrNull { it.value == statusInteger } ?: return
+        val status = TransactionValidationStatus.entries.firstOrNull { it.value == statusInteger } ?: return
         logger.i("Tx validation [$requestId] complete. Result: $status")
         localScope.launch { listener?.onTxValidationComplete(requestId, status) }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
     @Suppress("MemberVisibilityCanBePrivate", "UNUSED_PARAMETER")
     fun onContactLivenessDataUpdated(livenessUpdate: FFIPointer) {
         logger.i("OnContactLivenessDataUpdated")
@@ -573,10 +542,6 @@ class FFIWallet(
         }
     }
 
-    /**
-     * This callback function cannot be private due to JNI behaviour.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
     fun onWalletRecovery(event: Int, firstArg: ByteArray, secondArg: ByteArray) {
         val result = WalletRestorationResult.create(event, firstArg, secondArg)
         logger.i("Wallet restored with $result")

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWalletListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWalletListener.kt
@@ -57,4 +57,5 @@ interface FFIWalletListener {
     fun onBalanceUpdated(balanceInfo: BalanceInfo)
     fun onConnectivityStatus(status: Int)
     fun onWalletRestoration(result: WalletRestorationResult)
+    fun onBaseNodeStateChanged(baseNodeState: FFITariBaseNodeState)
 }

--- a/app/src/main/java/com/tari/android/wallet/model/BalanceInfo.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/BalanceInfo.kt
@@ -49,5 +49,5 @@ data class BalanceInfo(
     val timeLockedBalance: MicroTari = 0.toMicroTari(),
 ) : Parcelable {
     val totalBalance: MicroTari
-        get() = availableBalance + pendingIncomingBalance
+        get() = availableBalance + pendingIncomingBalance + timeLockedBalance
 }

--- a/app/src/main/java/com/tari/android/wallet/model/CompletedTransactionKernel.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/CompletedTransactionKernel.kt
@@ -1,3 +1,11 @@
 package com.tari.android.wallet.model
 
-class CompletedTransactionKernel(val excess: String, val publicNonce: String, val signature: String)
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CompletedTransactionKernel(
+    val excess: String,
+    val publicNonce: String,
+    val signature: String,
+) : Parcelable

--- a/app/src/main/java/com/tari/android/wallet/model/PendingInboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/PendingInboundTx.kt
@@ -32,12 +32,11 @@
  */
 package com.tari.android.wallet.model
 
-import android.os.Parcel
 import android.os.Parcelable
+import com.tari.android.wallet.extension.toMicroTari
 import com.tari.android.wallet.ffi.FFICompletedTx
 import com.tari.android.wallet.ffi.FFIPendingInboundTx
-import com.tari.android.wallet.ui.extension.readP
-import com.tari.android.wallet.ui.extension.readS
+import kotlinx.parcelize.Parcelize
 import java.math.BigInteger
 
 /**
@@ -45,76 +44,36 @@ import java.math.BigInteger
  *
  * @author The Tari Development Team
  */
-class PendingInboundTx() : Tx(), Parcelable {
+@Parcelize
+data class PendingInboundTx(
+    override val id: BigInteger = 0.toBigInteger(),
+    override val direction: Direction = Direction.INBOUND,
+    override val amount: MicroTari = 0.toMicroTari(),
+    override val timestamp: BigInteger = 0.toBigInteger(),
+    override val message: String = "",
+    override val status: TxStatus = TxStatus.PENDING,
+    override val tariContact: TariContact = TariContact(),
+) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
 
-    constructor(tx: FFICompletedTx) : this() {
-        this.id = tx.getId()
-        this.direction = tx.getDirection()
-        this.tariContact = tx.getContact()
-        this.amount = MicroTari(tx.getAmount())
-        this.timestamp = tx.getTimestamp()
-        this.message = tx.getMessage()
-        this.status = TxStatus.map(tx.getStatus())
-        tx.destroy()
-    }
+    constructor(tx: FFICompletedTx) : this(
+        id = tx.getId(),
+        direction = tx.getDirection(),
+        tariContact = tx.getContact(),
+        amount = tx.getAmount().toMicroTari(),
+        timestamp = tx.getTimestamp(),
+        message = tx.getMessage(),
+        status = TxStatus.map(tx.getStatus()),
+    )
 
-    constructor(tx: FFIPendingInboundTx) : this() {
-        this.id = tx.getId()
-        this.direction = tx.getDirection()
-        this.tariContact = tx.getContact()
-        this.amount = MicroTari(tx.getAmount())
-        this.timestamp = tx.getTimestamp()
-        this.message = tx.getMessage()
-        this.status = TxStatus.map(tx.getStatus())
-        tx.destroy()
-    }
+    constructor(tx: FFIPendingInboundTx) : this(
+        id = tx.getId(),
+        direction = tx.getDirection(),
+        tariContact = tx.getContact(),
+        amount = MicroTari(tx.getAmount()),
+        timestamp = tx.getTimestamp(),
+        message = tx.getMessage(),
+        status = TxStatus.map(tx.getStatus()),
+    )
 
-    override fun toString(): String {
-        return "PendingInboundTx(status=$status) ${super.toString()}"
-    }
-
-    // region Parcelable
-
-    constructor(parcel: Parcel) : this() {
-        readFromParcel(parcel)
-    }
-
-    companion object CREATOR : Parcelable.Creator<PendingInboundTx> {
-
-        override fun createFromParcel(parcel: Parcel): PendingInboundTx {
-            return PendingInboundTx(parcel)
-        }
-
-        override fun newArray(size: Int): Array<PendingInboundTx> {
-            return Array(size) { PendingInboundTx() }
-        }
-    }
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeSerializable(id)
-        parcel.writeSerializable(direction)
-        parcel.writeSerializable(tariContact.javaClass)
-        parcel.writeParcelable(tariContact, flags)
-        parcel.writeParcelable(amount, flags)
-        parcel.writeSerializable(timestamp)
-        parcel.writeString(message)
-        parcel.writeSerializable(status)
-    }
-
-    private fun readFromParcel(inParcel: Parcel) {
-        id = inParcel.readS(BigInteger::class.java)
-        direction = inParcel.readS(Direction::class.java)
-        tariContact = inParcel.readP(TariContact::class.java)
-        amount = inParcel.readP(MicroTari::class.java)
-        timestamp = inParcel.readS(BigInteger::class.java)
-        message = inParcel.readString().orEmpty()
-        status = inParcel.readS(TxStatus::class.java)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    // endregion
-
+    override fun toString() = "PendingInboundTx(status=$status) ${super.toString()}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/PendingOutboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/PendingOutboundTx.kt
@@ -32,12 +32,11 @@
  */
 package com.tari.android.wallet.model
 
-import android.os.Parcel
 import android.os.Parcelable
+import com.tari.android.wallet.extension.toMicroTari
 import com.tari.android.wallet.ffi.FFICompletedTx
 import com.tari.android.wallet.ffi.FFIPendingOutboundTx
-import com.tari.android.wallet.ui.extension.readP
-import com.tari.android.wallet.ui.extension.readS
+import kotlinx.parcelize.Parcelize
 import java.math.BigInteger
 
 /**
@@ -45,82 +44,39 @@ import java.math.BigInteger
  *
  * @author The Tari Development Team
  */
-class PendingOutboundTx() : Tx(), Parcelable {
+@Parcelize
+data class PendingOutboundTx(
+    override val id: BigInteger = 0.toBigInteger(),
+    override val direction: Direction = Direction.INBOUND,
+    override val amount: MicroTari = 0.toMicroTari(),
+    override val timestamp: BigInteger = 0.toBigInteger(),
+    override val message: String = "",
+    override val status: TxStatus = TxStatus.PENDING,
+    override val tariContact: TariContact = TariContact(),
+    val fee: MicroTari = 0.toMicroTari(),
+) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
 
-    var fee = MicroTari(BigInteger("0"))
+    constructor(tx: FFICompletedTx) : this(
+        id = tx.getId(),
+        direction = tx.getDirection(),
+        tariContact = tx.getContact(),
+        amount = tx.getAmount().toMicroTari(),
+        fee = tx.getFee().toMicroTari(),
+        timestamp = tx.getTimestamp(),
+        message = tx.getMessage(),
+        status = TxStatus.map(tx.getStatus()),
+    )
 
-    constructor(tx: FFICompletedTx) : this() {
-        this.id = tx.getId()
-        this.direction = tx.getDirection()
-        this.tariContact = tx.getContact()
-        this.amount = MicroTari(tx.getAmount())
-        this.fee = MicroTari(tx.getFee())
-        this.timestamp = tx.getTimestamp()
-        this.message = tx.getMessage()
-        this.status = TxStatus.map(tx.getStatus())
-        tx.destroy()
-    }
+    constructor(tx: FFIPendingOutboundTx) : this(
+        id = tx.getId(),
+        direction = tx.getDirection(),
+        tariContact = tx.getContact(),
+        amount = MicroTari(tx.getAmount()),
+        fee = MicroTari(tx.getFee()),
+        timestamp = tx.getTimestamp(),
+        message = tx.getMessage(),
+        status = TxStatus.map(tx.getStatus()),
+    )
 
-    constructor(tx: FFIPendingOutboundTx) : this() {
-        this.id = tx.getId()
-        this.direction = tx.getDirection()
-        this.tariContact = tx.getContact()
-        this.amount = MicroTari(tx.getAmount())
-        this.fee = MicroTari(tx.getFee())
-        this.timestamp = tx.getTimestamp()
-        this.message = tx.getMessage()
-        this.status = TxStatus.map(tx.getStatus())
-        tx.destroy()
-    }
-
-    override fun toString(): String {
-        return "PendingOutboundTx(fee=$fee, status=$status) ${super.toString()}"
-    }
-
-    // region Parcelable
-
-    constructor(parcel: Parcel) : this() {
-        readFromParcel(parcel)
-    }
-
-    companion object CREATOR : Parcelable.Creator<PendingOutboundTx> {
-
-        override fun createFromParcel(parcel: Parcel): PendingOutboundTx {
-            return PendingOutboundTx(parcel)
-        }
-
-        override fun newArray(size: Int): Array<PendingOutboundTx> {
-            return Array(size) { PendingOutboundTx() }
-        }
-    }
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeSerializable(id)
-        parcel.writeSerializable(direction)
-        parcel.writeSerializable(tariContact.javaClass)
-        parcel.writeParcelable(tariContact, flags)
-        parcel.writeParcelable(amount, flags)
-        parcel.writeParcelable(fee, flags)
-        parcel.writeSerializable(timestamp)
-        parcel.writeString(message)
-        parcel.writeSerializable(status)
-    }
-
-    private fun readFromParcel(inParcel: Parcel) {
-        id = inParcel.readS(BigInteger::class.java)
-        direction = inParcel.readS(Direction::class.java)
-        tariContact = inParcel.readP(TariContact::class.java)
-        amount = inParcel.readP(MicroTari::class.java)
-        fee = inParcel.readP(MicroTari::class.java)
-        timestamp = inParcel.readS(BigInteger::class.java)
-        message = inParcel.readString().orEmpty()
-        status = inParcel.readS(TxStatus::class.java)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    // endregion
-
+    override fun toString() = "PendingOutboundTx(fee=$fee, status=$status) ${super.toString()}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/TariContact.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariContact.kt
@@ -32,69 +32,22 @@
  */
 package com.tari.android.wallet.model
 
-import android.os.Parcel
 import android.os.Parcelable
-import com.tari.android.wallet.ui.extension.readP
+import kotlinx.parcelize.Parcelize
 
 /**
  * Contact is a user with an alias.
  *
  * @author The Tari Development Team
  */
-class TariContact() : Parcelable {
-
-    var walletAddress = TariWalletAddress.createWalletAddress()
-    var isFavorite: Boolean = false
-    var alias: String = ""
-
-    constructor(
-        tariWalletAddress: TariWalletAddress,
-        alias: String = "",
-        isFavorite: Boolean = false
-    ) : this() {
-        this.walletAddress = tariWalletAddress
-        this.alias = alias
-        this.isFavorite = isFavorite
-    }
+@Parcelize
+class TariContact(
+    val walletAddress: TariWalletAddress = TariWalletAddress.createWalletAddress(),
+    val alias: String = "",
+    val isFavorite: Boolean = false,
+) : Parcelable {
 
     fun filtered(text: String): Boolean = walletAddress.emojiId.contains(text, true) || alias.contains(text, true)
 
-    override fun toString(): String = "Contact(alias='$alias') ${super.toString()}"
-
-    // region Parcelable
-
-    constructor(parcel: Parcel) : this() {
-        readFromParcel(parcel)
-    }
-
-    companion object CREATOR : Parcelable.Creator<TariContact> {
-
-        override fun createFromParcel(parcel: Parcel): TariContact {
-            return TariContact(parcel)
-        }
-
-        override fun newArray(size: Int): Array<TariContact> {
-            return Array(size) { TariContact() }
-        }
-
-    }
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeParcelable(walletAddress, flags)
-        parcel.writeString(alias)
-        parcel.writeBoolean(isFavorite)
-    }
-
-    private fun readFromParcel(inParcel: Parcel) {
-        walletAddress = inParcel.readP(TariWalletAddress::class.java)
-        alias = inParcel.readString().orEmpty()
-        isFavorite = inParcel.readBoolean()
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    // endregion
-
+    override fun toString() = "Contact(alias='$alias') ${super.toString()}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/TariUtxo.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariUtxo.kt
@@ -1,56 +1,26 @@
 package com.tari.android.wallet.model
 
-import android.os.Parcel
 import android.os.Parcelable
 import com.tari.android.wallet.ffi.FFITariUtxo
-import com.tari.android.wallet.ui.extension.readP
+import kotlinx.parcelize.Parcelize
 import java.math.BigInteger
 
-class TariUtxo() : Parcelable {
+@Parcelize
+data class TariUtxo(
+    val commitment: String = "",
+    val value: MicroTari = MicroTari(BigInteger.ZERO),
+    val minedHeight: Long = -1,
+    val timestamp: Long = -1,
+    val status: UtxoStatus = UtxoStatus.Spent,
+) : Parcelable {
 
-    var commitment: String = ""
-    var value: MicroTari = MicroTari(BigInteger.ZERO)
-    var minedHeight: Long = -1
-    var timestamp: Long = -1
-    var status: UtxoStatus = UtxoStatus.Spent
-
-    constructor(parcel: Parcel) : this() {
-        commitment = parcel.readString()!!
-        value = parcel.readP(MicroTari::class.java)
-        minedHeight = parcel.readLong()
-        timestamp = parcel.readLong()
-        status = UtxoStatus.fromValue(parcel.readInt())
-    }
-
-    constructor(ffiUtxo: FFITariUtxo) : this() {
-        commitment = ffiUtxo.commitment
-        value = MicroTari(BigInteger.valueOf(ffiUtxo.value))
-        minedHeight = ffiUtxo.minedHeight
-        timestamp = ffiUtxo.minedTimestamp
-        status = UtxoStatus.fromValue(ffiUtxo.status.toInt())
-    }
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeString(commitment)
-        parcel.writeParcelable(value, flags)
-        parcel.writeLong(minedHeight)
-        parcel.writeLong(timestamp)
-        parcel.writeInt(status.value)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    companion object CREATOR : Parcelable.Creator<TariUtxo> {
-        override fun createFromParcel(parcel: Parcel): TariUtxo {
-            return TariUtxo(parcel)
-        }
-
-        override fun newArray(size: Int): Array<TariUtxo?> {
-            return arrayOfNulls(size)
-        }
-    }
+    constructor(ffiUtxo: FFITariUtxo) : this(
+        commitment = ffiUtxo.commitment,
+        value = MicroTari(BigInteger.valueOf(ffiUtxo.value)),
+        minedHeight = ffiUtxo.minedHeight,
+        timestamp = ffiUtxo.minedTimestamp,
+        status = UtxoStatus.fromValue(ffiUtxo.status.toInt()),
+    )
 
     enum class UtxoStatus(val value: Int) {
         Unspent(0),
@@ -67,7 +37,7 @@ class TariUtxo() : Parcelable {
         NotStored(11);
 
         companion object {
-            fun fromValue(value: Int): UtxoStatus = values().first { it.value == value }
+            fun fromValue(value: Int): UtxoStatus = entries.first { it.value == value }
         }
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/model/TariUtxo.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariUtxo.kt
@@ -11,6 +11,7 @@ data class TariUtxo(
     val value: MicroTari = MicroTari(BigInteger.ZERO),
     val minedHeight: Long = -1,
     val timestamp: Long = -1,
+    val lockHeight: Long = -1,
     val status: UtxoStatus = UtxoStatus.Spent,
 ) : Parcelable {
 
@@ -19,6 +20,7 @@ data class TariUtxo(
         value = MicroTari(BigInteger.valueOf(ffiUtxo.value)),
         minedHeight = ffiUtxo.minedHeight,
         timestamp = ffiUtxo.minedTimestamp,
+        lockHeight = ffiUtxo.lockHeight,
         status = UtxoStatus.fromValue(ffiUtxo.status.toInt()),
     )
 

--- a/app/src/main/java/com/tari/android/wallet/model/TariVector.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariVector.kt
@@ -32,52 +32,22 @@
  */
 package com.tari.android.wallet.model
 
-import android.os.Parcel
 import android.os.Parcelable
 import com.tari.android.wallet.ffi.FFITariVector
-import com.tari.android.wallet.ui.extension.readList
+import kotlinx.parcelize.Parcelize
 
-class TariVector() : Parcelable {
+@Parcelize
+data class TariVector(
+    val len: Long = -1,
+    val cap: Long = -1,
+    val itemsList: List<TariUtxo> = emptyList(),
+    val longs: List<Long> = emptyList(),
+) : Parcelable {
 
-    var len: Long = -1
-    var cap: Long = -1
-    var itemsList = mutableListOf<TariUtxo>()
-    var longs = mutableListOf<Long>()
-
-    constructor(ffiTariVector: FFITariVector) : this() {
-        len = ffiTariVector.len
-        cap = ffiTariVector.cap
-        itemsList = ffiTariVector.itemsList.map { TariUtxo(it) }.toMutableList()
-        longs = ffiTariVector.longs.toMutableList()
-    }
-
-    constructor(parcel: Parcel) : this() {
-        len = parcel.readLong()
-        cap = parcel.readLong()
-        itemsList = parcel.readList(itemsList, TariUtxo::class.java).toMutableList()
-        val longArray = longArrayOf()
-        parcel.readLongArray(longArray)
-        longs = longArray.toMutableList()
-    }
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeLong(len)
-        parcel.writeLong(cap)
-        parcel.writeParcelableList(itemsList, flags)
-        parcel.writeLongArray(longs.toLongArray())
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    companion object CREATOR : Parcelable.Creator<TariVector> {
-        override fun createFromParcel(parcel: Parcel): TariVector {
-            return TariVector(parcel)
-        }
-
-        override fun newArray(size: Int): Array<TariVector?> {
-            return arrayOfNulls(size)
-        }
-    }
+    constructor(ffiTariVector: FFITariVector) : this(
+        len = ffiTariVector.len,
+        cap = ffiTariVector.cap,
+        itemsList = ffiTariVector.itemsList.map { TariUtxo(it) },
+        longs = ffiTariVector.longs,
+    )
 }

--- a/app/src/main/java/com/tari/android/wallet/model/Tx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/Tx.kt
@@ -40,28 +40,23 @@ import java.math.BigInteger
  *
  * @author The Tari Development Team
  */
-abstract class Tx : Parcelable {
+abstract class Tx(
+    open val id: BigInteger,
+    open val direction: Direction,
+    open val amount: MicroTari,
+    open val timestamp: BigInteger,
+    open val message: String,
+    open val status: TxStatus,
+    open val tariContact: TariContact, // This is the receiver for an outbound tx and sender for an inbound tx.
+): Parcelable {
 
     enum class Direction {
         INBOUND,
         OUTBOUND
     }
 
-    var id = BigInteger("0")
-    var direction = Direction.INBOUND
-    var amount = MicroTari(BigInteger("0"))
-    var timestamp = BigInteger("0")
-    var message = ""
-    var status = TxStatus.PENDING
-
-    /**
-     * This is the receiver for an outbound tx and sender for an inbound tx.
-     */
-    var tariContact = TariContact()
-
     val isOneSided
-        get() = tariContact.walletAddress.hexString.all{ it == '0' }
+        get() = tariContact.walletAddress.hexString.all { it == '0' }
 
-    override fun toString(): String = "Tx(id=$id, direction=$direction, amount=$amount, timestamp=$timestamp, message='$message', user=$tariContact)"
-
+    override fun toString() = "Tx(id=$id, direction=$direction, amount=$amount, timestamp=$timestamp, message='$message', user=$tariContact)"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/Tx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/Tx.kt
@@ -48,7 +48,7 @@ abstract class Tx(
     open val message: String,
     open val status: TxStatus,
     open val tariContact: TariContact, // This is the receiver for an outbound tx and sender for an inbound tx.
-): Parcelable {
+) : Parcelable {
 
     enum class Direction {
         INBOUND,
@@ -56,7 +56,10 @@ abstract class Tx(
     }
 
     val isOneSided
-        get() = tariContact.walletAddress.hexString.all { it == '0' }
+        get() = status.isOneSided()
+
+    val isCoinbase
+        get() = status.isCoinbase()
 
     override fun toString() = "Tx(id=$id, direction=$direction, amount=$amount, timestamp=$timestamp, message='$message', user=$tariContact)"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/TxStatus.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TxStatus.kt
@@ -49,13 +49,22 @@ enum class TxStatus {
     COINBASE,
     MINED_CONFIRMED,
     REJECTED,
-    FAUX_UNCONFIRMED,
-    FAUX_CONFIRMED,
+    ONE_SIDED_UNCONFIRMED,
+    ONE_SIDED_CONFIRMED,
     QUEUED,
     COINBASE_UNCONFIRMED,
     COINBASE_CONFIRMED,
+    COINBASE_NOT_IN_BLOCKCHAIN,
     UNKNOWN;
-    
+
+    fun isOneSided(): Boolean {
+        return this == ONE_SIDED_CONFIRMED || this == ONE_SIDED_UNCONFIRMED
+    }
+
+    fun isCoinbase(): Boolean {
+        return this == COINBASE || this == COINBASE_UNCONFIRMED || this == COINBASE_CONFIRMED || this == COINBASE_NOT_IN_BLOCKCHAIN
+    }
+
     companion object {
         fun map(ffiStatus: FFITxStatus): TxStatus {
             return when (ffiStatus) {
@@ -68,12 +77,13 @@ enum class TxStatus {
                 FFITxStatus.COINBASE -> COINBASE
                 FFITxStatus.MINED_CONFIRMED -> MINED_CONFIRMED
                 FFITxStatus.REJECTED -> REJECTED
-                FFITxStatus.FAUX_CONFIRMED -> FAUX_CONFIRMED
-                FFITxStatus.FAUX_UNCONFIRMED -> FAUX_UNCONFIRMED
+                FFITxStatus.ONE_SIDED_CONFIRMED -> ONE_SIDED_CONFIRMED
+                FFITxStatus.ONE_SIDED_UNCONFIRMED -> ONE_SIDED_UNCONFIRMED
                 FFITxStatus.QUEUED -> QUEUED
                 FFITxStatus.COINBASE_UNCONFIRMED -> COINBASE_UNCONFIRMED
                 FFITxStatus.COINBASE_CONFIRMED -> COINBASE_CONFIRMED
-                else -> UNKNOWN
+                FFITxStatus.COINBASE_NOT_IN_BLOCKCHAIN -> COINBASE_NOT_IN_BLOCKCHAIN
+                FFITxStatus.UNKNOWN -> UNKNOWN
             }
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
@@ -7,6 +7,7 @@ import com.tari.android.wallet.application.baseNodes.BaseNodesManager
 import com.tari.android.wallet.data.sharedPrefs.baseNode.BaseNodeSharedRepository
 import com.tari.android.wallet.event.Event
 import com.tari.android.wallet.event.EventBus
+import com.tari.android.wallet.ffi.FFITariBaseNodeState
 import com.tari.android.wallet.ffi.FFIWallet
 import com.tari.android.wallet.ffi.FFIWalletListener
 import com.tari.android.wallet.ffi.TransactionValidationStatus
@@ -326,6 +327,10 @@ class FFIWalletListenerImpl(
 
     override fun onWalletRestoration(result: WalletRestorationResult) {
         EventBus.walletRestorationState.post(result)
+    }
+
+    override fun onBaseNodeStateChanged(baseNodeState: FFITariBaseNodeState) {
+        baseNodesManager.saveBaseNodeState(baseNodeState)
     }
 
     enum class ConnectivityStatus(val value: Int) {

--- a/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/FFIWalletListenerImpl.kt
@@ -73,92 +73,92 @@ class FFIWalletListenerImpl(
     val outboundTxIdsToBePushNotified = CopyOnWriteArraySet<Pair<BigInteger, String>>()
 
     override fun onTxReceived(pendingInboundTx: PendingInboundTx) {
-        pendingInboundTx.tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress)
+        val newTx = pendingInboundTx.copy(tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxReceived(pendingInboundTx))
+        EventBus.post(Event.Transaction.TxReceived(newTx))
         // manage notifications
-        postTxNotification(pendingInboundTx)
-        listeners.forEach { it.onTxReceived(pendingInboundTx) }
+        postTxNotification(newTx)
+        listeners.forEach { it.onTxReceived(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxReplyReceived(pendingOutboundTx: PendingOutboundTx) {
-        pendingOutboundTx.tariContact = getUserByWalletAddress(pendingOutboundTx.tariContact.walletAddress)
+        val newTx = pendingOutboundTx.copy(tariContact = getUserByWalletAddress(pendingOutboundTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxReplyReceived(pendingOutboundTx))
+        EventBus.post(Event.Transaction.TxReplyReceived(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxReplyReceived(pendingOutboundTx) }
+        listeners.iterator().forEach { it.onTxReplyReceived(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxFinalized(pendingInboundTx: PendingInboundTx) {
-        pendingInboundTx.tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress)
+        val newTx = pendingInboundTx.copy(tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxFinalized(pendingInboundTx))
+        EventBus.post(Event.Transaction.TxFinalized(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxFinalized(pendingInboundTx) }
+        listeners.iterator().forEach { it.onTxFinalized(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onInboundTxBroadcast(pendingInboundTx: PendingInboundTx) {
-        pendingInboundTx.tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress)
+        val newTx = pendingInboundTx.copy(tariContact = getUserByWalletAddress(pendingInboundTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.InboundTxBroadcast(pendingInboundTx))
+        EventBus.post(Event.Transaction.InboundTxBroadcast(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onInboundTxBroadcast(pendingInboundTx) }
+        listeners.iterator().forEach { it.onInboundTxBroadcast(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onOutboundTxBroadcast(pendingOutboundTx: PendingOutboundTx) {
-        pendingOutboundTx.tariContact = getUserByWalletAddress(pendingOutboundTx.tariContact.walletAddress)
+        val newTx = pendingOutboundTx.copy(tariContact = getUserByWalletAddress(pendingOutboundTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.OutboundTxBroadcast(pendingOutboundTx))
+        EventBus.post(Event.Transaction.OutboundTxBroadcast(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onOutboundTxBroadcast(pendingOutboundTx) }
+        listeners.iterator().forEach { it.onOutboundTxBroadcast(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxMined(completedTx: CompletedTx) {
-        completedTx.tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress)
+        val newTx = completedTx.copy(tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxMined(completedTx))
+        EventBus.post(Event.Transaction.TxMined(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxMined(completedTx) }
+        listeners.iterator().forEach { it.onTxMined(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxMinedUnconfirmed(completedTx: CompletedTx, confirmationCount: Int) {
-        completedTx.tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress)
+        val newTx = completedTx.copy(tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxMinedUnconfirmed(completedTx))
+        EventBus.post(Event.Transaction.TxMinedUnconfirmed(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxMinedUnconfirmed(completedTx, confirmationCount) }
+        listeners.iterator().forEach { it.onTxMinedUnconfirmed(newTx, confirmationCount) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxFauxConfirmed(completedTx: CompletedTx) {
-        completedTx.tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress)
+        val newTx = completedTx.copy(tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxFauxConfirmed(completedTx))
+        EventBus.post(Event.Transaction.TxFauxConfirmed(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxFauxConfirmed(completedTx) }
+        listeners.iterator().forEach { it.onTxFauxConfirmed(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }
 
     override fun onTxFauxUnconfirmed(completedTx: CompletedTx, confirmationCount: Int) {
-        completedTx.tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress)
+        val newTx = completedTx.copy(tariContact = getUserByWalletAddress(completedTx.tariContact.walletAddress))
         // post event to bus for the listeners
-        EventBus.post(Event.Transaction.TxFauxMinedUnconfirmed(completedTx))
+        EventBus.post(Event.Transaction.TxFauxMinedUnconfirmed(newTx))
         // notify external listeners
-        listeners.iterator().forEach { it.onTxFauxUnconfirmed(completedTx, confirmationCount) }
+        listeners.iterator().forEach { it.onTxFauxUnconfirmed(newTx, confirmationCount) }
         // schedule a backup
         backupManager.backupNow()
     }
@@ -177,16 +177,16 @@ class FFIWalletListenerImpl(
     }
 
     override fun onTxCancelled(cancelledTx: CancelledTx, rejectionReason: Int) {
-        cancelledTx.tariContact = getUserByWalletAddress(cancelledTx.tariContact.walletAddress)
+        val newTx = cancelledTx.copy(tariContact = getUserByWalletAddress(cancelledTx.tariContact.walletAddress))
         // post event to bus
-        EventBus.post(Event.Transaction.TxCancelled(cancelledTx))
+        EventBus.post(Event.Transaction.TxCancelled(newTx))
         val currentActivity = app.currentActivity
         if (cancelledTx.direction == Tx.Direction.INBOUND && !(app.isInForeground && currentActivity is HomeActivity && currentActivity.willNotifyAboutNewTx())
         ) {
-            notificationHelper.postTxCanceledNotification(cancelledTx)
+            notificationHelper.postTxCanceledNotification(newTx)
         }
         // notify external listeners
-        listeners.iterator().forEach { listener -> listener.onTxCancelled(cancelledTx) }
+        listeners.iterator().forEach { listener -> listener.onTxCancelled(newTx) }
         // schedule a backup
         backupManager.backupNow()
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/homeTransactionHistory/HomeTransactionHistoryFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/homeTransactionHistory/HomeTransactionHistoryFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.FragmentHomeContactTransactionHistoryBinding
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.ui.common.CommonFragment
@@ -15,7 +14,6 @@ import com.tari.android.wallet.ui.common.recyclerView.AdapterFactory
 import com.tari.android.wallet.ui.common.recyclerView.CommonAdapter
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
 import com.tari.android.wallet.ui.common.recyclerView.viewHolders.TitleViewHolder
-import com.tari.android.wallet.ui.component.tari.toolbar.TariToolbarActionArg
 import com.tari.android.wallet.ui.extension.setVisible
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.tx.adapter.TransactionItem
@@ -57,10 +55,6 @@ class HomeTransactionHistoryFragment : CommonFragment<FragmentHomeContactTransac
         list.adapter = adapter
         list.layoutManager = LinearLayoutManager(context)
         requestTariButton.setOnClickListener { viewModel.navigation.postValue(Navigation.AllSettingsNavigation.ToRequestTari) }
-
-        toolbar.setRightArgs(TariToolbarActionArg(icon = R.drawable.vector_wallet) {
-            viewModel.navigation.postValue(Navigation.TxListNavigation.ToUtxos)
-        })
 
         adapter.setClickListener(CommonAdapter.ItemClickListener { item ->
             if (item is TransactionItem) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/TransactionRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/TransactionRepository.kt
@@ -136,7 +136,7 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
         val items = mutableListOf<CommonViewHolderItem>()
 
         if (DebugConfig.mockTxs) {
-            items.addAll(MockDataStub.createTxList(contactsRepository, gifRepository, confirmationCount))
+            items.addAll(MockDataStub.createTxList(gifRepository, confirmationCount))
         } else {
             val minedUnconfirmedTxs = completedTxs.filter { it.status == TxStatus.MINED_UNCONFIRMED }
             val nonMinedUnconfirmedCompletedTxs = completedTxs.filter { it.status != TxStatus.MINED_UNCONFIRMED }
@@ -145,14 +145,14 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
             val pendingTxs = (pendingInboundTxs + pendingOutboundTxs + minedUnconfirmedTxs).toMutableList()
             pendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
             if (pendingTxs.isNotEmpty()) {
-                items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_pending_transactions_title), true))
+                items.add(TitleViewHolderItem(title = resourceManager.getString(R.string.home_pending_transactions_title), isFirst = true))
                 items.addAll(pendingTxs.mapIndexed { index, tx ->
                     TransactionItem(
-                        tx,
-                        contactsRepository.ffiBridge.getContactForTx(tx),
-                        index,
-                        GIFViewModel(gifRepository),
-                        confirmationCount
+                        tx = tx,
+                        contact = contactsRepository.ffiBridge.getContactForTx(tx),
+                        position = index,
+                        viewModel = GIFViewModel(gifRepository),
+                        requiredConfirmationCount = confirmationCount,
                     )
                 })
             }
@@ -161,7 +161,7 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
             val nonPendingTxs = (cancelledTxs + nonMinedUnconfirmedCompletedTxs).toMutableList()
             nonPendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
             if (nonPendingTxs.isNotEmpty()) {
-                items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_completed_transactions_title), false))
+                items.add(TitleViewHolderItem(title = resourceManager.getString(R.string.home_completed_transactions_title), isFirst = false))
                 items.addAll(nonPendingTxs.mapIndexed { index, tx ->
                     TransactionItem(
                         tx = tx,

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/TransactionRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/TransactionRepository.kt
@@ -14,10 +14,8 @@ import com.tari.android.wallet.extension.getWithError
 import com.tari.android.wallet.extension.repopulate
 import com.tari.android.wallet.model.CancelledTx
 import com.tari.android.wallet.model.CompletedTx
-import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.PendingInboundTx
 import com.tari.android.wallet.model.PendingOutboundTx
-import com.tari.android.wallet.model.TariContact
 import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.TxId
 import com.tari.android.wallet.model.TxStatus
@@ -34,7 +32,6 @@ import com.tari.android.wallet.util.MockDataStub
 import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.math.BigInteger
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -49,8 +46,8 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
     lateinit var gifRepository: GIFRepository
 
 
-    private val _list = MutableLiveData<MutableList<CommonViewHolderItem>>(mutableListOf())
-    val list: LiveData<MutableList<CommonViewHolderItem>> = _list
+    private val _list = MutableLiveData<List<CommonViewHolderItem>>(emptyList())
+    val list: LiveData<List<CommonViewHolderItem>> = _list
 
     private val _listUpdateTrigger = MediatorLiveData<Unit>()
     val listUpdateTrigger: LiveData<Unit> = _listUpdateTrigger
@@ -138,104 +135,43 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
 
         val items = mutableListOf<CommonViewHolderItem>()
 
-        val minedUnconfirmedTxs = completedTxs.filter { it.status == TxStatus.MINED_UNCONFIRMED }
-        val nonMinedUnconfirmedCompletedTxs = completedTxs.filter { it.status != TxStatus.MINED_UNCONFIRMED }
+        if (DebugConfig.mockTxs) {
+            items.addAll(MockDataStub.createTxList(contactsRepository, gifRepository, confirmationCount))
+        } else {
+            val minedUnconfirmedTxs = completedTxs.filter { it.status == TxStatus.MINED_UNCONFIRMED }
+            val nonMinedUnconfirmedCompletedTxs = completedTxs.filter { it.status != TxStatus.MINED_UNCONFIRMED }
 
-        // sort and add pending txs
-        val pendingTxs = (pendingInboundTxs + pendingOutboundTxs + minedUnconfirmedTxs).toMutableList()
-        pendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
-        if (pendingTxs.isNotEmpty()) {
-            items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_pending_transactions_title), true))
-            items.addAll(pendingTxs.mapIndexed { index, tx ->
-                TransactionItem(
-                    tx,
-                    contactsRepository.ffiBridge.getContactForTx(tx),
-                    index,
-                    GIFViewModel(gifRepository),
-                    confirmationCount
-                )
-            })
-        }
-
-        // sort and add non-pending txs
-        val nonPendingTxs = (cancelledTxs + nonMinedUnconfirmedCompletedTxs).toMutableList()
-        nonPendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
-        if (nonPendingTxs.isNotEmpty()) {
-            items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_completed_transactions_title), false))
-            items.addAll(nonPendingTxs.mapIndexed { index, tx ->
-                TransactionItem(
-                    tx,
-                    contactsRepository.ffiBridge.getContactForTx(tx),
-                    index + pendingTxs.size,
-                    GIFViewModel(gifRepository),
-                    confirmationCount
-                )
-            })
-        }
-
-        if (DebugConfig.mockedDataEnabled) {
-
-            val title = TitleViewHolderItem("Mocked Transactions", true)
-            val messageGiphy = " https://giphy.com/embed/5885nYOgBHdCw"
-
-            val item = TransactionItem(
-                CompletedTx().apply {
-                    direction = Tx.Direction.INBOUND
-                    status = TxStatus.MINED_CONFIRMED
-                    amount = MicroTari(BigInteger.valueOf(100000))
-                    fee = MicroTari(BigInteger.valueOf(1000))
-                    message = messageGiphy
-                    timestamp = BigInteger.valueOf(System.currentTimeMillis())
-                    id = BigInteger.valueOf(1)
-                    tariContact = TariContact(MockDataStub.WALLET_ADDRESS_ZERO, "test1")
-                },
-                contactsRepository.ffiBridge.getContactForTx(CompletedTx()),
-                0,
-                GIFViewModel(gifRepository),
-                confirmationCount
-            )
-
-            val tx2 = CompletedTx().apply {
-                direction = Tx.Direction.INBOUND
-                status = TxStatus.MINED_CONFIRMED
-                amount = MicroTari(BigInteger.valueOf(110000))
-                fee = MicroTari(BigInteger.valueOf(1000))
-                timestamp = BigInteger.valueOf(System.currentTimeMillis())
-                id = BigInteger.valueOf(1)
-                message = messageGiphy
-                tariContact = TariContact(MockDataStub.WALLET_ADDRESS_ZERO, "test2")
+            // sort and add pending txs
+            val pendingTxs = (pendingInboundTxs + pendingOutboundTxs + minedUnconfirmedTxs).toMutableList()
+            pendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
+            if (pendingTxs.isNotEmpty()) {
+                items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_pending_transactions_title), true))
+                items.addAll(pendingTxs.mapIndexed { index, tx ->
+                    TransactionItem(
+                        tx,
+                        contactsRepository.ffiBridge.getContactForTx(tx),
+                        index,
+                        GIFViewModel(gifRepository),
+                        confirmationCount
+                    )
+                })
             }
-            val item2 = TransactionItem(
-                tx2,
-                contactsRepository.ffiBridge.getContactForTx(tx2),
-                0,
-                GIFViewModel(gifRepository),
-                confirmationCount
-            )
 
-            val tx3 = CompletedTx().apply {
-                direction = Tx.Direction.INBOUND
-                status = TxStatus.MINED_CONFIRMED
-                message = messageGiphy
-                amount = MicroTari(BigInteger.valueOf(111000))
-                fee = MicroTari(BigInteger.valueOf(1000))
-                timestamp = BigInteger.valueOf(System.currentTimeMillis())
-                id = BigInteger.valueOf(1)
-                tariContact = TariContact(MockDataStub.WALLET_ADDRESS, "test3")
-
+            // sort and add non-pending txs
+            val nonPendingTxs = (cancelledTxs + nonMinedUnconfirmedCompletedTxs).toMutableList()
+            nonPendingTxs.sortWith(compareByDescending(Tx::timestamp).thenByDescending { it.id })
+            if (nonPendingTxs.isNotEmpty()) {
+                items.add(TitleViewHolderItem(resourceManager.getString(R.string.home_completed_transactions_title), false))
+                items.addAll(nonPendingTxs.mapIndexed { index, tx ->
+                    TransactionItem(
+                        tx = tx,
+                        contact = contactsRepository.ffiBridge.getContactForTx(tx),
+                        position = index + pendingTxs.size,
+                        viewModel = GIFViewModel(gifRepository),
+                        requiredConfirmationCount = confirmationCount,
+                    )
+                })
             }
-            val item3 = TransactionItem(
-                tx3,
-                contactsRepository.ffiBridge.getContactForTx(tx3),
-                0,
-                GIFViewModel(gifRepository),
-                confirmationCount
-            )
-
-            items.add(title)
-            items.add(item)
-            items.add(item2)
-            items.add(item3)
         }
 
         _list.postValue(items)
@@ -247,21 +183,41 @@ class TransactionRepository @Inject constructor() : CommonViewModel() {
     }
 
     private fun onTxReplyReceived(tx: PendingOutboundTx) {
-        pendingOutboundTxs.firstOrNull { it.id == tx.id }?.status = tx.status
-        _listUpdateTrigger.postValue(Unit)
+        val index = pendingOutboundTxs.indexOfFirst { it.id == tx.id }
+        if (index != -1) {
+            pendingOutboundTxs[index] = pendingOutboundTxs[index].copy(status = tx.status)
+            _listUpdateTrigger.postValue(Unit)
+        } else {
+            logger.i("onTxReplyReceived: tx ${tx.id} not found in pendingOutboundTxs")
+        }
     }
 
     private fun onTxFinalized(tx: PendingInboundTx) {
-        pendingInboundTxs.firstOrNull { it.id == tx.id }?.status = tx.status
-        _listUpdateTrigger.postValue(Unit)
+        val index = pendingInboundTxs.indexOfFirst { it.id == tx.id }
+        if (index != -1) {
+            pendingInboundTxs[index] = pendingInboundTxs[index].copy(status = tx.status)
+            _listUpdateTrigger.postValue(Unit)
+        } else {
+            logger.i("onTxFinalized: tx ${tx.id} not found in pendingInboundTxs")
+        }
     }
 
     private fun onInboundTxBroadcast(tx: PendingInboundTx) {
-        pendingInboundTxs.firstOrNull { it.id == tx.id }?.status = TxStatus.BROADCAST
+        val index = pendingInboundTxs.indexOfFirst { it.id == tx.id }
+        if (index != -1) {
+            pendingInboundTxs[index] = pendingInboundTxs[index].copy(status = TxStatus.BROADCAST)
+        } else {
+            logger.i("onInboundTxBroadcast: tx ${tx.id} not found in pendingInboundTxs")
+        }
     }
 
     private fun onOutboundTxBroadcast(tx: PendingOutboundTx) {
-        pendingOutboundTxs.firstOrNull { it.id == tx.id }?.status = TxStatus.BROADCAST
+        val index = pendingOutboundTxs.indexOfFirst { it.id == tx.id }
+        if (index != -1) {
+            pendingOutboundTxs[index] = pendingOutboundTxs[index].copy(status = TxStatus.BROADCAST)
+        } else {
+            logger.i("onOutboundTxBroadcast: tx ${tx.id} not found in pendingOutboundTxs")
+        }
     }
 
     private fun onTxMinedUnconfirmed(tx: CompletedTx) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
@@ -45,6 +45,13 @@ class TxListHomeViewHolder(view: ItemHomeTxListBinding) : CommonViewHolder<Trans
         val txUser = tx.tariContact
         // display contact name or emoji id
         when {
+            tx.isCoinbase -> {
+                ui.participantTextView1.visible()
+                ui.participantTextView2.gone()
+                ui.participantEmojiIdView.gone()
+                ui.participantTextView1.text = string(R.string.tx_details_coinbase_placeholder)
+            }
+
             tx.isOneSided -> {
                 val title = string(R.string.tx_list_someone) + " " + string(R.string.tx_list_paid_you)
                 ui.participantTextView1.visible()

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
@@ -68,8 +68,11 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
         val avatar = (contact?.contact as? MergedContactDto)?.phoneContactDto?.avatar.orEmpty()
         if (avatar.isEmpty()) {
             // display first emoji of emoji id
-            val firstEmoji =
-                if (tx.isOneSided) string(R.string.tx_list_emoji_one_side_payment_placeholder) else tx.tariContact.walletAddress.emojiId.extractEmojis()[0]
+            val firstEmoji = when {
+                tx.isCoinbase -> string(R.string.tx_list_emoji_coinbase_payment_placeholder)
+                tx.isOneSided -> string(R.string.tx_list_emoji_one_side_payment_placeholder)
+                else -> tx.tariContact.walletAddress.emojiId.extractEmojis()[0]
+            }
             ui.firstEmojiTextView.text = firstEmoji
         } else {
             // display avatar
@@ -83,6 +86,13 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
         val txUser = tx.tariContact
         // display contact name or emoji id
         when {
+            tx.isCoinbase -> {
+                ui.participantTextView1.visible()
+                ui.participantTextView2.gone()
+                ui.participantEmojiIdView.root.gone()
+                ui.participantTextView1.text = string(R.string.tx_details_coinbase_placeholder)
+            }
+
             tx.isOneSided -> {
                 val title = string(R.string.tx_list_someone) + " " + string(R.string.tx_list_paid_you)
                 ui.participantTextView1.visible()

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
@@ -73,10 +73,10 @@ import com.tari.android.wallet.model.Tx.Direction.OUTBOUND
 import com.tari.android.wallet.model.TxId
 import com.tari.android.wallet.model.TxNote
 import com.tari.android.wallet.model.TxStatus.COINBASE
-import com.tari.android.wallet.model.TxStatus.FAUX_CONFIRMED
-import com.tari.android.wallet.model.TxStatus.FAUX_UNCONFIRMED
 import com.tari.android.wallet.model.TxStatus.IMPORTED
 import com.tari.android.wallet.model.TxStatus.MINED_CONFIRMED
+import com.tari.android.wallet.model.TxStatus.ONE_SIDED_CONFIRMED
+import com.tari.android.wallet.model.TxStatus.ONE_SIDED_UNCONFIRMED
 import com.tari.android.wallet.model.TxStatus.PENDING
 import com.tari.android.wallet.ui.animation.collapseAndHideAnimation
 import com.tari.android.wallet.ui.common.CommonFragment
@@ -210,7 +210,8 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
     }
 
     private fun bindTxData(tx: Tx) {
-        ui.userContainer.setVisible(!tx.isOneSided)
+        ui.userContainer.setVisible(!tx.isOneSided && !tx.isCoinbase)
+        ui.contactContainerView.setVisible(!tx.isOneSided && !tx.isCoinbase)
 
         setTxStatusData(tx)
         setTxMetaData(tx)
@@ -284,7 +285,7 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
             tx is CancelledTx -> ""
             state == TxState(INBOUND, PENDING) -> string(tx_detail_waiting_for_sender_to_complete)
             state == TxState(OUTBOUND, PENDING) -> string(tx_detail_waiting_for_recipient)
-            state == TxState(INBOUND, FAUX_UNCONFIRMED) || state == TxState(INBOUND, FAUX_CONFIRMED) -> ""
+            state == TxState(INBOUND, ONE_SIDED_UNCONFIRMED) || state == TxState(INBOUND, ONE_SIDED_CONFIRMED) -> ""
             state.status != MINED_CONFIRMED && state.status != COINBASE -> string(
                 tx_detail_completing_final_processing,
                 if (tx is CompletedTx) tx.confirmationCount.toInt() + 1 else 1,

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTextListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTextListViewHolder.kt
@@ -14,13 +14,13 @@ class UtxosTextListViewHolder(view: ItemUtxosTextBinding) : CommonViewHolder<Utx
 
         val amountText = item.amount + " XTR"
         ui.amount.text = amountText
-        val statusStr = if (item.isShowingStatus) itemView.context.getString(item.status!!.text) else ""
-        val dateStr = if (item.isShowDate) " | ${item.formattedDate} | ${item.formattedTime}" else ""
+        val statusStr = if (item.showStatus) itemView.context.getString(item.status!!.text) else ""
+        val dateStr = if (item.showDate) " | ${item.formattedDate} | ${item.formattedTime}" else ""
         val additionalDataText = statusStr + dateStr
         ui.additionalData.text = additionalDataText
         ui.hash.text = item.source.commitment
 
-        val drawable = if (item.isShowingStatus) ContextCompat.getDrawable(itemView.context, item.status!!.textIcon) else null
+        val drawable = if (item.showStatus) ContextCompat.getDrawable(itemView.context, item.status!!.textIcon) else null
         ui.additionalData.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
 
         setCheckedSilently(item)
@@ -29,7 +29,7 @@ class UtxosTextListViewHolder(view: ItemUtxosTextBinding) : CommonViewHolder<Utx
         ui.checkedState.setVisible(item.selectionState.value)
         item.selectionState.beforeTextChangeListener = { _, newValue -> ui.checkedState.setVisible(newValue) }
 
-        ui.root.alpha = if (item.status == UtxosStatus.Mined) 1.0F else 0.4F
+        ui.root.alpha = if (item.enabled) 1.0F else 0.4F
     }
 
     private fun setCheckedSilently(item: UtxosViewHolderItem) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTileListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTileListViewHolder.kt
@@ -27,10 +27,10 @@ class UtxosTileListViewHolder(view: ItemUtxosTileBinding) : CommonViewHolder<Utx
         ui.amount.text = amount
         ui.amountDecimal.text = decimal
         ui.dateTime.text = item.formattedDate
-        ui.dateTime.setVisible(item.isShowDate)
+        ui.dateTime.setVisible(item.showDate)
 
-        ui.status.setVisible(item.isShowingStatus)
-        if (item.isShowingStatus) {
+        ui.status.setVisible(item.showStatus)
+        if (item.showStatus) {
             ui.status.setImageResource(item.status!!.icon)
         }
 
@@ -43,7 +43,7 @@ class UtxosTileListViewHolder(view: ItemUtxosTileBinding) : CommonViewHolder<Utx
         shapeDrawable.setColor(newColor.toArgb())
         ui.colorContainer.background = shapeDrawable
 
-        ui.root.alpha = if (item.status == UtxosStatus.Mined) 1.0F else 0.4F
+        ui.rootCard.alpha = if (item.enabled) 1.0F else 0.4F
 
         setCheckedSilently(item)
         item.checked.afterTileChangeListener = { _, _ -> setCheckedSilently(item) }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosViewHolderItem.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosViewHolderItem.kt
@@ -4,45 +4,45 @@ import com.tari.android.wallet.model.TariUtxo
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
 import com.tari.android.wallet.ui.dialog.ChangedPropertyDelegate
 import com.tari.android.wallet.util.WalletUtil
-import org.joda.time.DateTime
 import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
 
-class UtxosViewHolderItem(val source: TariUtxo, var height: Int = 0) : CommonViewHolderItem() {
+class UtxosViewHolderItem(val source: TariUtxo, networkBlockHeight: Long) : CommonViewHolderItem() {
 
+    val amount = WalletUtil.amountFormatter.format(source.value.tariValue)!!
+    val formattedDate: String = SimpleDateFormat("d MMM, y", Locale.getDefault()).format(Date(source.timestamp))
+    val formattedTime: String = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(source.timestamp))
+    val status: UtxosStatus? = when (source.status) {
+        TariUtxo.UtxoStatus.Unspent -> UtxosStatus.Mined
+        TariUtxo.UtxoStatus.EncumberedToBeReceived,
+        TariUtxo.UtxoStatus.UnspentMinedUnconfirmed -> UtxosStatus.Confirmed
+
+        else -> null
+    }
+    val immature: Boolean = source.lockHeight > networkBlockHeight
+
+    var height: Int = 0
     var selectionState = ChangedPropertyDelegate(false)
     var checked = ChangedPropertyDelegate(false)
 
-    val isShowDate: Boolean = source.timestamp != 0L
-    val isShowMinedHeight: Boolean = source.minedHeight != 0L
-    val amount = WalletUtil.amountFormatter.format(source.value.tariValue)!!
-    val formattedDate: String
-    val formattedTime: String
-    val status: UtxosStatus?
-    val isSelectable: Boolean
-    val isShowingStatus: Boolean
-
-    init {
-        val dateTime = DateTime.now().withMillis(source.timestamp)
-        val format = SimpleDateFormat("HH:mm", Locale.getDefault())
-        formattedDate = format.format(dateTime.toDate()).split(" ")[0]
-        formattedTime = dateTime.toString()
-
-        status = when (source.status) {
-            TariUtxo.UtxoStatus.Unspent -> UtxosStatus.Mined
-            TariUtxo.UtxoStatus.EncumberedToBeReceived,
-            TariUtxo.UtxoStatus.UnspentMinedUnconfirmed -> UtxosStatus.Confirmed
-
-            else -> null
-        }
-        isSelectable = status == UtxosStatus.Mined
-        isShowingStatus = status != null
-    }
+    val enabled
+        get() = !immature && status == UtxosStatus.Mined
+    val showDate: Boolean
+        get() = source.timestamp != 0L
+    val showMinedHeight: Boolean
+        get() = source.minedHeight != 0L
+    val showLockHeight: Boolean
+        get() = source.lockHeight != 0L
+    val selectable: Boolean
+        get() = enabled
+    val showStatus: Boolean
+        get() = status != null
 
     override val viewHolderUUID: String = "UtxosViewHolderItem" + source.value.toString()
 
     companion object {
-        const val minTileHeight = 100.0
-        const val maxTileHeight = 300.0
+        const val MIN_TILE_HEIGHT = 100.0
+        const val MAX_TILE_HEIGHT = 300.0
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/util/DebugConfig.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/DebugConfig.kt
@@ -30,20 +30,40 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+@file:Suppress("MemberVisibilityCanBePrivate", "ConstPropertyName", "KotlinConstantConditions", "SameParameterValue")
+
 package com.tari.android.wallet.util
 
 import com.tari.android.wallet.BuildConfig
+import com.tari.android.wallet.model.CompletedTx
+import com.tari.android.wallet.model.MicroTari
+import com.tari.android.wallet.model.TariContact
+import com.tari.android.wallet.model.TariUtxo
 import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.model.Tx
+import com.tari.android.wallet.model.TxStatus
+import com.tari.android.wallet.ui.common.gyphy.presentation.GIFViewModel
+import com.tari.android.wallet.ui.common.gyphy.repository.GIFRepository
+import com.tari.android.wallet.ui.common.recyclerView.items.TitleViewHolderItem
+import com.tari.android.wallet.ui.fragment.contact_book.data.ContactsRepository
+import com.tari.android.wallet.ui.fragment.tx.adapter.TransactionItem
+import com.tari.android.wallet.ui.fragment.utxos.list.adapters.UtxosViewHolderItem
+import org.joda.time.DateTime
 import yat.android.lib.YatIntegration
+import java.math.BigInteger
+import kotlin.random.Random
 
 /**
  *  Constants used for developing and debugging.
  */
-@Suppress("ConstPropertyName", "KotlinConstantConditions")
 object DebugConfig {
 
     private const val _mockedTurned = false
     val mockedDataEnabled = _mockedTurned && isDebug() // TODO split this flag to multiple different types of mocked data
+
+    val mockUtxos = valueIfDebug(true)
+
+    val mockTxs = valueIfDebug(false)
 
     const val isChatEnabled = false
 
@@ -57,6 +77,8 @@ object DebugConfig {
     val hardcodedBaseNodes = _hardcodedBaseNode && isDebug()
 
     private fun isDebug() = BuildConfig.BUILD_TYPE == "debug"
+
+    private fun valueIfDebug(value: Boolean) = isDebug() && value
 }
 
 object MockDataStub {
@@ -69,6 +91,63 @@ object MockDataStub {
 
     val WALLET_ADDRESS = TariWalletAddress(hexString = HEX, emojiId = EMOJI_ID)
     val WALLET_ADDRESS_ZERO = TariWalletAddress(HEX_ZERO, EMOJI_ID_ZERO)
+
+    fun createUtxoList() = List(20) { UtxosViewHolderItem(createUtxo()) }
+
+    fun createUtxo() = TariUtxo(
+        value = MicroTari(BigInteger.valueOf(Random.nextLong(1, 100000) * 10000)),
+        status = TariUtxo.UtxoStatus.entries.toTypedArray()[Random.nextInt(0, 3)],
+        timestamp = DateTime.now().toDate().time,
+        minedHeight = 12243,
+        commitment = "Mocked Tari UTXO!!!",
+    )
+
+    fun createTxList(
+        contactsRepository: ContactsRepository,
+        gifRepository: GIFRepository,
+        confirmationCount: Long,
+        title: String = "Mocked Transactions"
+    ) = listOf(
+        TitleViewHolderItem(title = title, isFirst = true),
+        createTx(
+            contactsRepository, gifRepository, confirmationCount,
+            amount = 1100000,
+            contactAlias = "Alice",
+        ),
+        createTx(
+            contactsRepository, gifRepository, confirmationCount,
+            amount = 1200000,
+            contactAlias = "Bob",
+        ),
+        createTx(
+            contactsRepository, gifRepository, confirmationCount,
+            amount = 1300000,
+            contactAlias = "Charlie",
+        ),
+    )
+
+    fun createTx(
+        contactsRepository: ContactsRepository,
+        gifRepository: GIFRepository,
+        confirmationCount: Long,
+        amount: Long = 100000,
+        contactAlias: String = "Test",
+    ) = TransactionItem(
+        tx = CompletedTx(
+            direction = Tx.Direction.INBOUND,
+            status = TxStatus.MINED_CONFIRMED,
+            amount = MicroTari(BigInteger.valueOf(amount)),
+            fee = MicroTari(BigInteger.valueOf(1000)),
+            message = "https://giphy.com/embed/5885nYOgBHdCw",
+            timestamp = BigInteger.valueOf(System.currentTimeMillis()),
+            id = BigInteger.valueOf(1),
+            tariContact = TariContact(WALLET_ADDRESS_ZERO, contactAlias),
+        ),
+        contact = contactsRepository.ffiBridge.getContactForTx(CompletedTx()),
+        position = 0,
+        viewModel = GIFViewModel(gifRepository),
+        requiredConfirmationCount = confirmationCount,
+    )
 }
 
 object YatEnvironment {

--- a/app/src/main/res/layout/item_utxos_text.xml
+++ b/app/src/main/res/layout/item_utxos_text.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:animateLayoutChanges="true"
+    android:foreground="?attr/selectableItemBackground"
     android:orientation="horizontal"
     android:paddingHorizontal="30dp">
 
@@ -14,7 +15,7 @@
         android:layout_width="wrap_content"
         android:layout_height="24dp"
         android:layout_marginTop="12dp"
-        android:buttonTint="@color/white"
+        android:buttonTint="?attr/palette_brand_purple"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_utxos_tile.xml
+++ b/app/src/main/res/layout/item_utxos_tile.xml
@@ -13,6 +13,7 @@
         android:layout_height="match_parent"
         android:layout_margin="6dp"
         android:clipChildren="false"
+        android:foreground="?attr/selectableItemBackground"
         app:cardBackgroundColor="?attr/palette_neutral_secondary"
         app:cardCornerRadius="11dp"
         app:cardElevation="0dp">
@@ -58,9 +59,9 @@
                             android:id="@+id/balance_gem_image_view"
                             android:layout_width="@dimen/home_balance_gem_width"
                             android:layout_height="@dimen/home_balance_gem_height"
-                            android:tint="@color/white"
                             android:layout_gravity="center_vertical"
-                            android:src="@drawable/vector_gem" />
+                            android:src="@drawable/vector_gem"
+                            android:tint="@color/white" />
 
                         <com.tari.android.wallet.ui.component.tari.TariTextView
                             android:id="@+id/amount"

--- a/app/src/main/res/layout/view_share_option.xml
+++ b/app/src/main/res/layout/view_share_option.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_horizontal"
@@ -12,10 +11,11 @@
     <com.tari.android.wallet.ui.component.tari.TariAlphaBackground
         android:id="@+id/option_background"
         android:layout_width="46dp"
-        android:padding="12dp"
         android:layout_height="46dp"
         android:layout_gravity="center_horizontal"
         android:elevation="8dp"
+        android:foreground="?attr/selectableItemBackground"
+        android:padding="12dp"
         app:alpha="1"
         app:backgroundColor="?attr/palette_background_primary"
         app:cornerRadius="40dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="tx_list_loading_gif">Loading GIF</string>
     <string name="tx_list_retry_loading_gif">Retry loading GIF</string>
     <string name="tx_list_emoji_one_side_payment_placeholder">➡️</string>
+    <string name="tx_list_emoji_coinbase_payment_placeholder">🪙</string>
     <string name="tx_list_someone">Someone</string>
     <string name="tx_list_you_received_one_side_payment">You received a one side payment</string>
 
@@ -338,6 +339,7 @@
     <string name="tx_details_cancel_dialog_not_cancel">Not now</string>
     <string name="tx_details_error_tx_not_found_title">Requested transaction was not found</string>
     <string name="tx_details_error_tx_not_found_desc">Please try again later</string>
+    <string name="tx_details_coinbase_placeholder">🪙 Coinbase</string>
 
     <string name="tx_details_cancellation_reason_unknown">The transaction failed for an unknown reason.</string>
     <string name="tx_details_cancellation_reason_user_cancelled">The transaction was canceled by the sender.</string>
@@ -716,6 +718,7 @@
     <string name="utxos_detailed_status">Status:</string>
     <string name="utxos_detailed_commitment">Commitment:</string>
     <string name="utxos_detailed_block_height">Block Height:</string>
+    <string name="utxos_detailed_lock_height">Lock Height:</string>
     <string name="utxos_detailed_date">Date:</string>
     <string name="utxos_split_preview_fee">Estimated Fee:</string>
     <string name="utxos_split_preview_break">Break</string>


### PR DESCRIPTION
Implemented the Coinbase maturity feature:
- Disable UTXOs if it's immature (lock height > network block height)
- Calculated total balance as `available + incoming pending + time-locked balances`
- Marked Coinbase transaction as "🪙 Coinbase" and hid contact section for such txs
- Added cpp wrapper for TariBaseNodeState
- Refactored some classes and made them immutable