### PR TITLE
feat: ContactsRepository refactoring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,8 +196,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutines_version"
+
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-reactivestreams-ktx:$lifecycle_version"

--- a/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
@@ -123,7 +123,8 @@ import javax.inject.Singleton
         ServiceModule::class,
         TorModule::class,
         PresentationModule::class,
-        YatModule::class
+        YatModule::class,
+        CoroutinesDispatchersModule::class,
     ]
 )
 

--- a/app/src/main/java/com/tari/android/wallet/di/CoroutinesDispatchersModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/CoroutinesDispatchersModule.kt
@@ -1,0 +1,49 @@
+package com.tari.android.wallet.di
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.plus
+import javax.inject.Named
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class ApplicationScope
+
+@Module
+class CoroutinesDispatchersModule {
+    private companion object {
+        private const val DEFAULT = "DEFAULT"
+        private const val IO = "IO"
+        private const val MAIN = "MAIN"
+        private const val MAIN_IMMEDIATE = "MAIN_IMMEDIATE"
+    }
+
+    @Named(DEFAULT)
+    @Provides
+    fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Named(IO)
+    @Provides
+    fun providesIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Named(MAIN)
+    @Provides
+    fun providesMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    @Named(MAIN_IMMEDIATE)
+    @Provides
+    fun providesMainImmediateDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+
+    @Singleton
+    @ApplicationScope
+    @Provides
+    fun providesCoroutineScope(
+        @Named(DEFAULT) defaultDispatcher: CoroutineDispatcher
+    ): CoroutineScope = MainScope() + defaultDispatcher
+}

--- a/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
@@ -1,13 +1,33 @@
 package com.tari.android.wallet.extension
 
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 inline fun LifecycleOwner.launchAndRepeatOnLifecycle(
     state: Lifecycle.State,
     crossinline block: suspend CoroutineScope.() -> Unit,
 ) = lifecycleScope.launch { repeatOnLifecycle(state) { block() } }
+
+fun <T> Fragment.collectFlow(stateFlow: Flow<T>, action: (T) -> Unit) {
+    viewLifecycleOwner.launchAndRepeatOnLifecycle(Lifecycle.State.STARTED) {
+        stateFlow.collect { state ->
+            action(state)
+        }
+    }
+}
+
+fun <T> ViewModel.collectFlow(stateFlow: Flow<T>, action: (T) -> Unit) {
+    viewModelScope.launch {
+        stateFlow.collect { state ->
+            action(state)
+        }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/service/connection/ServiceConnectionState.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/connection/ServiceConnectionState.kt
@@ -1,8 +1,0 @@
-package com.tari.android.wallet.service.connection
-
-import com.tari.android.wallet.service.TariWalletService
-
-data class ServiceConnectionState(
-    val status: ServiceConnectionStatus,
-    val service: TariWalletService?
-)

--- a/app/src/main/java/com/tari/android/wallet/service/connection/ServiceConnectionStatus.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/connection/ServiceConnectionStatus.kt
@@ -1,7 +1,0 @@
-package com.tari.android.wallet.service.connection
-
-enum class ServiceConnectionStatus {
-    NOT_YET_CONNECTED,
-    CONNECTED,
-    DISCONNECTED
-}

--- a/app/src/main/java/com/tari/android/wallet/ui/component/clipboardController/WalletAddressViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/clipboardController/WalletAddressViewModel.kt
@@ -31,7 +31,7 @@ class WalletAddressViewModel : CommonViewModel() {
     }
 
     fun tryToCheckClipboard() {
-        doOnConnected {
+        doOnWalletServiceConnected {
             checkClipboardForValidEmojiId(it)
         }
     }
@@ -39,7 +39,7 @@ class WalletAddressViewModel : CommonViewModel() {
     fun checkClipboardForValidEmojiId(walletService: TariWalletService) {
         val clipboardString = clipboardManager.primaryClip?.getItemAt(0)?.text?.toString() ?: return
 
-        doOnConnectedToWallet {
+        doOnWalletRunning {
             runCatching {
                 checkForValidEmojiId(walletService, clipboardString)
 
@@ -49,7 +49,7 @@ class WalletAddressViewModel : CommonViewModel() {
     }
 
     fun checkFromQuery(walletService: TariWalletService, query: String) {
-        doOnConnectedToWallet {
+        doOnWalletRunning {
             checkForValidEmojiId(walletService, query)
             discoveredWalletAddressFromQuery.postValue(discoveredWalletAddress)
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/ChatListViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/ChatListViewModel.kt
@@ -26,23 +26,23 @@ class ChatListViewModel : CommonViewModel() {
     init {
         component.inject(this)
 
-        list.addSource(chatsRepository.list) {
-            list.postValue(it.map {
-                val firstEmoji = it.walletAddress.emojiId.extractEmojis().first()
-                val contact = contactsRepository.ffiBridge.getContactByAddress(it.walletAddress)
-                val lastMessage = it.messages.sortedBy { it.date }.lastOrNull()
-                val unreadCount = it.messages.count { it.isRead.not() }
+        list.addSource(chatsRepository.list) { chats ->
+            list.postValue(chats.map { chat ->
+                val firstEmoji = chat.walletAddress.emojiId.extractEmojis().first()
+                val contact = contactsRepository.getContactByAddress(chat.walletAddress)
+                val lastMessage = chat.messages.maxByOrNull { it.date }
+                val unreadCount = chat.messages.count { it.isRead.not() }
                 ChatItemViewHolderItem(
-                    it.walletAddress,
-                    it.uuid,
-                    firstEmoji,
-                    contact.getPhoneDto()?.avatar.orEmpty(),
-                    contact.contact.getAlias(),
-                    it.walletAddress.emojiId,
-                    lastMessage?.message.orEmpty(),
-                    lastMessage?.date.orEmpty(),
-                    unreadCount,
-                    true
+                    walletAddress = chat.walletAddress,
+                    uuid = chat.uuid,
+                    firstEmoji = firstEmoji,
+                    avatar = contact.getPhoneDto()?.avatar.orEmpty(),
+                    alias = contact.contact.getAlias(),
+                    emojiId = chat.walletAddress.emojiId,
+                    subtitle = lastMessage?.message.orEmpty(),
+                    dateMessage = lastMessage?.date.orEmpty(),
+                    unreadCount = unreadCount,
+                    isOnline = true,
                 )
             }.toMutableList())
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/addChat/AddChatFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/addChat/AddChatFragment.kt
@@ -5,10 +5,8 @@ import android.view.View
 import com.tari.android.wallet.R
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.string
-import com.tari.android.wallet.ui.fragment.chat_list.data.ChatItemDto
 import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionFragment
-import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
-import java.util.UUID
+import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionViewModel.ContinueButtonEffect
 
 class AddChatFragment : ContactSelectionFragment() {
 
@@ -24,11 +22,6 @@ class AddChatFragment : ContactSelectionFragment() {
     override fun goToNext() {
         super.goToNext()
 
-        val user = viewModel.getUserDto()
-
-        val chatDto = ChatItemDto(UUID.randomUUID().toString(), listOf(), user.getFFIDto()!!.walletAddress)
-        viewModel.chatsRepository.addChat(chatDto)
-
-        viewModel.navigation.postValue(Navigation.ChatNavigation.ToChat(user.getFFIDto()?.walletAddress!!, true))
+        viewModel.onContinueButtonClick(ContinueButtonEffect.AddChat)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/chat_list/chat/ChatViewModel.kt
@@ -41,7 +41,7 @@ class ChatViewModel : CommonViewModel() {
     fun startWith(walletAddress: TariWalletAddress) {
         userAddress.postValue(walletAddress)
 
-        val contact = contactsRepository.ffiBridge.getContactByAddress(walletAddress)
+        val contact = contactsRepository.getContactByAddress(walletAddress)
         this.contact.postValue(contact)
 
         val chat = chatRepository.getByWalletAddress(walletAddress)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/add/AddContactFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/add/AddContactFragment.kt
@@ -6,7 +6,7 @@ import com.tari.android.wallet.R
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.visible
 import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionFragment
-import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
+import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionViewModel.ContinueButtonEffect
 
 class AddContactFragment : ContactSelectionFragment() {
 
@@ -22,13 +22,6 @@ class AddContactFragment : ContactSelectionFragment() {
     override fun goToNext() {
         super.goToNext()
 
-        val user = viewModel.getUserDto()
-        val fullName = ui.addFirstNameInput.ui.editText.text.toString()
-        val split = fullName.split(" ")
-        val firstName = split.getOrNull(1).orEmpty().trim()
-        val surname = split.getOrNull(0).orEmpty().trim()
-
-        viewModel.contactsRepository.updateContactInfo(user, firstName, surname, "")
-        viewModel.navigation.postValue(Navigation.ContactBookNavigation.BackToContactBook)
+        viewModel.onContinueButtonClick(ContinueButtonEffect.AddContact(name = ui.addFirstNameInput.ui.editText.text.toString()))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/add/SelectUserContactFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/add/SelectUserContactFragment.kt
@@ -7,7 +7,7 @@ import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.setVisible
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionFragment
-import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
+import com.tari.android.wallet.ui.fragment.contact_book.contactSelection.ContactSelectionViewModel.ContinueButtonEffect
 import com.tari.android.wallet.ui.fragment.qr.QRScannerActivity
 import com.tari.android.wallet.ui.fragment.qr.QrScannerSource
 
@@ -39,7 +39,6 @@ class SelectUserContactFragment : ContactSelectionFragment() {
     override fun goToNext() {
         super.goToNext()
 
-        val user = viewModel.getUserDto()
-        viewModel.navigation.postValue(Navigation.TxListNavigation.ToSendTariToUser(user, viewModel.amount.value))
+        viewModel.onContinueButtonClick(ContinueButtonEffect.SelectUserContact)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/BadgeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/BadgeViewModel.kt
@@ -3,8 +3,8 @@ package com.tari.android.wallet.ui.fragment.contact_book.contacts
 import com.tari.android.wallet.ui.fragment.contact_book.contacts.adapter.contact.ContactItem
 
 class BadgeViewModel {
-    var closeLastBadge: () -> Unit = {}
-    var lastItem: ContactItem? = null
+    private var closeLastBadge: () -> Unit = {}
+    private var lastItem: ContactItem? = null
 
     fun openNew(item: ContactItem, closeAction: () -> Unit) {
         if (item == lastItem) return

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/ContactsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/ContactsFragment.kt
@@ -37,7 +37,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.tari.android.wallet.databinding.FragmentContactsBinding
 import com.tari.android.wallet.extension.observe
@@ -45,8 +44,6 @@ import com.tari.android.wallet.extension.observeOnLoad
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.common.recyclerView.CommonAdapter
 import com.tari.android.wallet.ui.fragment.contact_book.contacts.adapter.ContactListAdapter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 open class ContactsFragment : CommonFragment<FragmentContactsBinding, ContactsViewModel>() {
 
@@ -61,8 +58,6 @@ open class ContactsFragment : CommonFragment<FragmentContactsBinding, ContactsVi
         val viewModel: ContactsViewModel by viewModels()
         bindViewModel(viewModel)
 
-        viewModel.serviceConnection.reconnectToService()
-
         setupUI()
         observeUI()
     }
@@ -75,7 +70,7 @@ open class ContactsFragment : CommonFragment<FragmentContactsBinding, ContactsVi
             recyclerViewAdapter.update(it)
         }
 
-        observe(grantPermission) { grantPermission() }
+        observe(grantPermission) { viewModel.grantPermission() }
 
         observeOnLoad(listUpdateTrigger)
         observeOnLoad(debouncedList)
@@ -93,15 +88,6 @@ open class ContactsFragment : CommonFragment<FragmentContactsBinding, ContactsVi
         ui.contactsListRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerViewAdapter.setClickListener(CommonAdapter.ItemClickListener { viewModel.processItemClick(it) })
         ui.contactsListRecyclerView.adapter = recyclerViewAdapter
-    }
-
-    private fun grantPermission() {
-        viewModel.permissionManager.runWithPermission(listOf(android.Manifest.permission.READ_CONTACTS), true) {
-            viewModel.viewModelScope.launch(Dispatchers.IO) {
-                viewModel.contactsRepository.contactPermission.postValue(true)
-                viewModel.contactsRepository.phoneBookRepositoryBridge.loadFromPhoneBook()
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/data/FFIContactsRepositoryBridge.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/data/FFIContactsRepositoryBridge.kt
@@ -1,0 +1,149 @@
+package com.tari.android.wallet.ui.fragment.contact_book.data
+
+import com.orhanobut.logger.Logger
+import com.tari.android.wallet.event.Event
+import com.tari.android.wallet.event.EventBus
+import com.tari.android.wallet.ffi.FFIWallet
+import com.tari.android.wallet.model.TariContact
+import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.model.WalletError
+import com.tari.android.wallet.service.connection.TariWalletServiceConnection
+import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.ContactDto
+import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.FFIContactDto
+import com.tari.android.wallet.util.ContactUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class FFIContactsRepositoryBridge(
+    private val contactsRepository: ContactsRepository,
+    private val tariWalletServiceConnection: TariWalletServiceConnection,
+    private val contactUtil: ContactUtil,
+    private val externalScope: CoroutineScope,
+) {
+    private val logger
+        get() = Logger.t(this::class.simpleName)
+
+    init {
+        externalScope.launch {
+            tariWalletServiceConnection.doOnWalletRunning {
+                tariWalletServiceConnection.doOnWalletServiceConnected {
+                    subscribeToActions()
+                }
+            }
+        }
+    }
+
+    suspend fun updateToFFI(list: List<ContactDto>) {
+        tariWalletServiceConnection.doOnWalletRunning {
+            tariWalletServiceConnection.doOnWalletServiceConnected { service ->
+                for (item in list.mapNotNull { it.getFFIDto() }) {
+                    val error = WalletError()
+                    service.updateContact(
+                        item.walletAddress,
+                        contactUtil.normalizeAlias(item.getAlias(), item.walletAddress),
+                        item.isFavorite,
+                        error,
+                    )
+                    if (error.code != WalletError.NoError.code) {
+                        logger.i("Error updating contact: ${error.signature}")
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun deleteContact(contact: FFIContactDto) {
+        contactsRepository.doWithLoading("Deleting contact") {
+            tariWalletServiceConnection.doOnWalletRunning {
+                tariWalletServiceConnection.doOnWalletServiceConnected { service ->
+                    service.updateContact(contact.walletAddress, "", false, WalletError())
+                }
+            }
+        }
+    }
+
+    private fun subscribeToActions() {
+        EventBus.subscribe<Event.Transaction.TxReceived>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxReplyReceived>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxFinalized>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.InboundTxBroadcast>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.OutboundTxBroadcast>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxMinedUnconfirmed>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxMined>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxFauxMinedUnconfirmed>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxFauxConfirmed>(this) { updateContactChange(it.tx.tariContact) }
+        EventBus.subscribe<Event.Transaction.TxCancelled>(this) { updateContactChange(it.tx.tariContact) }
+    }
+
+    private fun updateContactChange(tariContact: TariContact) {
+        externalScope.launch {
+            contactsRepository.doWithLoading("Updating contact changes to phone and FFI") {
+                updateFFIContacts()
+
+                val existingContact = contactsRepository.getContacts()
+                    .firstOrNull { it.contact.extractWalletAddress() == tariContact.walletAddress }
+                val contact = existingContact ?: ContactDto(FFIContactDto(tariContact.walletAddress, tariContact.alias, tariContact.isFavorite))
+                contactsRepository.updateRecentUsedTime(contact)
+            }
+        }
+    }
+
+    private suspend fun updateFFIContacts() {
+        contactsRepository.doWithLoading("Updating FFI contacts") {
+            try {
+                val contacts = FFIWallet.instance!!.getContacts()
+                for (contactIndex in 0 until contacts.getLength()) {
+                    val actualContact = contacts.getAt(contactIndex)
+
+                    val walletAddress = actualContact.getWalletAddress()
+                    val ffiWalletAddress = TariWalletAddress.createWalletAddress(walletAddress.toString(), walletAddress.getEmojiId())
+                    val alias = actualContact.getAlias()
+                    val isFavorite = actualContact.getIsFavorite()
+
+                    onFFIContactAddedOrUpdated(ffiWalletAddress, alias, isFavorite)
+                }
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+
+            try {
+                tariWalletServiceConnection.doOnWalletServiceConnected { service ->
+                    val allTxs = service.getCompletedTxs(WalletError()) + service.getCancelledTxs(WalletError()) +
+                            service.getPendingInboundTxs(WalletError()) + service.getPendingOutboundTxs(WalletError())
+                    val allUsers = allTxs.map { it.tariContact }.distinctBy { it.walletAddress }
+                    for (user in allUsers) {
+                        onFFIContactAddedOrUpdated(user.walletAddress, user.alias, user.isFavorite)
+                    }
+                }
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private suspend fun onFFIContactAddedOrUpdated(contact: TariWalletAddress, alias: String, isFavorite: Boolean) {
+        if (ffiContactExist(contact)) {
+            // TODO turn off updated because of name erasing
+//                withFFIContact(contact) {
+//                    it.getFFIDto()?.let { ffiContactDto ->
+//                        ffiContactDto.setAlias(alias)
+//                        ffiContactDto.isFavorite = isFavorite
+//                    }
+//                }
+        } else {
+            contactsRepository.updateContactList { contacts ->
+                contacts.add(ContactDto(FFIContactDto(contact, alias, isFavorite)))
+            }
+        }
+    }
+
+    private suspend fun withFFIContact(walletAddress: TariWalletAddress, updateAction: (contact: ContactDto) -> Unit) {
+        contactsRepository.updateContactList { contacts ->
+            contacts.firstOrNull { it.contact.extractWalletAddress() == walletAddress }
+                ?.let { contact -> updateAction.invoke(contact) }
+        }
+    }
+
+    private fun ffiContactExist(walletAddress: TariWalletAddress): Boolean =
+        contactsRepository.getContacts().any { it.contact.extractWalletAddress() == walletAddress }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/data/PhoneBookRepositoryBridge.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/data/PhoneBookRepositoryBridge.kt
@@ -1,0 +1,162 @@
+package com.tari.android.wallet.ui.fragment.contact_book.data
+
+import android.content.ContentProviderOperation
+import android.content.Context
+import android.provider.ContactsContract
+import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.ContactDto
+import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.PhoneContactDto
+import contacts.core.Contacts
+import contacts.core.Fields
+import contacts.core.entities.NewOptions
+import contacts.core.equalTo
+import contacts.core.util.names
+import contacts.core.util.setName
+import contacts.core.util.setOptions
+
+class PhoneBookRepositoryBridge(
+    private val contactsRepository: ContactsRepository,
+    private val context: Context,
+) {
+
+    private val phoneContactsSource = Contacts(context)
+
+    internal suspend fun updateContactListWithPhoneBook() {
+        if (!contactsRepository.contactPermissionGranted) return
+
+        contactsRepository.doWithLoading("Loading contacts from phone book") {
+            val phoneContacts = getPhoneContacts()
+
+            contactsRepository.updateContactList { contacts ->
+                phoneContacts.forEach { phoneContact ->
+                    val existingContact = contacts.firstOrNull { it.getPhoneDto()?.id == phoneContact.id }
+                    if (existingContact == null) {
+                        contacts.add(ContactDto(phoneContact.toPhoneContactDto()))
+                    } else {
+                        existingContact.getPhoneDto()?.let {
+                            it.avatar = phoneContact.avatar
+                            it.firstName = phoneContact.firstName
+                            it.surname = phoneContact.surname
+                            it.displayName = phoneContact.displayName
+                            it.isFavorite = phoneContact.isFavorite
+//                                it.yat = phoneContact.yat
+//                                it.phoneEmojiId = phoneContact.emojiId
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal suspend fun updateToPhoneBook() {
+        if (contactsRepository.contactPermissionGranted) {
+            contactsRepository.doWithLoading("Saving updates to contact book") {
+                try {
+                    contactsRepository.updateContactList(silently = true) { contacts ->
+                        val phoneContacts = contacts.mapNotNull { it.getPhoneDto() }.filter { it.shouldUpdate }
+
+                        for (item in phoneContacts) {
+                            val contact = ContactsRepository.PhoneContact(
+                                id = item.id,
+                                firstName = item.firstName,
+                                surname = item.surname,
+                                displayName = item.displayName,
+                                yat = item.yat,
+                                emojiId = item.phoneEmojiId,
+                                avatar = item.avatar,
+                                isFavorite = item.isFavorite,
+                            )
+                            saveNamesToPhoneBook(contact)
+                            saveStarredToPhoneBook(contact)
+//                                saveCustomFieldsToPhoneBook(contact) // todo why it's  commented? Should we store Yat and EmojiID custom fields in the phone book?
+                            item.shouldUpdate = false
+                        }
+                    }
+                } catch (e: Throwable) {
+                    e.printStackTrace()
+                }
+            }
+        }
+    }
+
+    internal suspend fun deleteFromContactBook(contact: PhoneContactDto) {
+        contactsRepository.doWithLoading("Deleting contact from contact book") {
+            phoneContactsSource.delete().contactsWithId(contact.id.toLong()).commit()
+        }
+    }
+
+    private fun saveNamesToPhoneBook(contact: ContactsRepository.PhoneContact) {
+        val phoneContact = phoneContactsSource.query().include(Fields.all()).where { Contact.Id equalTo contact.id }.find().firstOrNull()
+
+        val updatedContact = phoneContact?.mutableCopy {
+            val name = this.names().firstOrNull()?.redactedCopy()?.apply {
+                this.givenName = contact.firstName
+                this.familyName = contact.surname
+                this.displayName = contact.displayName
+            }
+
+            setName(name)
+        }
+
+        updatedContact?.let {
+            phoneContactsSource.update()
+                .contacts(it)
+                .commit()
+        }
+    }
+
+    private fun getPhoneContacts() = phoneContactsSource.query().include(Fields.all()).find()
+        .map {
+            val name = it.names().firstOrNull()
+            ContactsRepository.PhoneContact(
+                id = it.id.toString(),
+                firstName = name?.givenName.orEmpty(),
+                surname = name?.familyName.orEmpty(),
+                displayName = name?.displayName.orEmpty(),
+                yat = "",
+                emojiId = "",
+                avatar = it.photoUri?.toString().orEmpty(),
+                isFavorite = it.options?.starred ?: false,
+            )
+        }.toMutableList()
+
+
+    private fun saveStarredToPhoneBook(contact: ContactsRepository.PhoneContact) {
+        val phoneContact = phoneContactsSource.query().include(Fields.all()).where { Contact.Id equalTo contact.id }.find().firstOrNull()
+
+        val updatedContact = phoneContact?.mutableCopy {
+            if (options == null) {
+                setOptions(NewOptions(starred = contact.isFavorite))
+            } else {
+                val copy = options!!.redactedCopy()
+                copy.starred = contact.isFavorite
+                setOptions(copy)
+            }
+        }
+
+        updatedContact?.let {
+            phoneContactsSource.update()
+                .contacts(it)
+                .commit()
+        }
+    }
+
+    private fun saveCustomFieldsToPhoneBook(contact: ContactsRepository.PhoneContact) {
+        runCatching {
+            val operations = arrayListOf<ContentProviderOperation>()
+
+            ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, contact.id.toInt())
+                .withValue(ContactsContract.Data.MIMETYPE, "vnd.android.cursor.item/com.tari.android.wallet.yat")
+                .withValue("data1", contact.yat)
+                .build().apply { operations.add(this) }
+
+            ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+                .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, contact.id.toInt())
+                .withValue(ContactsContract.Data.MIMETYPE, "vnd.android.cursor.item/com.tari.android.wallet.emojiId")
+                .withValue("data1", contact.emojiId)
+                .build().apply { operations.add(this) }
+
+            context.contentResolver.applyBatch(ContactsContract.AUTHORITY, operations)
+        }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.tari.android.wallet.databinding.FragmentContactsLinkBinding
 import com.tari.android.wallet.extension.observe
@@ -15,8 +14,6 @@ import com.tari.android.wallet.ui.extension.serializable
 import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.ContactDto
 import com.tari.android.wallet.ui.fragment.contact_book.link.adapter.LinkContactAdapter
 import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_CONTACT
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class ContactLinkFragment : CommonFragment<FragmentContactsLinkBinding, ContactLinkViewModel>() {
 
@@ -40,7 +37,7 @@ class ContactLinkFragment : CommonFragment<FragmentContactsLinkBinding, ContactL
     private fun observeUI() = with(viewModel) {
         observe(list) { adapter.update(it) }
 
-        observe(grantPermission) { grantPermission() }
+        observe(grantPermission) { viewModel.grantPermission() }
     }
 
     private fun initUI() = with(ui) {
@@ -48,15 +45,6 @@ class ContactLinkFragment : CommonFragment<FragmentContactsLinkBinding, ContactL
         listUi.layoutManager = LinearLayoutManager(context)
 
         adapter.setClickListener(CommonAdapter.ItemClickListener { item -> viewModel.onContactClick(item) })
-    }
-
-    private fun grantPermission() {
-        viewModel.permissionManager.runWithPermission(listOf(android.Manifest.permission.READ_CONTACTS), true) {
-            viewModel.viewModelScope.launch(Dispatchers.IO) {
-                viewModel.contactsRepository.contactPermission.postValue(true)
-                viewModel.contactsRepository.phoneBookRepositoryBridge.loadFromPhoneBook()
-            }
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkViewModel.kt
@@ -4,7 +4,7 @@ import android.text.SpannableString
 import android.text.SpannedString
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import com.tari.android.wallet.R
 import com.tari.android.wallet.R.string.common_cancel
 import com.tari.android.wallet.R.string.common_close
@@ -16,6 +16,7 @@ import com.tari.android.wallet.R.string.contact_book_contacts_book_link_success_
 import com.tari.android.wallet.R.string.contact_book_contacts_book_link_title
 import com.tari.android.wallet.R.string.contact_book_contacts_book_unlink_success_title
 import com.tari.android.wallet.data.sharedPrefs.SharedPrefsRepository
+import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
@@ -34,23 +35,12 @@ import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.MergedCont
 import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.PhoneContactDto
 import com.tari.android.wallet.ui.fragment.contact_book.link.adapter.link_header.ContactLinkHeaderViewHolderItem
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
-import io.reactivex.BackpressureStrategy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import yat.android.ui.extension.HtmlHelper
 import javax.inject.Inject
 
 class ContactLinkViewModel : CommonViewModel() {
-
-    val grantPermission = SingleLiveEvent<Unit>()
-
-    val contactListSource = MediatorLiveData<List<ContactItem>>()
-
-    val searchText = MutableLiveData("")
-
-    val list = MediatorLiveData<MutableList<CommonViewHolderItem>>()
-
-    val ffiContact = MutableLiveData<ContactDto>()
-
-    private var searchModule: ContactLinkHeaderViewHolderItem? = null
 
     @Inject
     lateinit var sharedPrefsWrapper: SharedPrefsRepository
@@ -58,15 +48,27 @@ class ContactLinkViewModel : CommonViewModel() {
     @Inject
     lateinit var contactsRepository: ContactsRepository
 
+    val grantPermission = SingleLiveEvent<Unit>()
+
+    val list = MediatorLiveData<List<CommonViewHolderItem>>()
+
+    private val ffiContact = MutableLiveData<ContactDto>()
+
+    private val contactListSource = MediatorLiveData<List<ContactItem>>()
+
+    private val searchText = MutableLiveData("")
+
+    private var searchModule: ContactLinkHeaderViewHolderItem? = null
+
     init {
         component.inject(this)
 
-        contactListSource.addSource(contactsRepository.publishSubject.toFlowable(BackpressureStrategy.LATEST).toLiveData()) {
-            contactListSource.value = it.filter(contactsRepository.filter).map { contactDto -> ContactItem(contactDto, true) }
-        }
-
         list.addSource(contactListSource) { updateList() }
         list.addSource(searchText) { updateList() }
+
+        collectFlow(contactsRepository.contactListFiltered) {
+            contactListSource.value = it.map { contactDto -> ContactItem(contact = contactDto, isSimple = true) }
+        }
     }
 
     fun initArgs(contact: ContactDto) {
@@ -79,7 +81,15 @@ class ContactLinkViewModel : CommonViewModel() {
         }
     }
 
-    fun onSearchQueryChanged(query: String) {
+    fun grantPermission() {
+        permissionManager.runWithPermission(listOf(android.Manifest.permission.READ_CONTACTS), true) {
+            viewModelScope.launch(Dispatchers.IO) {
+                contactsRepository.grantContactPermissionAndRefresh()
+            }
+        }
+    }
+
+    private fun onSearchQueryChanged(query: String) {
         searchText.value = query
     }
 
@@ -116,7 +126,7 @@ class ContactLinkViewModel : CommonViewModel() {
     private fun getBody(sourceList: List<ContactItem>): SpannedString {
         val noContacts = sourceList.none { it.contact.contact is PhoneContactDto }
         val noMergedContacts = sourceList.none { it.contact.contact is MergedContactDto }
-        val havePermission = contactsRepository.contactPermission.value == true
+        val havePermission = contactsRepository.contactPermissionGranted
 
         val resource = when {
             !havePermission -> R.string.contact_book_contacts_book_link_empty_state_no_access
@@ -131,7 +141,7 @@ class ContactLinkViewModel : CommonViewModel() {
     private fun getEmptyImage(): Int = R.drawable.vector_contact_favorite_empty_state
 
     private fun getButtonTitle(): String {
-        val havePermission = contactsRepository.contactPermission.value == true
+        val havePermission = contactsRepository.contactPermissionGranted
 
         return when {
             !havePermission -> resourceManager.getString(R.string.contact_book_contacts_book_link_empty_state_go_to_permission_settings)
@@ -140,7 +150,7 @@ class ContactLinkViewModel : CommonViewModel() {
     }
 
     private fun doAction() {
-        val havePermission = contactsRepository.contactPermission.value == true
+        val havePermission = contactsRepository.contactPermissionGranted
 
         if (!havePermission) {
             grantPermission.postValue(Unit)
@@ -161,9 +171,13 @@ class ContactLinkViewModel : CommonViewModel() {
             ShortEmojiIdModule(tariWalletAddress),
             BodyModule(null, SpannableString(secondLineHtml)),
             ButtonModule(resourceManager.getString(common_confirm), ButtonStyle.Normal) {
-                contactsRepository.linkContacts(ffiContact.value!!, phoneContactDto)
-                dismissDialog.postValue(Unit)
-                showLinkSuccessDialog(phoneContactDto)
+                viewModelScope.launch(Dispatchers.IO) {
+                    contactsRepository.linkContacts(ffiContact.value!!, phoneContactDto)
+                    viewModelScope.launch(Dispatchers.Main) {
+                        dismissDialog.postValue(Unit)
+                        showLinkSuccessDialog(phoneContactDto)
+                    }
+                }
             },
             ButtonModule(resourceManager.getString(common_cancel), ButtonStyle.Close)
         )

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/ContactSelectionRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/ContactSelectionRepository.kt
@@ -1,13 +1,12 @@
 package com.tari.android.wallet.ui.fragment.contact_book.root
 
 import androidx.lifecycle.MutableLiveData
-import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.fragment.contact_book.contacts.adapter.contact.ContactItem
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ContactSelectionRepository @Inject constructor() : CommonViewModel() {
+class ContactSelectionRepository @Inject constructor() {
     val selectedContacts = mutableListOf<ContactItem>()
 
     val isSelectionState = MutableLiveData(false)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/transactionHistory/TransactionHistoryFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/transactionHistory/TransactionHistoryFragment.kt
@@ -49,7 +49,7 @@ class TransactionHistoryFragment : CommonFragment<FragmentContactTransactionHist
         observe(selectedContact) { setContactText(it) }
     }
 
-    private fun updateList(items: MutableList<CommonViewHolderItem>) {
+    private fun updateList(items: List<CommonViewHolderItem>) {
         ui.list.setVisible(items.isNotEmpty())
         ui.descriptionView.setVisible(items.isNotEmpty())
         ui.emptyState.setVisible(items.isEmpty())

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/transactionHistory/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/transactionHistory/TransactionHistoryViewModel.kt
@@ -2,14 +2,13 @@ package com.tari.android.wallet.ui.fragment.contact_book.transactionHistory
 
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.toLiveData
+import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
 import com.tari.android.wallet.ui.fragment.contact_book.data.ContactsRepository
 import com.tari.android.wallet.ui.fragment.contact_book.data.contacts.ContactDto
 import com.tari.android.wallet.ui.fragment.tx.TransactionRepository
 import com.tari.android.wallet.ui.fragment.tx.adapter.TransactionItem
-import io.reactivex.BackpressureStrategy
 import javax.inject.Inject
 
 class TransactionHistoryViewModel : CommonViewModel() {
@@ -18,36 +17,35 @@ class TransactionHistoryViewModel : CommonViewModel() {
     lateinit var transactionRepository: TransactionRepository
 
     @Inject
-    lateinit var contactRepository: ContactsRepository
+    lateinit var contactsRepository: ContactsRepository
 
     var selectedContact = MutableLiveData<ContactDto>()
 
-    var list = MediatorLiveData<MutableList<CommonViewHolderItem>>()
+    var list = MediatorLiveData<List<CommonViewHolderItem>>()
 
     init {
         component.inject(this)
 
-        list.addSource(contactRepository.publishSubject.toFlowable(BackpressureStrategy.LATEST).toLiveData()) {
+        collectFlow(contactsRepository.contactList) {
             updateList()
         }
 
         list.addSource(selectedContact) { updateList() }
-
         list.addSource(transactionRepository.list) { updateList() }
     }
 
     private fun updateList() {
         val contact = selectedContact.value ?: return
-        val actualContact = contactRepository.getByUuid(contact.uuid)
+        val actualContact = contactsRepository.getByUuid(contact.uuid)
         if (contact != actualContact) selectedContact.postValue(actualContact)
 
-        val filtered: MutableList<CommonViewHolderItem> = transactionRepository.list.value?.filter {
+        val filtered = transactionRepository.list.value?.filter {
             if (it is TransactionItem) {
                 it.tx.tariContact.walletAddress == selectedContact.value?.contact?.extractWalletAddress()
             } else {
                 false
             }
-        }.orEmpty().map { (it as TransactionItem).copy(contact = actualContact) }.toMutableList()
+        }.orEmpty().map { (it as TransactionItem).copy(contact = actualContact) }
         list.postValue(filtered)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/HomeActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/HomeActivity.kt
@@ -55,7 +55,6 @@ import com.tari.android.wallet.databinding.ActivityHomeBinding
 import com.tari.android.wallet.di.DiContainer.appComponent
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.model.TxId
-import com.tari.android.wallet.service.connection.ServiceConnectionStatus
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonActivity
 import com.tari.android.wallet.ui.common.domain.ResourceManager
@@ -170,7 +169,7 @@ class HomeActivity : CommonActivity<ActivityHomeBinding, HomeViewModel>() {
 
         if (savedInstanceState == null) {
             enableNavigationView(ui.homeImageView)
-            viewModel.doOnConnected {
+            viewModel.doOnWalletServiceConnected {
                 ui.root.postDelayed({
                     processIntentDeepLink(intent)
                 }, Constants.UI.mediumDurationMs)
@@ -217,7 +216,7 @@ class HomeActivity : CommonActivity<ActivityHomeBinding, HomeViewModel>() {
 
         // onNewIntent might get called before onCreate, so we anticipate that here
         checkScreensDeeplink(intent)
-        if (viewModel.serviceConnection.currentState.status == ServiceConnectionStatus.CONNECTED) {
+        if (viewModel.serviceConnection.isWalletServiceConnected()) {
             processIntentDeepLink(intent)
         } else {
             setIntent(intent)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/homeTransactionHistory/HomeTransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/homeTransactionHistory/HomeTransactionHistoryViewModel.kt
@@ -2,13 +2,12 @@ package com.tari.android.wallet.ui.fragment.home.homeTransactionHistory
 
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.toLiveData
+import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
 import com.tari.android.wallet.ui.fragment.contact_book.data.ContactsRepository
 import com.tari.android.wallet.ui.fragment.tx.TransactionRepository
 import com.tari.android.wallet.ui.fragment.tx.adapter.TransactionItem
-import io.reactivex.BackpressureStrategy
 import javax.inject.Inject
 
 class HomeTransactionHistoryViewModel : CommonViewModel() {
@@ -19,24 +18,23 @@ class HomeTransactionHistoryViewModel : CommonViewModel() {
     @Inject
     lateinit var contactsRepository: ContactsRepository
 
-    var list = MediatorLiveData<MutableList<CommonViewHolderItem>>()
-
-    val searchText = MutableLiveData("")
+    var list = MediatorLiveData<List<CommonViewHolderItem>>()
 
     val searchBarVisible = MutableLiveData(false)
-    val searchEmptyStateVisible = MutableLiveData(false)
     val txEmptyStateVisible = MutableLiveData(false)
     val txListVisible = MutableLiveData(false)
+
+    private val searchText = MutableLiveData("")
+    private val searchEmptyStateVisible = MutableLiveData(false)
 
     init {
         component.inject(this)
 
-        list.addSource(contactsRepository.publishSubject.toFlowable(BackpressureStrategy.LATEST).toLiveData()) {
+        collectFlow(contactsRepository.contactList) {
             updateList()
         }
 
         list.addSource(transactionRepository.list) { updateList() }
-
         list.addSource(searchText) { updateList() }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
@@ -363,7 +363,7 @@ class TariNavigator @Inject constructor(val prefs: SharedPrefsRepository, val ta
 
     fun sendTariToUser(service: TariWalletService, sendDeeplink: DeepLink.Send) {
         val walletAddress = service.getWalletAddressFromHexString(sendDeeplink.walletAddressHex)
-        sendToUser((activity as HomeActivity).viewModel.contactsRepository.ffiBridge.getContactByAddress(walletAddress))
+        sendToUser((activity as HomeActivity).viewModel.contactsRepository.getContactByAddress(walletAddress))
     }
 
     private fun sendToUserByDeeplink(deeplink: DeepLink.Send) {
@@ -371,7 +371,7 @@ class TariNavigator @Inject constructor(val prefs: SharedPrefsRepository, val ta
         val address = FFITariWalletAddress(HexString(deeplink.walletAddressHex)).runWithDestroy {
             walletAddressFromFFI(it)
         }
-        val contact = (activity as HomeActivity).viewModel.contactsRepository.ffiBridge.getContactByAddress(address)
+        val contact = (activity as HomeActivity).viewModel.contactsRepository.getContactByAddress(address)
         val bundle = Bundle().apply {
             putSerializable(PARAMETER_CONTACT, contact)
             putParcelable(PARAMETER_AMOUNT, deeplink.amount)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountViewModel.kt
@@ -42,13 +42,13 @@ class AddAmountViewModel : CommonViewModel() {
     init {
         component.inject(this)
 
-        doOnConnected { _serviceConnected.postValue(Unit) }
+        doOnWalletServiceConnected { _serviceConnected.postValue(Unit) }
 
         loadFees()
         _isOneSidePaymentEnabled.postValue(tariSettingsSharedRepository.isOneSidePaymentEnabled)
     }
 
-    private fun loadFees() = doOnConnected {
+    private fun loadFees() = doOnWalletServiceConnected {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val stats = FFIWallet.instance!!.getFeePerGramStats()

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/finalize/FinalizeSendTxViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/finalize/FinalizeSendTxViewModel.kt
@@ -109,7 +109,7 @@ class FinalizeSendTxViewModel : CommonViewModel() {
             }
         }
 
-        override fun execute() = doOnConnected { onServiceConnected() }
+        override fun execute() = doOnWalletServiceConnected { onServiceConnected() }
 
         private fun onServiceConnected() {
             // start checking network connection

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/writeDownSeedWords/WriteDownSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/writeDownSeedWords/WriteDownSeedPhraseViewModel.kt
@@ -15,7 +15,7 @@ class WriteDownSeedPhraseViewModel : CommonViewModel() {
 
     init {
         _seedWords.value = listOf()
-        doOnConnected { getSeedWords() }
+        doOnWalletServiceConnected { getSeedWords() }
     }
 
     private fun getSeedWords() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
@@ -35,7 +35,6 @@ package com.tari.android.wallet.ui.fragment.tx
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -88,11 +87,9 @@ class HomeFragment : CommonFragment<FragmentHomeBinding, HomeFragmentViewModel>(
         val viewModel: HomeFragmentViewModel by viewModels()
         bindViewModel(viewModel)
 
-        viewModel.serviceConnection.reconnectToService()
-
         subscribeVM(deeplinkViewModel)
 
-        checkPermission()
+        viewModel.checkPermission()
         setupUI()
         subscribeToViewModel()
         observeUI()
@@ -130,25 +127,13 @@ class HomeFragment : CommonFragment<FragmentHomeBinding, HomeFragmentViewModel>(
 
     override fun onResume() {
         super.onResume()
-        grantPermission()
+        viewModel.grantContactsPermission()
     }
 
     override fun onDestroyView() {
         EventBus.unsubscribe(this)
         EventBus.networkConnectionState.unsubscribe(this)
         super.onDestroyView()
-    }
-
-    private fun checkPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            viewModel.permissionManager.runWithPermission(listOf(android.Manifest.permission.POST_NOTIFICATIONS)) {
-                viewModel.logger.i("notification permission checked successfully")
-            }
-        }
-
-        viewModel.permissionManager.runWithPermission(listOf(android.Manifest.permission.READ_CONTACTS)) {
-            viewModel.contactsRepository.phoneBookRepositoryBridge.loadFromPhoneBook()
-        }
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -167,13 +152,6 @@ class HomeFragment : CommonFragment<FragmentHomeBinding, HomeFragmentViewModel>(
 
         ui.balanceQuestionMark.viewLifecycle = viewLifecycleOwner
         ui.balanceQuestionMark.bindViewModel(questionMarkViewModel)
-    }
-
-    private fun grantPermission() {
-        viewModel.permissionManager.runWithPermission(listOf(android.Manifest.permission.READ_CONTACTS), true) {
-            viewModel.contactsRepository.contactPermission.value = true
-            viewModel.contactsRepository.phoneBookRepositoryBridge.loadFromPhoneBook()
-        }
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/UtxosListViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/UtxosListViewModel.kt
@@ -57,7 +57,7 @@ class UtxosListViewModel : CommonViewModel() {
         sortingMediator.addSource(ordering) { generateFromScratch() }
         setSelectionState(false)
 
-        doOnConnected { loadUtxosFromFFI() }
+        doOnWalletServiceConnected { loadUtxosFromFFI() }
 
         component.inject(this)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -843,6 +843,7 @@
     <string name="contact_book_type_ffi">Tari Contact</string>
     <string name="contact_book_type_contact_book">Phone Contact</string>
     <string name="contact_book_type_merged">Linked Contact</string>
+    <string name="contact_book_loading_sec">%s %ss</string>
     <string name="remove_all">Remove all contacts</string>
     <string name="add_1000_contacts">Add 1000 contacts</string>
     <string name="share_contact_via_qr_code">QR Code</string>

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     ext.kotlin_version = '1.9.23'
 
     ext.lifecycle_version = '2.6.2'
+    ext.coroutines_version = '1.8.0'
 
     // build & version
     ext.buildNumber = 290


### PR DESCRIPTION
Refactored `ContactsRepository`
- Now `ContactsRepository` doesn't depend on the UI lifecycle 
- Fix threading issues and memory leaks
- Made the repository's methods suspend to call it in external (a ViewModel's) scope instead of creating a new scope inside the repository (*which won't be closed never*)

- Move business logic from Fragments to ViewModels
- Make ViewModels' fields private
- Reduced use of mutable values

- Fix code-style