### PR TITLE
feat: Onboarding activity error handling

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkViewModel.kt
@@ -10,8 +10,6 @@ import com.tari.android.wallet.ffi.HexString
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.dialog.confirm.ConfirmDialogArgs
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
@@ -59,16 +57,16 @@ class DeeplinkViewModel : CommonViewModel() {
     private fun addBaseNode(deeplink: DeepLink.AddBaseNode, isQrData: Boolean = true) {
         val baseNode = getData(deeplink)
         val args = ConfirmDialogArgs(
-            resourceManager.getString(R.string.home_custom_base_node_title),
-            resourceManager.getString(R.string.home_custom_base_node_description),
-            resourceManager.getString(R.string.home_custom_base_node_no_button),
-            resourceManager.getString(R.string.common_lets_do_it),
+            title = resourceManager.getString(R.string.home_custom_base_node_title),
+            description = resourceManager.getString(R.string.home_custom_base_node_description),
+            cancelButtonText = resourceManager.getString(R.string.home_custom_base_node_no_button),
+            confirmButtonText = resourceManager.getString(R.string.common_lets_do_it),
             onConfirm = {
                 hideDialog()
                 addBaseNodeAction(baseNode, isQrData)
-            }
+            },
         ).getModular(baseNode, resourceManager)
-        modularDialog.postValue(args)
+        showModularDialog(args)
     }
 
     private fun addUserProfile(deeplink: DeepLink.UserProfile, isQrData: Boolean) {
@@ -87,18 +85,15 @@ class DeeplinkViewModel : CommonViewModel() {
         val contactDtos = getData(contacts)
         if (contactDtos.isEmpty()) return
         val names = contactDtos.joinToString(", ") { it.contact.getAlias().trim() }
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                HeadModule(resourceManager.getString(R.string.contact_deeplink_title)),
-                BodyModule(resourceManager.getString(R.string.contact_deeplink_message, contactDtos.size.toString()) + ". " + names),
-                ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Normal) {
-                    addContactsAction(contactDtos, isQrData)
-                    hideDialog()
-                },
-                ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
-            )
+        showModularDialog(
+            HeadModule(resourceManager.getString(R.string.contact_deeplink_title)),
+            BodyModule(resourceManager.getString(R.string.contact_deeplink_message, contactDtos.size.toString()) + ". " + names),
+            ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Normal) {
+                addContactsAction(contactDtos, isQrData)
+                hideDialog()
+            },
+            ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(args)
     }
 
     fun addTorBridges(deeplink: DeepLink.TorBridges, isQrData: Boolean) {

--- a/app/src/main/java/com/tari/android/wallet/application/walletManager/WalletStateHandler.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/walletManager/WalletStateHandler.kt
@@ -1,7 +1,6 @@
 package com.tari.android.wallet.application.walletManager
 
 import com.orhanobut.logger.Logger
-import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.ffi.FFIWallet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,7 +11,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
-
 
 @Singleton
 class WalletStateHandler @Inject constructor() {

--- a/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/TorModule.kt
@@ -51,7 +51,7 @@ class TorModule {
     @Provides
     @Singleton
     fun provideTorConfig(context: Context): TorConfig {
-        val cookieFilePath = File(context.getDir(TorProxyManager.torDataDirectoryName, Context.MODE_PRIVATE), "control_auth_cookie").absolutePath
+        val cookieFilePath = File(context.getDir(TorProxyManager.TOR_DATA_DIRECTORY_NAME, Context.MODE_PRIVATE), "control_auth_cookie").absolutePath
 
         return TorConfig(
             controlPort = 39069,

--- a/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/extension/FlowExtensions.kt
@@ -1,5 +1,6 @@
 package com.tari.android.wallet.extension
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -15,6 +16,14 @@ inline fun LifecycleOwner.launchAndRepeatOnLifecycle(
     state: Lifecycle.State,
     crossinline block: suspend CoroutineScope.() -> Unit,
 ) = lifecycleScope.launch { repeatOnLifecycle(state) { block() } }
+
+fun <T> AppCompatActivity.collectFlow(stateFlow: Flow<T>, action: (T) -> Unit) {
+    launchAndRepeatOnLifecycle(Lifecycle.State.STARTED) {
+        stateFlow.collect { state ->
+            action(state)
+        }
+    }
+}
 
 fun <T> Fragment.collectFlow(stateFlow: Flow<T>, action: (T) -> Unit) {
     viewLifecycleOwner.launchAndRepeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/java/com/tari/android/wallet/tor/TorProxyManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/tor/TorProxyManager.kt
@@ -57,10 +57,10 @@ class TorProxyManager @Inject constructor(
 ) {
 
     companion object {
-        const val torDataDirectoryName = "tor_data"
+        const val TOR_DATA_DIRECTORY_NAME = "tor_data"
     }
 
-    private val appCacheHome = context.getDir(torDataDirectoryName, Service.MODE_PRIVATE)
+    private val appCacheHome = context.getDir(TOR_DATA_DIRECTORY_NAME, Service.MODE_PRIVATE)
     private val torProxyControl: TorProxyControl
     private val logger
         get() = Logger.t(LoggerTags.Connection.name)

--- a/app/src/main/java/com/tari/android/wallet/tor/TorProxyState.kt
+++ b/app/src/main/java/com/tari/android/wallet/tor/TorProxyState.kt
@@ -38,11 +38,8 @@ package com.tari.android.wallet.tor
  * @author The Tari Development Team
  */
 sealed class TorProxyState {
-    object NotReady : TorProxyState()
-
+    data object NotReady : TorProxyState()
     data class Initializing(val bootstrapStatus: TorBootstrapStatus? = null) : TorProxyState()
-
     data class Running(val bootstrapStatus: TorBootstrapStatus) : TorProxyState()
-
-    class Failed(val e: Throwable) : TorProxyState()
+    data class Failed(val e: Throwable) : TorProxyState()
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -77,6 +77,9 @@ open class CommonViewModel : ViewModel() {
     @Inject
     lateinit var walletStateHandler: WalletStateHandler
 
+    @Inject
+    lateinit var dialogManager: DialogManager
+
     private var authorizedAction: (() -> Unit)? = null
 
     val logger: Printer
@@ -195,11 +198,11 @@ open class CommonViewModel : ViewModel() {
     }
 
     fun showErrorDialog(error: CoreError) {
-        showModularDialog(WalletErrorArgs(resourceManager, error).getErrorArgs().getModular(resourceManager))
+        showModularDialog(WalletErrorArgs(resourceManager, error).getErrorArgs().getModular(resourceManager, isRefreshing = true))
     }
 
     fun showErrorDialog(exception: Throwable) {
-        showModularDialog(WalletErrorArgs(resourceManager, exception).getErrorArgs().getModular(resourceManager))
+        showModularDialog(WalletErrorArgs(resourceManager, exception).getErrorArgs().getModular(resourceManager, isRefreshing = true))
     }
 
     fun hideDialog() {

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -95,15 +95,17 @@ open class CommonViewModel : ViewModel() {
     protected val _copyToClipboard = SingleLiveEvent<ClipboardArgs>()
     val copyToClipboard: LiveData<ClipboardArgs> = _copyToClipboard
 
-    val modularDialog = SingleLiveEvent<ModularDialogArgs>()
+    private val _modularDialog = SingleLiveEvent<ModularDialogArgs>()
+    val modularDialog: LiveData<ModularDialogArgs> = _modularDialog
 
-    protected val _inputDialog = SingleLiveEvent<ModularDialogArgs>()
+    private val _inputDialog = SingleLiveEvent<ModularDialogArgs>()
     val inputDialog: LiveData<ModularDialogArgs> = _inputDialog
 
-    protected val _loadingDialog = SingleLiveEvent<ProgressDialogArgs>()
+    private val _loadingDialog = SingleLiveEvent<ProgressDialogArgs>()
     val loadingDialog: LiveData<ProgressDialogArgs> = _loadingDialog
 
-    val dismissDialog: SingleLiveEvent<Unit> = SingleLiveEvent()
+    private val _dismissDialog = SingleLiveEvent<Unit>()
+    val dismissDialog: LiveData<Unit> = _dismissDialog
 
     protected val _blockedBackPressed = SingleLiveEvent<Boolean>()
     val blockedBackPressed: LiveData<Boolean> = _blockedBackPressed
@@ -173,11 +175,11 @@ open class CommonViewModel : ViewModel() {
     fun doOnBackground(action: suspend CoroutineScope.() -> Unit): Job = viewModelScope.launch { action() }
 
     fun showModularDialog(args: ModularDialogArgs) {
-        modularDialog.postValue(args)
+        _modularDialog.postValue(args)
     }
 
     fun showModularDialog(vararg modules: IDialogModule) {
-        modularDialog.postValue(ModularDialogArgs(modules = modules.toList()))
+        _modularDialog.postValue(ModularDialogArgs(modules = modules.toList()))
     }
 
     fun showLoadingDialog(progressArgs: ProgressDialogArgs) {
@@ -186,6 +188,10 @@ open class CommonViewModel : ViewModel() {
 
     fun showInputModalDialog(inputArgs: ModularDialogArgs) {
         _inputDialog.postValue(inputArgs)
+    }
+
+    fun showInputModalDialog(vararg modules: IDialogModule) {
+        _inputDialog.postValue(ModularDialogArgs(modules = modules.toList()))
     }
 
     fun showErrorDialog(error: CoreError) {
@@ -198,7 +204,7 @@ open class CommonViewModel : ViewModel() {
 
     fun hideDialog() {
         viewModelScope.launch(Dispatchers.Main) {
-            dismissDialog.postValue(Unit)
+            _dismissDialog.postValue(Unit)
         }
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -20,7 +20,6 @@ import com.tari.android.wallet.infrastructure.logging.LoggerTags
 import com.tari.android.wallet.model.CoreError
 import com.tari.android.wallet.service.TariWalletService
 import com.tari.android.wallet.service.connection.TariWalletServiceConnection
-import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.domain.ResourceManager
 import com.tari.android.wallet.ui.common.permission.PermissionManager
 import com.tari.android.wallet.ui.component.tari.toast.TariToastArgs
@@ -60,9 +59,6 @@ open class CommonViewModel : ViewModel() {
 
     @Inject
     lateinit var tariSettingsSharedRepository: TariSettingsPrefRepository
-
-    @Inject
-    lateinit var paletteManager: PaletteManager
 
     @Inject
     lateinit var tariNavigator: TariNavigator

--- a/app/src/main/java/com/tari/android/wallet/ui/common/DialogManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/DialogManager.kt
@@ -1,46 +1,45 @@
 package com.tari.android.wallet.ui.common
 
-import android.content.Context
 import com.tari.android.wallet.ui.dialog.TariDialog
-import com.tari.android.wallet.ui.dialog.inProgress.ProgressDialogArgs
 import com.tari.android.wallet.ui.dialog.inProgress.TariProgressDialog
 import com.tari.android.wallet.ui.dialog.modular.ModularDialog
+import com.tari.android.wallet.ui.dialog.modular.isRefreshing
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class DialogManager {
-
-    var context: Context? = null
+@Singleton
+class DialogManager @Inject constructor() {
 
     private val dialogQueue = mutableListOf<TariDialog>()
 
     private val currentDialog: TariDialog?
         get() = dialogQueue.lastOrNull()
 
-    fun handleProgress(progressDialogArgs: ProgressDialogArgs) {
-        if (progressDialogArgs.isShow) replace(TariProgressDialog(context!!, progressDialogArgs)) else currentDialog?.dismiss()
-    }
+    fun replace(newDialog: TariDialog) {
+        currentDialog.let { currentDialog ->
+            when {
+                currentDialog != null && newDialog.isRefreshing -> {
+                    /* do nothing */
+                    return
+                }
 
-    fun replace(dialog: TariDialog) {
-        val currentLoadingDialog = currentDialog as? TariProgressDialog
-        if (currentLoadingDialog != null && currentLoadingDialog.isShowing() && dialog is TariProgressDialog) {
-            currentLoadingDialog.applyArgs(dialog.progressDialogArgs)
-            return
-        }
-        val currentModularDialog = currentDialog as? ModularDialog
-        val newModularDialog = dialog as? ModularDialog
-        if (currentModularDialog != null && newModularDialog != null && currentModularDialog.args::class.java == newModularDialog.args::class.java
-            && currentModularDialog.isShowing()
-        ) {
-            currentModularDialog.applyArgs(newModularDialog.args)
-            return
-        }
+                currentDialog is TariProgressDialog && newDialog is TariProgressDialog && currentDialog.isShowing() -> {
+                    currentDialog.applyArgs(newDialog.progressDialogArgs)
+                    return
+                }
 
-        if (newModularDialog?.args?.dialogArgs?.isRefreshing == true) {
-            return
-        }
+                currentDialog is ModularDialog && newDialog is ModularDialog && currentDialog.args::class.java == newDialog.args::class.java -> {
+                    currentDialog.applyArgs(newDialog.args)
+                    return
+                }
 
-        dialog.addDismissListener { dialogQueue.remove(dialog) }
-        dialogQueue.add(dialog)
-        dialog.show()
+                else -> {
+                    newDialog.addDismissListener { dialogQueue.remove(newDialog) }
+                    dialogQueue.add(newDialog)
+                    newDialog.show()
+                }
+            }
+        }
     }
 
     fun dismiss() {

--- a/app/src/main/java/com/tari/android/wallet/ui/common/domain/PaletteManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/domain/PaletteManager.kt
@@ -4,11 +4,8 @@ import android.content.Context
 import com.tari.android.wallet.R
 import com.tari.android.wallet.ui.extension.color
 import com.tari.android.wallet.ui.extension.colorFromAttribute
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class PaletteManager @Inject constructor() {
+object PaletteManager {
 
     fun getTextHeading(context: Context): Int = context.colorFromAttribute(R.attr.palette_text_heading)
 
@@ -55,7 +52,6 @@ class PaletteManager @Inject constructor() {
     fun getIconInactive(context: Context) = context.colorFromAttribute(R.attr.palette_icons_inactive)
 
     fun getShadowBox(context: Context) = context.colorFromAttribute(R.attr.palette_shadow_box)
-
 
     fun getWhite(context: Context): Int = context.color(R.color.white)
 

--- a/app/src/main/java/com/tari/android/wallet/ui/common/recyclerView/CommonViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/recyclerView/CommonViewHolder.kt
@@ -3,7 +3,6 @@ package com.tari.android.wallet.ui.common.recyclerView
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
-import com.tari.android.wallet.ui.common.domain.PaletteManager
 
 abstract class CommonViewHolder<T : CommonViewHolderItem, VB: ViewBinding>(val ui: VB) : RecyclerView.ViewHolder(ui.root) {
 
@@ -13,8 +12,6 @@ abstract class CommonViewHolder<T : CommonViewHolderItem, VB: ViewBinding>(val u
         get() = item?.javaClass
 
     var clickView : View? = null
-
-    val paletteManager = PaletteManager()
 
     open fun bind(item: T) {
         this.item = item

--- a/app/src/main/java/com/tari/android/wallet/ui/component/clipboardController/ClipboardController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/clipboardController/ClipboardController.kt
@@ -44,6 +44,7 @@ import com.daasuu.ei.EasingInterpolator
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.ViewClipboardWalletBinding
 import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.extension.dimenPx
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.hideKeyboard
@@ -102,10 +103,10 @@ class ClipboardController(
      */
     private fun showPasteEmojiIdViews(emojiId: String) {
         ui.emojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
-            emojiId,
-            context.string(R.string.emoji_id_chunk_separator),
-            viewModel.paletteManager.getBlack(context),
-            viewModel.paletteManager.getLightGray(context)
+            emojiId = emojiId,
+            separator = context.string(R.string.emoji_id_chunk_separator),
+            darkColor = PaletteManager.getBlack(context),
+            lightColor = PaletteManager.getLightGray(context)
         )
         ui.emojiIdContainerView.setBottomMargin(-context.dimenPx(R.dimen.add_recipient_clipboard_emoji_id_container_height))
         ui.emojiIdContainerView.visible()

--- a/app/src/main/java/com/tari/android/wallet/ui/component/common/CommonView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/common/CommonView.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.viewbinding.ViewBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.DialogManager
-import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.component.tari.toast.TariToast
 import com.tari.android.wallet.ui.dialog.modular.ModularDialog
 
@@ -23,8 +22,6 @@ abstract class CommonView<VM : CommonViewModel, VB : ViewBinding> : LinearLayout
         private set
 
     private val dialogManager = DialogManager()
-
-    val paletteManager = PaletteManager()
 
     abstract fun bindingInflate(layoutInflater: LayoutInflater, parent: ViewGroup?, attachToRoot: Boolean): VB
 

--- a/app/src/main/java/com/tari/android/wallet/ui/component/fullEmojiId/FullEmojiIdViewController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/fullEmojiId/FullEmojiIdViewController.kt
@@ -58,8 +58,8 @@ import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.visible
 import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.EmojiUtil
-import com.tari.android.wallet.util.EmojiUtil.Companion.getGraphemeLength
 import com.tari.android.wallet.util.EmojiUtil.Companion.SMALL_EMOJI_ID_SIZE
+import com.tari.android.wallet.util.EmojiUtil.Companion.getGraphemeLength
 import me.everything.android.ui.overscroll.OverScrollDecoratorHelper
 
 /**
@@ -74,7 +74,6 @@ class FullEmojiIdViewController(
     private val listener: Listener? = null
 ) {
     private val emojiIdCopiedViewController = EmojiIdCopiedViewController(ui.emojiIdCopiedView)
-    private val paletteManager = PaletteManager()
     private val summaryParent = summary.root.parent as View
     private var _fullEmojiId = ""
 
@@ -296,8 +295,8 @@ class FullEmojiIdViewController(
         ui.fullEmojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
             _fullEmojiId,
             string(R.string.emoji_id_chunk_separator),
-            paletteManager.getBlack(context),
-            paletteManager.getLightGray(context)
+            PaletteManager.getBlack(context),
+            PaletteManager.getLightGray(context)
         )
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
@@ -44,14 +44,15 @@ class ConnectionIndicatorViewModel : CommonViewModel() {
         _baseNodeState.value ?: return
         _syncState.value ?: return
 
-        val args = ModularDialogArgs(
-            DialogArgs(isRefreshing = isRefreshing), listOf(
-                HeadModule(resourceManager.getString(R.string.connection_status_dialog_title)),
-                ConnectionStatusesModule(_networkState.value!!, _torProxyState.value!!, _baseNodeState.value!!, _syncState.value!!),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
+        showModularDialog(
+            ModularDialogArgs(
+                DialogArgs(isRefreshing = isRefreshing), listOf(
+                    HeadModule(resourceManager.getString(R.string.connection_status_dialog_title)),
+                    ConnectionStatusesModule(_networkState.value!!, _torProxyState.value!!, _baseNodeState.value!!, _syncState.value!!),
+                    ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
+                )
             )
         )
-        modularDialog.postValue(args)
     }
 
     private fun subscribeOnEventBus() {

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariBackground.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariBackground.kt
@@ -41,7 +41,7 @@ abstract class TariBackground(context: Context, attrs: AttributeSet) : Constrain
         when {
             backElevation != 0.0F -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    val shadowColor = PaletteManager().getShadowBox(context)
+                    val shadowColor = PaletteManager.getShadowBox(context)
                     outlineSpotShadowColor = shadowColor
                     this.outlineProvider = object : ViewOutlineProvider() {
                         override fun getOutline(view: View?, outline: Outline?) {

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariCheckbox.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariCheckbox.kt
@@ -9,7 +9,7 @@ import com.tari.android.wallet.ui.common.domain.PaletteManager
 class TariCheckbox(context: Context, attrs: AttributeSet) : AppCompatCheckBox(context, attrs) {
 
     init {
-        buttonTintList = ColorStateList.valueOf(PaletteManager().getPurpleBrand(context))
+        buttonTintList = ColorStateList.valueOf(PaletteManager.getPurpleBrand(context))
         typeface = TariFont.getFromAttributeSet(context, attrs)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariDivider.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariDivider.kt
@@ -8,7 +8,7 @@ import com.tari.android.wallet.ui.common.domain.PaletteManager
 class TariDivider(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     init {
-        val backColor = PaletteManager().getNeutralSecondary(context)
+        val backColor = PaletteManager.getNeutralSecondary(context)
         setBackgroundColor(backColor)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariIconView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariIconView.kt
@@ -9,6 +9,6 @@ import com.tari.android.wallet.ui.common.domain.PaletteManager
 class TariIconView(context: Context, attrs: AttributeSet) : AppCompatImageView(context, attrs) {
 
     init {
-        imageTintList = ColorStateList.valueOf(PaletteManager().getIconDefault(context))
+        imageTintList = ColorStateList.valueOf(PaletteManager.getIconDefault(context))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariInput.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariInput.kt
@@ -42,17 +42,17 @@ import androidx.core.widget.addTextChangedListener
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.TariInputBinding
 import com.tari.android.wallet.ui.common.domain.PaletteManager
-import com.tari.android.wallet.ui.extension.*
+import com.tari.android.wallet.ui.extension.obtain
+import com.tari.android.wallet.ui.extension.runRecycle
+import com.tari.android.wallet.ui.extension.setVisible
 
 class TariInput(context: Context, attrs: AttributeSet) : FrameLayout(context, attrs) {
 
-    val ui: TariInputBinding
-    val paletteManager = PaletteManager()
+    val ui: TariInputBinding = TariInputBinding.inflate(LayoutInflater.from(context), this, false).also { addView(it.root) }
 
     var textChangedListener: (text: CharSequence?, start: Int, before: Int, count: Int) -> Unit = { _, _, _, _ -> }
 
     init {
-        ui = TariInputBinding.inflate(LayoutInflater.from(context), this, false).also { addView(it.root) }
 
         setErrorText(null)
         setIsInvalid(false)
@@ -79,7 +79,7 @@ class TariInput(context: Context, attrs: AttributeSet) : FrameLayout(context, at
 
     fun setIsInvalid(isInvalid: Boolean) {
         ui.invalidMessage.setVisible(isInvalid)
-        val backColor = if (isInvalid) paletteManager.getRed(context) else paletteManager.getNeutralSecondary(context)
+        val backColor = if (isInvalid) PaletteManager.getRed(context) else PaletteManager.getNeutralSecondary(context)
         ui.divider.setBackgroundColor(backColor)
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariPrimaryBackground.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariPrimaryBackground.kt
@@ -10,7 +10,7 @@ import com.tari.android.wallet.ui.extension.runRecycle
 class TariPrimaryBackground(context: Context, attrs: AttributeSet) : TariBackground(context, attrs) {
 
     init {
-        val backColor = PaletteManager().getBackgroundPrimary(context)
+        val backColor = PaletteManager.getBackgroundPrimary(context)
 
         obtain(attrs, R.styleable.TariPrimaryBackground).runRecycle {
             val r = getDimension(R.styleable.TariPrimaryBackground_cornerRadius, 0.0F)

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariProgressBar.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariProgressBar.kt
@@ -8,13 +8,11 @@ import com.tari.android.wallet.ui.extension.setColor
 
 class TariProgressBar(context: Context, attrs: AttributeSet) : ProgressBar(context, attrs) {
 
-    private val paletteManager = PaletteManager()
-
     init {
-        setColor(paletteManager.getPurpleBrand(context))
+        setColor(PaletteManager.getPurpleBrand(context))
     }
 
-    fun setWhite() = setColor(paletteManager.getWhite(context))
+    fun setWhite() = setColor(PaletteManager.getWhite(context))
 
-    fun setError() = setColor(paletteManager.getRed(context))
+    fun setError() = setColor(PaletteManager.getRed(context))
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariQrBackground.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariQrBackground.kt
@@ -10,7 +10,7 @@ import com.tari.android.wallet.ui.extension.runRecycle
 class TariQrBackground(context: Context, attrs: AttributeSet) : TariBackground(context, attrs) {
 
     init {
-        val backColor = PaletteManager().getBackgroundQr(context)
+        val backColor = PaletteManager.getBackgroundQr(context)
 
         obtain(attrs, R.styleable.TariQrBackground).runRecycle {
             val r = getDimension(R.styleable.TariQrBackground_cornerRadius, 0.0F)

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSecondaryBackground.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSecondaryBackground.kt
@@ -10,7 +10,7 @@ import com.tari.android.wallet.ui.extension.runRecycle
 class TariSecondaryBackground(context: Context, attrs: AttributeSet) : TariBackground(context, attrs) {
 
     init {
-        val backColor = PaletteManager().getBackgroundSecondary(context)
+        val backColor = PaletteManager.getBackgroundSecondary(context)
 
         obtain(attrs, R.styleable.TariSecondaryBackground).runRecycle {
             val r = getDimension(R.styleable.TariSecondaryBackground_cornerRadius, 0.0F)

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSeekbar.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSeekbar.kt
@@ -9,7 +9,7 @@ import com.tari.android.wallet.ui.common.domain.PaletteManager
 class TariSeekbar(context: Context, attrs: AttributeSet) : AppCompatSeekBar(context, attrs) {
 
     init {
-        val brandColor = PaletteManager().getPurpleBrand(context)
+        val brandColor = PaletteManager.getPurpleBrand(context)
         thumbTintList = ColorStateList.valueOf(brandColor)
         progressBackgroundTintList = ColorStateList.valueOf(brandColor)
         progressTintList = ColorStateList.valueOf(brandColor)

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSwitchedBackground.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariSwitchedBackground.kt
@@ -12,7 +12,7 @@ class TariSwitchedBackground(context: Context, attrs: AttributeSet) : TariBackgr
     private var isTurnedOn = false
 
     init {
-        val backColor = PaletteManager().getBackgroundPrimary(context)
+        val backColor = PaletteManager.getBackgroundPrimary(context)
 
         obtain(attrs, R.styleable.TariQrBackground).runRecycle {
             isTurnedOn = getBoolean(R.styleable.TariSwitchedBackground_turnedOn, false)

--- a/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariTertiaryDivider.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/tari/TariTertiaryDivider.kt
@@ -8,7 +8,7 @@ import com.tari.android.wallet.ui.common.domain.PaletteManager
 class TariTertiaryDivider(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     init {
-        val backColor = PaletteManager().getNeutralTertiary(context)
+        val backColor = PaletteManager.getNeutralTertiary(context)
         setBackgroundColor(backColor)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/DialogArgs.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/DialogArgs.kt
@@ -1,6 +1,6 @@
 package com.tari.android.wallet.ui.dialog.modular
 
-class DialogArgs(
+data class DialogArgs(
     val cancelable: Boolean = true,
     val canceledOnTouchOutside: Boolean = true,
     val isRefreshing: Boolean = false,

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialog.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialog.kt
@@ -12,8 +12,6 @@ import android.widget.LinearLayout
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.animation.doOnEnd
 import com.tari.android.wallet.R
-import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.SecurityStageHeadModule
-import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.SecurityStageHeadModuleView
 import com.tari.android.wallet.ui.component.networkStateIndicator.module.ConnectionStatusesModule
 import com.tari.android.wallet.ui.component.networkStateIndicator.module.ConnectionStatusesModuleView
 import com.tari.android.wallet.ui.dialog.TariDialog
@@ -41,6 +39,8 @@ import com.tari.android.wallet.ui.dialog.modular.modules.input.InputModule
 import com.tari.android.wallet.ui.dialog.modular.modules.input.InputModuleView
 import com.tari.android.wallet.ui.dialog.modular.modules.option.OptionModule
 import com.tari.android.wallet.ui.dialog.modular.modules.option.OptionModuleView
+import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.SecurityStageHeadModule
+import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.SecurityStageHeadModuleView
 import com.tari.android.wallet.ui.dialog.modular.modules.shortEmoji.ShortEmojiIdModule
 import com.tari.android.wallet.ui.dialog.modular.modules.shortEmoji.ShortEmojiModuleView
 import com.tari.android.wallet.ui.dialog.modular.modules.space.SpaceModule
@@ -181,3 +181,6 @@ open class ModularDialog(val context: Context) : TariDialog {
         }
     }
 }
+
+val TariDialog?.isRefreshing: Boolean
+    get() = this is ModularDialog && args.dialogArgs.isRefreshing

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/addressPoisoning/adapter/SimilarAddressItemViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/addressPoisoning/adapter/SimilarAddressItemViewHolder.kt
@@ -2,6 +2,7 @@ package com.tari.android.wallet.ui.dialog.modular.modules.addressPoisoning.adapt
 
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.ItemSimilarAddressBinding
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolder
 import com.tari.android.wallet.ui.common.recyclerView.ViewHolderBuilder
 import com.tari.android.wallet.ui.extension.setVisible
@@ -23,8 +24,8 @@ class SimilarAddressItemViewHolder(view: ItemSimilarAddressBinding) : CommonView
             EmojiUtil.getFullEmojiIdSpannable(
                 emojiId = ffiContact.walletAddress.emojiId,
                 separator = string(R.string.emoji_id_chunk_separator),
-                darkColor = paletteManager.getBlack(itemView.context),
-                lightColor = paletteManager.getLightGray(itemView.context),
+                darkColor = PaletteManager.getBlack(itemView.context),
+                lightColor = PaletteManager.getLightGray(itemView.context),
             )
         } ?: "" // the contact _should_ always be an FFIContactDto, because it has a wallet address
         val contactName = item.contactName

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/button/ButtonModuleView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/button/ButtonModuleView.kt
@@ -8,6 +8,7 @@ import androidx.core.content.ContextCompat
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.DialogModuleButtonBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.component.common.CommonView
 import com.tari.android.wallet.ui.extension.setOnThrottledClickListener
 
@@ -32,17 +33,17 @@ class ButtonModuleView : CommonView<CommonViewModel, DialogModuleButtonBinding> 
         ui.button.text = buttonModule.text
         when (buttonModule.style) {
             ButtonStyle.Normal -> {
-                ui.button.setTextColor(paletteManager.getButtonPrimaryText(context))
+                ui.button.setTextColor(PaletteManager.getButtonPrimaryText(context))
                 ui.button.background = ContextCompat.getDrawable(context, R.drawable.vector_disable_able_gradient_button_bg)
             }
 
             ButtonStyle.Warning -> {
-                ui.button.setTextColor(paletteManager.getButtonPrimaryText(context))
+                ui.button.setTextColor(PaletteManager.getButtonPrimaryText(context))
                 ui.button.background = ContextCompat.getDrawable(context, R.drawable.vector_destructive_action_button_bg)
             }
 
             ButtonStyle.Close -> {
-                ui.button.setTextColor(paletteManager.getOverlayText(context))
+                ui.button.setTextColor(PaletteManager.getOverlayText(context))
                 ui.button.background = null
             }
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/yatInput/YatInputModuleView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/yatInput/YatInputModuleView.kt
@@ -60,8 +60,8 @@ class YatInputModuleView(context: Context, private val inputModule: YatInputModu
 
             launch(Dispatchers.Main) {
                 isLoading(false)
-                ui.yat.imageTintList = if (yatInfo) createColorStateList(PaletteManager().getIconDefault(context))
-                else createColorStateList(PaletteManager().getIconInactive(context))
+                ui.yat.imageTintList = if (yatInfo) createColorStateList(PaletteManager.getIconDefault(context))
+                else createColorStateList(PaletteManager.getIconInactive(context))
             }
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/AuthActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/AuthActivity.kt
@@ -49,6 +49,7 @@ import com.tari.android.wallet.databinding.ActivityAuthBinding
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthenticationException
 import com.tari.android.wallet.ui.common.CommonActivity
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.extension.setColor
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.visible
@@ -151,7 +152,7 @@ class AuthActivity : CommonActivity<ActivityAuthBinding, AuthViewModel>() {
         viewModel.securityPrefRepository.saveAttempt(LoginAttemptDto(System.currentTimeMillis(), true))
         lifecycleScope.launch(Dispatchers.Main) {
             ui.loader.visible()
-            ui.progressBar.setColor(viewModel.paletteManager.getPurpleBrand(this@AuthActivity))
+            ui.progressBar.setColor(PaletteManager.getPurpleBrand(this@AuthActivity))
             continueToHomeActivity()
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/AuthViewModel.kt
@@ -7,8 +7,6 @@ import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthen
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
@@ -51,20 +49,18 @@ class AuthViewModel : CommonViewModel() {
     }
 
     private fun showIncompatibleVersionDialog() {
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                HeadModule(resourceManager.getString(R.string.ffi_validation_error_title)),
-                BodyModule(resourceManager.getString(R.string.ffi_validation_error_message)),
-                ButtonModule(resourceManager.getString(R.string.ffi_validation_error_delete), ButtonStyle.Warning) {
-                    dismissDialog.postValue(Unit)
-                    deleteWallet()
-                },
-                ButtonModule(resourceManager.getString(R.string.ffi_validation_error_cancel), ButtonStyle.Close) {
-                    goAuth.postValue(Unit)
-                    dismissDialog.postValue(Unit)
-                }
-            ))
-        modularDialog.postValue(args)
+        showModularDialog(
+            HeadModule(resourceManager.getString(R.string.ffi_validation_error_title)),
+            BodyModule(resourceManager.getString(R.string.ffi_validation_error_message)),
+            ButtonModule(resourceManager.getString(R.string.ffi_validation_error_delete), ButtonStyle.Warning) {
+                hideDialog()
+                deleteWallet()
+            },
+            ButtonModule(resourceManager.getString(R.string.ffi_validation_error_cancel), ButtonStyle.Close) {
+                goAuth.postValue(Unit)
+                hideDialog()
+            }
+        )
     }
 
     private fun deleteWallet() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/FeatureAuthFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/auth/FeatureAuthFragment.kt
@@ -50,6 +50,7 @@ import com.tari.android.wallet.databinding.FragmentFeatureAuthBinding
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthenticationException
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.extension.setColor
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.visible
@@ -146,7 +147,7 @@ class FeatureAuthFragment : CommonFragment<FragmentFeatureAuthBinding, AuthViewM
         viewModel.securityPrefRepository.saveAttempt(LoginAttemptDto(System.currentTimeMillis(), true))
         lifecycleScope.launch(Dispatchers.Main) {
             ui.loader.visible()
-            ui.progressBar.setColor(viewModel.paletteManager.getPurpleBrand(requireContext()))
+            ui.progressBar.setColor(PaletteManager.getPurpleBrand(requireContext()))
 
             viewModel.securityPrefRepository.isFeatureAuthenticated = true
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contactSelection/ContactSelectionFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contactSelection/ContactSelectionFragment.kt
@@ -29,6 +29,7 @@ import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.extension.observeOnLoad
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.recyclerView.CommonAdapter
 import com.tari.android.wallet.ui.component.clipboardController.ClipboardController
 import com.tari.android.wallet.ui.component.tari.toolbar.TariToolbarActionArg
@@ -323,7 +324,7 @@ open class ContactSelectionFragment : CommonFragment<FragmentContactsSelectionBi
             for ((offset, index) in EmojiUtil.getNewChunkSeparatorIndices(textWithoutSeparators).withIndex()) {
                 val chunkSeparatorSpannable = EmojiUtil.getChunkSeparatorSpannable(
                     separator = addressSeparator,
-                    color = viewModel.paletteManager.getLightGray(requireContext()),
+                    color = PaletteManager.getLightGray(requireContext()),
                 )
                 val target = index + (offset * addressSeparator.length)
                 editable.insert(target, chunkSeparatorSpannable)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/ContactsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/ContactsFragment.kt
@@ -42,6 +42,7 @@ import com.tari.android.wallet.databinding.FragmentContactsBinding
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.extension.observeOnLoad
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.recyclerView.CommonAdapter
 import com.tari.android.wallet.ui.fragment.contact_book.contacts.adapter.ContactListAdapter
 
@@ -80,7 +81,7 @@ open class ContactsFragment : CommonFragment<FragmentContactsBinding, ContactsVi
     private fun setupUI() = with(ui) {
         setupRecyclerView()
         swipeRefreshLayout.setOnRefreshListener { viewModel.refresh() }
-        swipeRefreshLayout.setColorSchemeColors(viewModel.paletteManager.getPurpleBrand(requireContext()))
+        swipeRefreshLayout.setColorSchemeColors(PaletteManager.getPurpleBrand(requireContext()))
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/adapter/contact/badges/BadgesController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/contacts/adapter/contact/badges/BadgesController.kt
@@ -23,7 +23,7 @@ class BadgesController(val view: ItemContactBinding) {
     private var lastAnimator: ValueAnimator? = null
 
     init {
-        view.profileBadgesContainer.updateBack(backColor = PaletteManager().getPurpleBrand(view.root.context))
+        view.profileBadgesContainer.updateBack(backColor = PaletteManager.getPurpleBrand(view.root.context))
         view.profileBadgesContainer.switch(false)
         view.profileBadgesContainerInner.outlineProvider = view.profileBadgesContainer.outlineProvider
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/details/ContactDetailsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/details/ContactDetailsViewModel.kt
@@ -22,6 +22,7 @@ import com.tari.android.wallet.R.string.contact_book_details_delete_button_title
 import com.tari.android.wallet.R.string.contact_book_details_delete_contact
 import com.tari.android.wallet.R.string.contact_book_details_delete_message
 import com.tari.android.wallet.R.string.contact_book_details_edit_title
+import com.tari.android.wallet.application.YatAdapter
 import com.tari.android.wallet.databinding.ViewEmojiIdWithYatSummaryBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
@@ -50,7 +51,6 @@ import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.settings.allSettings.row.SettingsRowStyle
 import com.tari.android.wallet.ui.fragment.settings.allSettings.row.SettingsRowViewDto
 import com.tari.android.wallet.ui.fragment.settings.allSettings.title.SettingsTitleViewHolderItem
-import com.tari.android.wallet.application.YatAdapter
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -235,8 +235,7 @@ class ContactDetailsViewModel : CommonViewModel() {
             true
         }
 
-        val args = ModularDialogArgs(DialogArgs(), moduleList)
-        _inputDialog.postValue(args)
+        showInputModalDialog(ModularDialogArgs(DialogArgs(), moduleList))
     }
 
     private suspend fun yatSearchAction(yat: String): Boolean {
@@ -274,7 +273,7 @@ class ContactDetailsViewModel : CommonViewModel() {
         val firstLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(contact_book_contacts_book_unlink_message_firstLine))
         val secondLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(contact_book_contacts_book_unlink_message_secondLine, name))
 
-        val modules = listOf(
+        showModularDialog(
             HeadModule(resourceManager.getString(contact_book_contacts_book_unlink_title)),
             BodyModule(null, SpannableString(firstLineHtml)),
             ShortEmojiIdModule(walletAddress),
@@ -288,7 +287,6 @@ class ContactDetailsViewModel : CommonViewModel() {
             },
             ButtonModule(resourceManager.getString(common_cancel), Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs(), modules))
     }
 
     private fun showUnlinkSuccessDialog() {
@@ -307,14 +305,14 @@ class ContactDetailsViewModel : CommonViewModel() {
                 BodyModule(null, SpannableString(secondLineHtml)),
                 ButtonModule(resourceManager.getString(common_close), Close)
             )
-            modularDialog.postValue(ModularDialogArgs(DialogArgs {
+            showModularDialog(ModularDialogArgs(DialogArgs {
                 navigation.value = Navigation.ContactBookNavigation.BackToContactBook
             }, modules))
         }
     }
 
     private fun showDeleteContactDialog() {
-        val modules = listOf(
+        showModularDialog(
             HeadModule(resourceManager.getString(contact_book_details_delete_contact)),
             BodyModule(resourceManager.getString(contact_book_details_delete_message)),
             ButtonModule(resourceManager.getString(contact_book_details_delete_button_title), Warning) {
@@ -328,6 +326,5 @@ class ContactDetailsViewModel : CommonViewModel() {
             },
             ButtonModule(resourceManager.getString(common_close), Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs(), modules))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/link/ContactLinkViewModel.kt
@@ -165,7 +165,7 @@ class ContactLinkViewModel : CommonViewModel() {
         val firstLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(contact_book_contacts_book_link_message_firstLine))
         val secondLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(contact_book_contacts_book_link_message_secondLine, name))
 
-        val modules = listOf(
+       showModularDialog(
             HeadModule(resourceManager.getString(contact_book_contacts_book_link_title)),
             BodyModule(null, SpannableString(firstLineHtml)),
             ShortEmojiIdModule(tariWalletAddress),
@@ -174,14 +174,13 @@ class ContactLinkViewModel : CommonViewModel() {
                 viewModelScope.launch(Dispatchers.IO) {
                     contactsRepository.linkContacts(ffiContact.value!!, phoneContactDto)
                     viewModelScope.launch(Dispatchers.Main) {
-                        dismissDialog.postValue(Unit)
+                        hideDialog()
                         showLinkSuccessDialog(phoneContactDto)
                     }
                 }
             },
             ButtonModule(resourceManager.getString(common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs(), modules))
     }
 
     private fun showLinkSuccessDialog(phoneContactDto: ContactDto) {
@@ -197,7 +196,7 @@ class ContactLinkViewModel : CommonViewModel() {
             BodyModule(null, SpannableString(secondLineHtml)),
             ButtonModule(resourceManager.getString(common_close), ButtonStyle.Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs {
+      showModularDialog(ModularDialogArgs(DialogArgs {
             navigation.value = Navigation.ContactBookNavigation.BackToContactBook
         }, modules))
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/ShareViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/ShareViewModel.kt
@@ -70,29 +70,31 @@ class ShareViewModel : CommonViewModel() {
     }
 
     fun startBLESharing() {
-        val args = ModularDialogArgs(
-            DialogArgs(canceledOnTouchOutside = false, cancelable = false) { tariBluetoothClient.stopSharing() }, listOf(
-                IconModule(R.drawable.vector_sharing_via_ble),
-                HeadModule(resourceManager.getString(R.string.share_via_bluetooth_title)),
-                BodyModule(resourceManager.getString(R.string.share_via_bluetooth_message)),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
+        showModularDialog(
+            ModularDialogArgs(
+                DialogArgs(canceledOnTouchOutside = false, cancelable = false) { tariBluetoothClient.stopSharing() }, listOf(
+                    IconModule(R.drawable.vector_sharing_via_ble),
+                    HeadModule(resourceManager.getString(R.string.share_via_bluetooth_title)),
+                    BodyModule(resourceManager.getString(R.string.share_via_bluetooth_message)),
+                    ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
+                )
             )
         )
-        modularDialog.postValue(args)
         tariBluetoothClient.startSharing(shareInfo.value.orEmpty())
     }
 
     fun doContactlessPayment() {
         permissionManager.runWithPermission(tariBluetoothClient.bluetoothPermissions) {
-            val args = ModularDialogArgs(
-                DialogArgs(canceledOnTouchOutside = false, cancelable = false) { tariBluetoothClient.stopSharing() }, listOf(
-                    IconModule(R.drawable.vector_sharing_via_ble),
-                    HeadModule(resourceManager.getString(R.string.contactless_payment_title)),
-                    BodyModule(resourceManager.getString(R.string.contactless_payment_description)),
-                    ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
+            showModularDialog(
+                ModularDialogArgs(
+                    DialogArgs(canceledOnTouchOutside = false, cancelable = false) { tariBluetoothClient.stopSharing() }, listOf(
+                        IconModule(R.drawable.vector_sharing_via_ble),
+                        HeadModule(resourceManager.getString(R.string.contactless_payment_title)),
+                        BodyModule(resourceManager.getString(R.string.contactless_payment_description)),
+                        ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
+                    )
                 )
             )
-            modularDialog.postValue(args)
             tariBluetoothClient.startDeviceScanning {
                 successfullDeviceFoundSharing(it)
             }
@@ -110,30 +112,28 @@ class ShareViewModel : CommonViewModel() {
             contactDto.contact.extractWalletAddress().emojiId.extractEmojis().take(3).joinToString("")
         }
 
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                IconModule(R.drawable.vector_sharing_via_ble),
-                HeadModule(resourceManager.getString(R.string.contactless_payment_success_title)),
-                BodyModule(resourceManager.getString(R.string.contactless_payment_success_description, name)),
-                ButtonModule(resourceManager.getString(R.string.common_lets_do_it_2), ButtonStyle.Normal) {
-                    navigation.postValue(Navigation.TxListNavigation.ToSendTariToUser(contactDto))
-                    dismissDialog.postValue(Unit)
-                },
-                ButtonModule(resourceManager.getString(R.string.common_no_2), ButtonStyle.Close)
-            )
+        showModularDialog(
+            IconModule(R.drawable.vector_sharing_via_ble),
+            HeadModule(resourceManager.getString(R.string.contactless_payment_success_title)),
+            BodyModule(resourceManager.getString(R.string.contactless_payment_success_description, name)),
+            ButtonModule(resourceManager.getString(R.string.common_lets_do_it_2), ButtonStyle.Normal) {
+                navigation.postValue(Navigation.TxListNavigation.ToSendTariToUser(contactDto))
+                hideDialog()
+            },
+            ButtonModule(resourceManager.getString(R.string.common_no_2), ButtonStyle.Close),
         )
-        modularDialog.postValue(args)
     }
 
     private fun doShareViaQrCode(deeplink: String) {
-        val args = ModularDialogArgs(
-            DialogArgs(true, canceledOnTouchOutside = true), listOf(
-                HeadModule(resourceManager.getString(R.string.share_via_qr_code_title)),
-                ShareQrCodeModule(deeplink),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
+        showModularDialog(
+            ModularDialogArgs(
+                DialogArgs(true, canceledOnTouchOutside = true), listOf(
+                    HeadModule(resourceManager.getString(R.string.share_via_qr_code_title)),
+                    ShareQrCodeModule(deeplink),
+                    ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
+                )
             )
         )
-        modularDialog.postValue(args)
     }
 
     private fun doShareViaLink(deeplink: String) {
@@ -148,27 +148,21 @@ class ShareViewModel : CommonViewModel() {
     }
 
     private fun showShareSuccessDialog() {
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                IconModule(R.drawable.vector_sharing_success),
-                HeadModule(resourceManager.getString(R.string.share_success_title)),
-                BodyModule(resourceManager.getString(R.string.share_success_message)),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
-            )
+        showModularDialog(
+            IconModule(R.drawable.vector_sharing_success),
+            HeadModule(resourceManager.getString(R.string.share_success_title)),
+            BodyModule(resourceManager.getString(R.string.share_success_message)),
+            ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
         )
-        modularDialog.postValue(args)
     }
 
     private fun showShareErrorDialog(message: String) {
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                IconModule(R.drawable.vector_sharing_failed),
-                HeadModule(resourceManager.getString(R.string.common_error_title)),
-                BodyModule(message),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
-            )
+        showModularDialog(
+            IconModule(R.drawable.vector_sharing_failed),
+            HeadModule(resourceManager.getString(R.string.common_error_title)),
+            BodyModule(message),
+            ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
         )
-        modularDialog.postValue(args)
     }
 
     private fun onReceived(data: List<DeepLink.Contacts.DeeplinkContact>) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/action_menu/ContactBookActionMenuViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/action_menu/ContactBookActionMenuViewModel.kt
@@ -63,7 +63,7 @@ class ContactBookActionMenuViewModel : CommonViewModel() {
         val firstLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(R.string.contact_book_contacts_book_unlink_message_firstLine))
         val secondLineHtml = HtmlHelper.getSpannedText(resourceManager.getString(R.string.contact_book_contacts_book_unlink_message_secondLine, name))
 
-        val modules = listOf(
+        showModularDialog(
             HeadModule(resourceManager.getString(R.string.contact_book_contacts_book_unlink_title)),
             BodyModule(null, SpannableString(firstLineHtml)),
             ShortEmojiIdModule(walletAddress),
@@ -79,7 +79,6 @@ class ContactBookActionMenuViewModel : CommonViewModel() {
             },
             ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs(), modules))
     }
 
     private fun showUnlinkSuccessDialog(contact: ContactDto) {
@@ -97,7 +96,7 @@ class ContactBookActionMenuViewModel : CommonViewModel() {
             BodyModule(null, SpannableString(secondLineHtml)),
             ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(ModularDialogArgs(DialogArgs {
+        showModularDialog(ModularDialogArgs(DialogArgs {
             navigation.value = Navigation.ContactBookNavigation.BackToContactBook
         }, modules))
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/share/ShareOptionView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contact_book/root/share/ShareOptionView.kt
@@ -37,12 +37,11 @@ class ShareOptionView @JvmOverloads constructor(
             width = backSize
         }
         ui.text.text = args.title
-        val paletteManager = PaletteManager()
-        val textColor = if (args.isSelected) paletteManager.getTextHeading(context) else paletteManager.getTextBody(context)
+        val textColor = if (args.isSelected) PaletteManager.getTextHeading(context) else PaletteManager.getTextBody(context)
         ui.text.setTextColor(textColor)
-        val backgroundColor = if (args.isSelected) paletteManager.getPurpleBrand(context) else paletteManager.getBackgroundPrimary(context)
+        val backgroundColor = if (args.isSelected) PaletteManager.getPurpleBrand(context) else PaletteManager.getBackgroundPrimary(context)
         ui.optionBackground.updateBack(backColor = backgroundColor)
-        val iconColor = if (args.isSelected) paletteManager.getBackgroundPrimary(context) else paletteManager.getTextHeading(context)
+        val iconColor = if (args.isSelected) PaletteManager.getBackgroundPrimary(context) else PaletteManager.getTextHeading(context)
         ui.icon.setColorFilter(iconColor)
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/HomeActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/HomeActivity.kt
@@ -57,6 +57,7 @@ import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.model.TxId
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonActivity
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.domain.ResourceManager
 import com.tari.android.wallet.ui.extension.parcelable
 import com.tari.android.wallet.ui.extension.setVisible
@@ -280,7 +281,7 @@ class HomeActivity : CommonActivity<ActivityHomeBinding, HomeViewModel>() {
 
     private fun enableNavigationView(view: ImageView) {
         arrayOf(ui.homeImageView, ui.storeImageView, ui.chatImageView, ui.settingsImageView).forEach { it.clearColorFilter() }
-        view.setColorFilter(viewModel.paletteManager.getPurpleBrand(this))
+        view.setColorFilter(PaletteManager.getPurpleBrand(this))
     }
 
     private fun checkScreensDeeplink(intent: Intent) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowFragment.kt
@@ -1,0 +1,12 @@
+package com.tari.android.wallet.ui.fragment.onboarding.activity
+
+import androidx.viewbinding.ViewBinding
+import com.tari.android.wallet.extension.safeCastTo
+import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.CommonViewModel
+
+abstract class OnboardingFlowFragment<Binding : ViewBinding, VM : CommonViewModel> : CommonFragment<Binding, VM>() {
+
+    val onboardingListener: OnboardingFlowListener
+        get() = requireActivity().safeCastTo<OnboardingFlowListener>() ?: error("Should implement be started from OnboardingActivity")
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowListener.kt
@@ -1,0 +1,8 @@
+package com.tari.android.wallet.ui.fragment.onboarding.activity
+
+interface OnboardingFlowListener {
+    fun continueToEnableAuth()
+    fun continueToCreateWallet()
+    fun onAuthSuccess()
+    fun navigateToNetworkSelection()
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowModel.kt
@@ -1,0 +1,7 @@
+package com.tari.android.wallet.ui.fragment.onboarding.activity
+
+object OnboardingFlowModel {
+    sealed class Effect{
+        data object ResetFlow : Effect()
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/activity/OnboardingFlowViewModel.kt
@@ -1,5 +1,36 @@
 package com.tari.android.wallet.ui.fragment.onboarding.activity
 
+import androidx.lifecycle.viewModelScope
+import com.tari.android.wallet.R
+import com.tari.android.wallet.event.EffectChannelFlow
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
+import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
+import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
+import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
+import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowModel.Effect
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
-class OnboardingFlowViewModel: CommonViewModel()
+class OnboardingFlowViewModel : CommonViewModel() {
+
+    private val _effect = EffectChannelFlow<Effect>()
+    val effect: Flow<Effect> = _effect.flow
+
+    fun showResetFlowDialog() {
+        showModularDialog(
+            HeadModule(resourceManager.getString(R.string.create_wallet_cancel_dialog_title)),
+            BodyModule(resourceManager.getString(R.string.create_wallet_cancel_dialog_description)),
+            ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Warning) {
+                viewModelScope.launch(Dispatchers.Main) {
+                    _effect.send(Effect.ResetFlow)
+                    hideDialog()
+                }
+            },
+            ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close) {
+                hideDialog()
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
@@ -59,6 +59,7 @@ import com.tari.android.wallet.application.walletManager.WalletStateHandler
 import com.tari.android.wallet.databinding.FragmentCreateWalletBinding
 import com.tari.android.wallet.di.DiContainer
 import com.tari.android.wallet.extension.applyFontStyle
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.component.fullEmojiId.EmojiIdSummaryViewController
 import com.tari.android.wallet.ui.component.tari.TariFont
 import com.tari.android.wallet.ui.extension.animateClick
@@ -260,8 +261,8 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
                         ui.emojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
                             emojiId,
                             string(emoji_id_chunk_separator),
-                            viewModel.paletteManager.getBlack(requireContext()),
-                            viewModel.paletteManager.getLightGray(requireContext())
+                            PaletteManager.getBlack(requireContext()),
+                            PaletteManager.getLightGray(requireContext())
                         )
                         emojiIdSummaryController.display(emojiId)
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
@@ -127,10 +127,10 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
         emojiIdSummaryController = EmojiIdSummaryViewController(ui.emojiIdSummaryView.root)
         ui.apply {
             yourEmojiIdTitleTextView.text = string(create_wallet_your_emoji_id_text_label).applyFontStyle(
-                requireActivity(),
-                TariFont.AVENIR_LT_STD_LIGHT,
-                listOf(string(create_wallet_your_emoji_id_text_label_bold_part)),
-                TariFont.AVENIR_LT_STD_BLACK
+                context = requireActivity(),
+                defaultFont = TariFont.AVENIR_LT_STD_LIGHT,
+                search = listOf(string(create_wallet_your_emoji_id_text_label_bold_part)),
+                tariFont = TariFont.AVENIR_LT_STD_BLACK,
             )
             bottomSpinnerLottieAnimationView.alpha = 0f
             bottomSpinnerLottieAnimationView.scaleX = 0.5F
@@ -153,8 +153,10 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
             continueButton.setOnClickListener { onContinueButtonClick() }
             createEmojiIdButton.setOnClickListener { onCreateEmojiIdButtonClick() }
             emojiIdTextView.setOnClickListener { fullEmojiIdTextViewClicked(it) }
-            arrayOf(seeFullEmojiIdButton, emojiIdSummaryContainerView)
-                .forEach { it.setOnClickListener(this@CreateWalletFragment::onSeeFullEmojiIdButtonClicked) }
+            arrayOf(
+                seeFullEmojiIdButton,
+                emojiIdSummaryContainerView
+            ).forEach { it.setOnClickListener(this@CreateWalletFragment::onSeeFullEmojiIdButtonClicked) }
         }
     }
 
@@ -257,12 +259,12 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
                 override fun onAnimationEnd(animation: Animator) {
                     super.onAnimationEnd(animation)
                     runCatching {
-                        val emojiId = viewModel.sharedPrefsWrapper.emojiId!!
+                        val emojiId = viewModel.corePrefRepository.emojiId!!
                         ui.emojiIdTextView.text = EmojiUtil.getFullEmojiIdSpannable(
-                            emojiId,
-                            string(emoji_id_chunk_separator),
-                            PaletteManager.getBlack(requireContext()),
-                            PaletteManager.getLightGray(requireContext())
+                            emojiId = emojiId,
+                            separator = string(emoji_id_chunk_separator),
+                            darkColor = PaletteManager.getBlack(requireContext()),
+                            lightColor = PaletteManager.getLightGray(requireContext()),
                         )
                         emojiIdSummaryController.display(emojiId)
 
@@ -292,19 +294,13 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
         }
 
         val createNowAnim: ObjectAnimator = ObjectAnimator.ofFloat(
-            ui.createYourEmojiIdLine2TextView,
-            View.TRANSLATION_Y,
-            0f,
-            -ui.createYourEmojiIdLine2TextView.height.toFloat()
+            ui.createYourEmojiIdLine2TextView, View.TRANSLATION_Y, 0f, -ui.createYourEmojiIdLine2TextView.height.toFloat()
         ).apply {
             duration = CreateEmojiId.awesomeTextAnimDurationMs
         }
 
         val awesomeAnim: ObjectAnimator = ObjectAnimator.ofFloat(
-            ui.createYourEmojiIdLine1TextView,
-            View.TRANSLATION_Y,
-            0f,
-            -ui.createYourEmojiIdLine1TextView.height.toFloat()
+            ui.createYourEmojiIdLine1TextView, View.TRANSLATION_Y, 0f, -ui.createYourEmojiIdLine1TextView.height.toFloat()
         ).apply {
             duration = CreateEmojiId.awesomeTextAnimDurationMs
         }
@@ -377,8 +373,7 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
         }
 
         uiHandler.postDelayed(
-            { startYourEmojiIdViewAnimation() },
-            ui.emojiWheelLottieAnimationView.duration - CreateEmojiId.awesomeTextAnimDurationMs
+            { startYourEmojiIdViewAnimation() }, ui.emojiWheelLottieAnimationView.duration - CreateEmojiId.awesomeTextAnimDurationMs
         )
     }
 
@@ -426,13 +421,9 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
             duration = CreateEmojiId.continueButtonAnimDurationMs
         }
 
-
         AnimatorSet().apply {
             playTogether(
-                buttonFadeInAnim,
-                emojiIdContainerViewScaleAnim,
-                fadeInAnim,
-                yourEmojiTitleAnim
+                buttonFadeInAnim, emojiIdContainerViewScaleAnim, fadeInAnim, yourEmojiTitleAnim
             )
             duration = CreateEmojiId.emojiIdCreationViewAnimDurationMs
             interpolator = EasingInterpolator(Ease.QUINT_IN)
@@ -448,7 +439,6 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
                 }
             })
         }
-
     }
 
     private fun elevateEmojiIdContainerView() {
@@ -530,7 +520,6 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
                 }
             })
         }
-
     }
 
     /**
@@ -578,10 +567,9 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
     }
 
     private fun onContinueButtonClick() {
+        viewModel.onContinueButtonClick()
         ui.continueButton.temporarilyDisableClick()
-        viewModel.sharedPrefsWrapper.onboardingCompleted = true
         ui.continueButton.animateClick {
-            viewModel.sharedPrefsWrapper.onboardingAuthSetupStarted = true
             onboardingListener.continueToEnableAuth()
         }
     }
@@ -607,4 +595,3 @@ class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding,
         }
     }
 }
-

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletFragment.kt
@@ -59,7 +59,6 @@ import com.tari.android.wallet.application.walletManager.WalletStateHandler
 import com.tari.android.wallet.databinding.FragmentCreateWalletBinding
 import com.tari.android.wallet.di.DiContainer
 import com.tari.android.wallet.extension.applyFontStyle
-import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.component.fullEmojiId.EmojiIdSummaryViewController
 import com.tari.android.wallet.ui.component.tari.TariFont
 import com.tari.android.wallet.ui.extension.animateClick
@@ -75,6 +74,7 @@ import com.tari.android.wallet.ui.extension.setTopMargin
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.temporarilyDisableClick
 import com.tari.android.wallet.ui.extension.visible
+import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowFragment
 import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.Constants.UI.CreateEmojiId
 import com.tari.android.wallet.util.EmojiUtil
@@ -88,7 +88,7 @@ import javax.inject.Inject
  *
  * @author The Tari Development Team
  */
-class CreateWalletFragment : CommonFragment<FragmentCreateWalletBinding, CreateWalletViewModel>() {
+class CreateWalletFragment : OnboardingFlowFragment<FragmentCreateWalletBinding, CreateWalletViewModel>() {
 
     @Inject
     lateinit var walletStateHandler: WalletStateHandler
@@ -581,7 +581,7 @@ class CreateWalletFragment : CommonFragment<FragmentCreateWalletBinding, CreateW
         viewModel.sharedPrefsWrapper.onboardingCompleted = true
         ui.continueButton.animateClick {
             viewModel.sharedPrefsWrapper.onboardingAuthSetupStarted = true
-            (requireActivity() as? CreateWalletListener)?.continueToEnableAuth()
+            onboardingListener.continueToEnableAuth()
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletListener.kt
@@ -1,5 +1,0 @@
-package com.tari.android.wallet.ui.fragment.onboarding.createWallet
-
-interface CreateWalletListener {
-    fun continueToEnableAuth()
-}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletModel.kt
@@ -1,0 +1,9 @@
+package com.tari.android.wallet.ui.fragment.onboarding.createWallet
+
+import com.tari.android.wallet.tor.TorProxyState
+
+object CreateWalletModel {
+    data class UiState(
+        val torState: TorProxyState = TorProxyState.NotReady,
+    )
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletViewModel.kt
@@ -1,7 +1,15 @@
 package com.tari.android.wallet.ui.fragment.onboarding.createWallet
 
+import androidx.lifecycle.viewModelScope
 import com.tari.android.wallet.data.sharedPrefs.CorePrefRepository
+import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.fragment.onboarding.createWallet.CreateWalletModel.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlow
 import javax.inject.Inject
 
 class CreateWalletViewModel : CommonViewModel() {
@@ -9,8 +17,17 @@ class CreateWalletViewModel : CommonViewModel() {
     @Inject
     lateinit var corePrefRepository: CorePrefRepository
 
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState = _uiState.asStateFlow()
+
     init {
         component.inject(this)
+
+        viewModelScope.launch(Dispatchers.IO) {
+            EventBus.torProxyState.publishSubject.asFlow().collect {
+                _uiState.value = _uiState.value.copy(torState = it)
+            }
+        }
     }
 
     fun onContinueButtonClick() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/createWallet/CreateWalletViewModel.kt
@@ -5,10 +5,16 @@ import com.tari.android.wallet.ui.common.CommonViewModel
 import javax.inject.Inject
 
 class CreateWalletViewModel : CommonViewModel() {
+
     @Inject
-    lateinit var sharedPrefsWrapper: CorePrefRepository
+    lateinit var corePrefRepository: CorePrefRepository
 
     init {
         component.inject(this)
+    }
+
+    fun onContinueButtonClick() {
+        corePrefRepository.onboardingCompleted = true
+        corePrefRepository.onboardingAuthSetupStarted = true
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionFragment.kt
@@ -36,7 +36,6 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
 import android.media.AudioManager
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -51,12 +50,27 @@ import androidx.fragment.app.viewModels
 import com.daasuu.ei.Ease
 import com.daasuu.ei.EasingInterpolator
 import com.tari.android.wallet.R
-import com.tari.android.wallet.R.string.*
+import com.tari.android.wallet.R.string.create_wallet_privacy_policy
+import com.tari.android.wallet.R.string.create_wallet_user_agreement
+import com.tari.android.wallet.R.string.create_wallet_user_agreement_and_privacy_policy
+import com.tari.android.wallet.R.string.introduction_selected_wallet
+import com.tari.android.wallet.R.string.privacy_policy_url
+import com.tari.android.wallet.R.string.user_agreement_url
 import com.tari.android.wallet.databinding.FragmentIntroductionBinding
 import com.tari.android.wallet.extension.applyURLStyle
-import com.tari.android.wallet.ui.common.CommonFragment
-import com.tari.android.wallet.ui.extension.*
-import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowActivity
+import com.tari.android.wallet.ui.extension.addAnimatorListener
+import com.tari.android.wallet.ui.extension.animateClick
+import com.tari.android.wallet.ui.extension.doOnGlobalLayout
+import com.tari.android.wallet.ui.extension.getResourceUri
+import com.tari.android.wallet.ui.extension.gone
+import com.tari.android.wallet.ui.extension.invisible
+import com.tari.android.wallet.ui.extension.postDelayed
+import com.tari.android.wallet.ui.extension.setLayoutSize
+import com.tari.android.wallet.ui.extension.setOnThrottledClickListener
+import com.tari.android.wallet.ui.extension.string
+import com.tari.android.wallet.ui.extension.temporarilyDisableClick
+import com.tari.android.wallet.ui.extension.visible
+import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowFragment
 import com.tari.android.wallet.ui.fragment.restore.activity.WalletRestoreActivity
 import com.tari.android.wallet.ui.fragment.settings.allSettings.TariVersionModel
 import com.tari.android.wallet.util.Constants
@@ -70,7 +84,7 @@ import kotlin.math.min
  * @author The Tari Development Team
  */
 
-class IntroductionFragment : CommonFragment<FragmentIntroductionBinding, IntroductionViewModel>() {
+class IntroductionFragment : OnboardingFlowFragment<FragmentIntroductionBinding, IntroductionViewModel>() {
 
     private val handler = Handler(Looper.getMainLooper())
 
@@ -147,7 +161,7 @@ class IntroductionFragment : CommonFragment<FragmentIntroductionBinding, Introdu
                 setupAndStartVideo()
             }
             createWalletButton.setOnThrottledClickListener { onCreateWalletClick() }
-            selectNetworkContainerView.setOnThrottledClickListener { (requireActivity() as OnboardingFlowActivity).navigateToNetworkSelection() }
+            selectNetworkContainerView.setOnThrottledClickListener { onboardingListener.navigateToNetworkSelection() }
         }
     }
 
@@ -155,9 +169,7 @@ class IntroductionFragment : CommonFragment<FragmentIntroductionBinding, Introdu
         val size = min(ui.videoOuterContainerView.width, ui.videoOuterContainerView.height)
         ui.videoInnerContainerView.setLayoutSize(size, size)
         ui.rainAnimationVideoView.setVideoURI(requireContext().getResourceUri(R.raw.purple_orb))
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            ui.rainAnimationVideoView.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
-        }
+        ui.rainAnimationVideoView.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
         startVideo()
         videoViewHasBeenSetup = true
     }
@@ -228,7 +240,7 @@ class IntroductionFragment : CommonFragment<FragmentIntroductionBinding, Introdu
             addListener(onEnd = { playTariWalletLottieAnimation() })
         }
 
-        ui.tariLogoLottieAnimationView.addAnimatorListener(onEnd = { (requireActivity() as? IntroductionListener)?.continueToCreateWallet() })
+        ui.tariLogoLottieAnimationView.addAnimatorListener(onEnd = { onboardingListener.continueToCreateWallet() })
 
         val tariViewScaleAnim = ValueAnimator.ofFloat(ui.tariLogoLottieAnimationView.scaleX, 1f).apply {
             duration = Constants.UI.CreateWallet.tariTextAnimViewDurationMs

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionFragment.kt
@@ -58,6 +58,7 @@ import com.tari.android.wallet.R.string.privacy_policy_url
 import com.tari.android.wallet.R.string.user_agreement_url
 import com.tari.android.wallet.databinding.FragmentIntroductionBinding
 import com.tari.android.wallet.extension.applyURLStyle
+import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.ui.extension.addAnimatorListener
 import com.tari.android.wallet.ui.extension.animateClick
 import com.tari.android.wallet.ui.extension.doOnGlobalLayout
@@ -72,7 +73,6 @@ import com.tari.android.wallet.ui.extension.temporarilyDisableClick
 import com.tari.android.wallet.ui.extension.visible
 import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowFragment
 import com.tari.android.wallet.ui.fragment.restore.activity.WalletRestoreActivity
-import com.tari.android.wallet.ui.fragment.settings.allSettings.TariVersionModel
 import com.tari.android.wallet.util.Constants
 import kotlin.math.min
 
@@ -119,7 +119,7 @@ class IntroductionFragment : OnboardingFlowFragment<FragmentIntroductionBinding,
 
     override fun onResume() {
         super.onResume()
-        ui.selectNetworkButton.text = string(introduction_selected_wallet, viewModel.networkRepository.currentNetwork.network.displayName)
+        ui.selectNetworkButton.text = string(introduction_selected_wallet, viewModel.uiState.value.networkName)
     }
 
     override fun onPause() {
@@ -130,39 +130,42 @@ class IntroductionFragment : OnboardingFlowFragment<FragmentIntroductionBinding,
 
     private fun setupUi() {
         ui.createWalletProgressBar.setWhite()
-        ui.apply {
-            tariLogoLottieAnimationView.alpha = 0f
-            tariLogoLottieAnimationView.scaleX = 0.84f
-            tariLogoLottieAnimationView.scaleY = 0.84f
-            networkInfoTextView.alpha = 0f
-            smallGemImageView.alpha = 0f
-            createWalletContainerView.alpha = 0f
-            selectNetworkContainerView.alpha = 0f
-            headerLineTopTextView.alpha = 0f
-            headerLineBottomTextView.alpha = 0f
-            userAgreementAndPrivacyPolicyTextView.alpha = 0f
-            restoreWalletCtaView.alpha = 0f
-            ui.restoreWalletCtaView.setOnClickListener {
-                activity?.let {
-                    it.startActivity(WalletRestoreActivity.navigationIntent(it))
+        collectFlow(viewModel.uiState) { uiState ->
+            ui.apply {
+                tariLogoLottieAnimationView.alpha = 0f
+                tariLogoLottieAnimationView.scaleX = 0.84f
+                tariLogoLottieAnimationView.scaleY = 0.84f
+                networkInfoTextView.alpha = 0f
+                smallGemImageView.alpha = 0f
+                createWalletContainerView.alpha = 0f
+                selectNetworkContainerView.alpha = 0f
+                headerLineTopTextView.alpha = 0f
+                headerLineBottomTextView.alpha = 0f
+                userAgreementAndPrivacyPolicyTextView.alpha = 0f
+                restoreWalletCtaView.alpha = 0f
+                ui.restoreWalletCtaView.setOnClickListener {
+                    activity?.let {
+                        it.startActivity(WalletRestoreActivity.navigationIntent(it))
+                    }
                 }
-            }
-            networkInfoTextView.text = TariVersionModel(viewModel.networkRepository).versionInfo
-            // highlight links
-            userAgreementAndPrivacyPolicyTextView.text =
-                SpannableString(string(create_wallet_user_agreement_and_privacy_policy)).apply {
-                    applyURLStyle(string(create_wallet_user_agreement), string(user_agreement_url))
-                    applyURLStyle(string(create_wallet_privacy_policy), string(privacy_policy_url))
+                networkInfoTextView.text = uiState.versionInfo
+                // highlight links
+                userAgreementAndPrivacyPolicyTextView.text =
+                    SpannableString(string(create_wallet_user_agreement_and_privacy_policy)).apply {
+                        applyURLStyle(string(create_wallet_user_agreement), string(user_agreement_url))
+                        applyURLStyle(string(create_wallet_privacy_policy), string(privacy_policy_url))
+                    }
+                // make the links clickable
+                userAgreementAndPrivacyPolicyTextView.movementMethod = LinkMovementMethod.getInstance()
+                rootView.doOnGlobalLayout {
+                    runStartupAnimation()
+                    setupAndStartVideo()
                 }
-            // make the links clickable
-            userAgreementAndPrivacyPolicyTextView.movementMethod = LinkMovementMethod.getInstance()
-            rootView.doOnGlobalLayout {
-                runStartupAnimation()
-                setupAndStartVideo()
+                createWalletButton.setOnThrottledClickListener { onCreateWalletClick() }
+                selectNetworkContainerView.setOnThrottledClickListener { onboardingListener.navigateToNetworkSelection() }
             }
-            createWalletButton.setOnThrottledClickListener { onCreateWalletClick() }
-            selectNetworkContainerView.setOnThrottledClickListener { onboardingListener.navigateToNetworkSelection() }
         }
+
     }
 
     private fun setupAndStartVideo() {
@@ -224,7 +227,7 @@ class IntroductionFragment : OnboardingFlowFragment<FragmentIntroductionBinding,
         restoreWalletCtaView.setOnClickListener(null)
         createWalletButton.gone()
         createWalletProgressBar.visible()
-        viewModel.walletServiceLauncher.start()
+        viewModel.onCreateWalletClick()
         createWalletContainerView.animateClick {
             selectNetworkContainerView.isEnabled = false
             rootView.postDelayed(createWalletArtificialDelay) { startTariWalletViewAnimation() }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionListener.kt
@@ -1,5 +1,0 @@
-package com.tari.android.wallet.ui.fragment.onboarding.inroduction
-
-interface IntroductionListener {
-    fun continueToCreateWallet()
-}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionModel.kt
@@ -2,7 +2,7 @@ package com.tari.android.wallet.ui.fragment.onboarding.inroduction
 
 object IntroductionModel {
     data class UiState(
-        val versionInfo: String ,
-        val networkName: String ,
+        val versionInfo: String,
+        val networkName: String,
     )
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionModel.kt
@@ -1,0 +1,8 @@
+package com.tari.android.wallet.ui.fragment.onboarding.inroduction
+
+object IntroductionModel {
+    data class UiState(
+        val versionInfo: String ,
+        val networkName: String ,
+    )
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/inroduction/IntroductionViewModel.kt
@@ -2,6 +2,9 @@ package com.tari.android.wallet.ui.fragment.onboarding.inroduction
 
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.fragment.settings.allSettings.TariVersionModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 class IntroductionViewModel : CommonViewModel() {
@@ -9,7 +12,19 @@ class IntroductionViewModel : CommonViewModel() {
     @Inject
     lateinit var walletServiceLauncher: WalletServiceLauncher
 
+    private val _uiState = MutableStateFlow(
+        IntroductionModel.UiState(
+            versionInfo = TariVersionModel(networkRepository).versionInfo,
+            networkName = networkRepository.currentNetwork.network.displayName,
+        )
+    )
+    val uiState = _uiState.asStateFlow()
+
     init {
         component.inject(this)
+    }
+
+    fun onCreateWalletClick() {
+        walletServiceLauncher.start()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthFragment.kt
@@ -44,10 +44,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.daasuu.ei.Ease
 import com.daasuu.ei.EasingInterpolator
+import com.orhanobut.logger.Logger
 import com.tari.android.wallet.R.string.onboarding_auth_biometric_prompt
 import com.tari.android.wallet.R.string.onboarding_auth_title
+import com.tari.android.wallet.application.TariWalletApplication
 import com.tari.android.wallet.databinding.FragmentLocalAuthBinding
 import com.tari.android.wallet.extension.launchAndRepeatOnLifecycle
+import com.tari.android.wallet.infrastructure.logging.LoggerTags
 import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthenticationException
 import com.tari.android.wallet.ui.extension.doOnGlobalLayout
 import com.tari.android.wallet.ui.extension.setOnThrottledClickListener
@@ -59,6 +62,8 @@ import com.tari.android.wallet.util.Constants.UI.Auth
 import kotlinx.coroutines.launch
 
 class LocalAuthFragment : OnboardingFlowFragment<FragmentLocalAuthBinding, LocalAuthViewModel>() {
+    private val logger
+        get() = Logger.t(LocalAuthFragment::class.simpleName)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         FragmentLocalAuthBinding.inflate(inflater, container, false).also { ui = it }.root
@@ -137,7 +142,7 @@ class LocalAuthFragment : OnboardingFlowFragment<FragmentLocalAuthBinding, Local
                     viewModel.securedWithBiometrics()
                 }
             } catch (exception: BiometricAuthenticationException) {
-                viewModel.logger.i(exception.message + "Biometric authentication failed")
+               logger.i(exception.message + "Biometric authentication failed")
             }
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthFragment.kt
@@ -48,18 +48,17 @@ import com.tari.android.wallet.R.string.onboarding_auth_biometric_prompt
 import com.tari.android.wallet.R.string.onboarding_auth_title
 import com.tari.android.wallet.databinding.FragmentLocalAuthBinding
 import com.tari.android.wallet.extension.launchAndRepeatOnLifecycle
-import com.tari.android.wallet.extension.safeCastTo
 import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthenticationException
-import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.extension.doOnGlobalLayout
 import com.tari.android.wallet.ui.extension.setOnThrottledClickListener
 import com.tari.android.wallet.ui.extension.setVisible
 import com.tari.android.wallet.ui.extension.string
+import com.tari.android.wallet.ui.fragment.onboarding.activity.OnboardingFlowFragment
 import com.tari.android.wallet.ui.fragment.onboarding.localAuth.LocalAuthModel.Effect
 import com.tari.android.wallet.util.Constants.UI.Auth
 import kotlinx.coroutines.launch
 
-class LocalAuthFragment : CommonFragment<FragmentLocalAuthBinding, LocalAuthViewModel>() {
+class LocalAuthFragment : OnboardingFlowFragment<FragmentLocalAuthBinding, LocalAuthViewModel>() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         FragmentLocalAuthBinding.inflate(inflater, container, false).also { ui = it }.root
@@ -90,7 +89,7 @@ class LocalAuthFragment : CommonFragment<FragmentLocalAuthBinding, LocalAuthView
                 viewModel.effect.collect { effect ->
                     when (effect) {
                         is Effect.OnAuthSuccess -> {
-                            requireActivity().safeCastTo<LocalAuthModel.LocalAuthListener>()?.onAuthSuccess()
+                            onboardingListener.onAuthSuccess()
                         }
                     }
                 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthModel.kt
@@ -1,12 +1,13 @@
 package com.tari.android.wallet.ui.fragment.onboarding.localAuth
 
 object LocalAuthModel {
+    data class SecureState(
+        val biometricsAvailable: Boolean = true,
+        val pinCodeSecured: Boolean = false,
+        val biometricsSecured: Boolean = false,
+    )
 
     sealed interface Effect {
         data object OnAuthSuccess : Effect
-    }
-
-    interface LocalAuthListener {
-        fun onAuthSuccess()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/LocalAuthViewModel.kt
@@ -8,6 +8,7 @@ import com.tari.android.wallet.infrastructure.security.biometric.BiometricAuthen
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.onboarding.localAuth.LocalAuthModel.Effect
+import com.tari.android.wallet.ui.fragment.onboarding.localAuth.LocalAuthModel.SecureState
 import com.tari.android.wallet.ui.fragment.pinCode.PinCodeScreenBehavior
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/SecureState.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/onboarding/localAuth/SecureState.kt
@@ -1,7 +1,0 @@
-package com.tari.android.wallet.ui.fragment.onboarding.localAuth
-
-data class SecureState(
-    val biometricsAvailable: Boolean = true,
-    val pinCodeSecured: Boolean = false,
-    val biometricsSecured: Boolean = false,
-)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/profile/RoundButtonWithIconView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/profile/RoundButtonWithIconView.kt
@@ -37,12 +37,11 @@ class RoundButtonWithIconView @JvmOverloads constructor(
             width = backSize
         }
         ui.text.text = text
-        val paletteManager = PaletteManager()
-        val textColor = if (isSelected) paletteManager.getTextHeading(context) else paletteManager.getTextBody(context)
+        val textColor = if (isSelected) PaletteManager.getTextHeading(context) else PaletteManager.getTextBody(context)
         ui.text.setTextColor(textColor)
-        val backgroundColor = if (isSelected) paletteManager.getPurpleBrand(context) else paletteManager.getBackgroundPrimary(context)
+        val backgroundColor = if (isSelected) PaletteManager.getPurpleBrand(context) else PaletteManager.getBackgroundPrimary(context)
         ui.optionBackground.updateBack(backColor = backgroundColor)
-        val iconColor = if (isSelected) paletteManager.getBackgroundPrimary(context) else paletteManager.getTextHeading(context)
+        val iconColor = if (isSelected) PaletteManager.getBackgroundPrimary(context) else PaletteManager.getTextHeading(context)
         ui.icon.setColorFilter(iconColor)
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/profile/WalletInfoViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/profile/WalletInfoViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.tari.android.wallet.R
+import com.tari.android.wallet.application.YatAdapter
 import com.tari.android.wallet.application.deeplinks.DeepLink
 import com.tari.android.wallet.application.deeplinks.DeeplinkHandler
 import com.tari.android.wallet.data.sharedPrefs.CorePrefRepository
+import com.tari.android.wallet.data.sharedPrefs.yat.YatPrefRepository
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.dialog.modular.DialogArgs
@@ -19,8 +21,6 @@ import com.tari.android.wallet.ui.fragment.contact_book.root.ShareViewModel
 import com.tari.android.wallet.ui.fragment.contact_book.root.share.ShareType
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.util.ContactUtil
-import com.tari.android.wallet.application.YatAdapter
-import com.tari.android.wallet.data.sharedPrefs.yat.YatPrefRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -137,8 +137,7 @@ class WalletInfoViewModel : CommonViewModel() {
             true
         }
 
-        val args = ModularDialogArgs(DialogArgs(), moduleList)
-        _inputDialog.postValue(args)
+        showInputModalDialog(ModularDialogArgs(DialogArgs(), moduleList))
     }
 
     fun openRequestTari() {
@@ -150,6 +149,6 @@ class WalletInfoViewModel : CommonViewModel() {
         sharedPrefsWrapper.name = split.getOrNull(0).orEmpty().trim()
         sharedPrefsWrapper.surname = split.getOrNull(1).orEmpty().trim()
         alias.postValue(name)
-        dismissDialog.postValue(Unit)
+        hideDialog()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/enterRestorationPassword/EnterRestorationPasswordFragment.kt
@@ -49,6 +49,7 @@ import com.tari.android.wallet.R.string.enter_backup_password_page_desc_highligh
 import com.tari.android.wallet.databinding.FragmentEnterRestorePasswordBinding
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.extension.colorFromAttribute
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.hideKeyboard
@@ -133,7 +134,7 @@ class EnterRestorationPasswordFragment : CommonFragment<FragmentEnterRestorePass
     private fun setPageDescription() {
         val generalPart = string(enter_backup_password_page_desc_general_part)
         val highlightedPart = SpannableString(string(enter_backup_password_page_desc_highlighted_part))
-        val spanColor = ForegroundColorSpan(viewModel.paletteManager.getTextHeading(requireContext()))
+        val spanColor = ForegroundColorSpan(PaletteManager.getTextHeading(requireContext()))
         highlightedPart.setSpan(spanColor, 0, highlightedPart.length, SPAN_EXCLUSIVE_EXCLUSIVE)
         ui.pageDescriptionTextView.text = SpannableStringBuilder().apply {
             insert(0, generalPart)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/InputSeedWordsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/InputSeedWordsViewModel.kt
@@ -19,8 +19,6 @@ import com.tari.android.wallet.ui.common.debounce
 import com.tari.android.wallet.ui.common.domain.ResourceManager
 import com.tari.android.wallet.ui.component.loadingButton.LoadingButtonState
 import com.tari.android.wallet.ui.dialog.error.ErrorDialogArgs
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
 import com.tari.android.wallet.ui.dialog.modular.modules.input.InputModule
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
@@ -161,7 +159,7 @@ class InputSeedWordsViewModel : CommonViewModel() {
         onError(errorDialogArgs)
     }
 
-    private fun onError(restorationError: RestorationError) = modularDialog.postValue(restorationError.args.getModular(resourceManager))
+    private fun onError(restorationError: RestorationError) = showModularDialog(restorationError.args.getModular(resourceManager))
 
     private fun clear() {
         walletServiceLauncher.stopAndDelete()
@@ -347,21 +345,16 @@ class InputSeedWordsViewModel : CommonViewModel() {
             true
         }
 
-        _inputDialog.postValue(
-            ModularDialogArgs(
-                dialogArgs = DialogArgs(),
-                modules = mutableListOf(
-                    title,
-                    nameInput,
-                    hexInput,
-                    addressInput,
-                )
-            )
+        showInputModalDialog(
+            title,
+            nameInput,
+            hexInput,
+            addressInput,
         )
     }
 
     private fun customBaseNodeEntered(enteredName: String, enteredHex: String, enteredAddress: String) {
-        dismissDialog.postValue(Unit)
+        hideDialog()
         if (baseNodesManager.isValidBaseNode("$enteredHex::$enteredAddress")) {
             val baseNode = BaseNodeDto(
                 name = enteredName.takeIf { it.isNotBlank() } ?: resourceManager.getString(R.string.add_base_node_default_name_custom),
@@ -372,7 +365,7 @@ class InputSeedWordsViewModel : CommonViewModel() {
             _customBaseNodeState.update { it.copy(customBaseNode = baseNode) }
         } else {
             _customBaseNodeState.update { it.copy(customBaseNode = null) }
-            modularDialog.postValue(
+            showModularDialog(
                 ErrorDialogArgs(
                     title = resourceManager.getString(R.string.common_error_title),
                     description = resourceManager.getString(R.string.restore_from_seed_words_form_error_message),

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/WordTextView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/inputSeedWords/WordTextView.kt
@@ -12,8 +12,6 @@ import com.tari.android.wallet.ui.extension.setVisible
 
 class WordTextView : FrameLayout {
 
-    val paletteManager = PaletteManager()
-
     constructor(context: Context) : super(context, null) {
         init()
     }
@@ -50,7 +48,7 @@ class WordTextView : FrameLayout {
         }
         ui.root.background = background?.let { ContextCompat.getDrawable(context, it) }
 
-        val textColor = if (isFocused || isValid) paletteManager.getTextHeading(context) else paletteManager.getRed(context)
+        val textColor = if (isFocused || isValid) PaletteManager.getTextHeading(context) else PaletteManager.getRed(context)
         ui.text.setTextColor(textColor)
 
         val deleteTintColor = ContextCompat.getDrawable(context, if (isFocused || isValid) R.drawable.vector_close else R.drawable.vector_close_error)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/walletRestoringFromSeedWords/WalletRestoringFromSeedWordsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/restore/walletRestoringFromSeedWords/WalletRestoringFromSeedWordsViewModel.kt
@@ -90,6 +90,7 @@ class WalletRestoringFromSeedWordsViewModel : CommonViewModel() {
                         onError(RestorationError.RecoveryInternalError(resourceManager, this@WalletRestoringFromSeedWordsViewModel::onErrorClosed))
                     }
                 }
+
                 is WalletRestorationResult.Completed -> onSuccessRestoration()
             }
         }.addTo(compositeDisposable)
@@ -107,7 +108,7 @@ class WalletRestoringFromSeedWordsViewModel : CommonViewModel() {
 
     private fun onError(restorationError: RestorationError) {
         walletServiceLauncher.stopAndDelete()
-        modularDialog.postValue(restorationError.args.getModular(resourceManager))
+        showModularDialog(restorationError.args.getModular(resourceManager))
     }
 
     private fun onSuccessRestoration() {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountViewModel.kt
@@ -9,8 +9,6 @@ import com.tari.android.wallet.ffi.FFIWallet
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.WalletError
 import com.tari.android.wallet.ui.common.CommonViewModel
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
@@ -67,18 +65,21 @@ class AddAmountViewModel : CommonViewModel() {
                         mediumOption = elements[0].getAverage()
                         fastOption = elements[0].getMax()
                     }
+
                     2 -> {
                         networkSpeed = NetworkSpeed.Medium
                         slowOption = elements[1].getAverage()
                         mediumOption = elements[0].getMin()
                         fastOption = elements[0].getMax()
                     }
+
                     3 -> {
                         networkSpeed = NetworkSpeed.Fast
                         slowOption = elements[2].getAverage()
                         mediumOption = elements[1].getAverage()
                         fastOption = elements[0].getMax()
                     }
+
                     else -> throw Exception("Unexpected block count")
                 }
                 _feePerGrams.postValue(FeePerGramOptions(networkSpeed, MicroTari(slowOption), MicroTari(mediumOption), MicroTari(fastOption)))
@@ -95,21 +96,17 @@ class AddAmountViewModel : CommonViewModel() {
 
     fun showFeeDialog() {
         val feeModule = FeeModule(MicroTari(), feeData, selectedSpeed)
-        val args = ModularDialogArgs(
-            DialogArgs(),
-            listOf(
-                HeadModule(resourceManager.getString(R.string.add_amount_modify_fee_title)),
-                BodyModule(resourceManager.getString(R.string.add_amount_modify_fee_description)),
-                feeModule,
-                ButtonModule(resourceManager.getString(R.string.add_amount_modify_fee_use), ButtonStyle.Normal) {
-                    selectedSpeed = feeModule.selectedSpeed
-                    selectedFeeData = feeModule.feePerGram
-                    dismissDialog.postValue(Unit)
-                },
-                ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
-            )
+        showModularDialog(
+            HeadModule(resourceManager.getString(R.string.add_amount_modify_fee_title)),
+            BodyModule(resourceManager.getString(R.string.add_amount_modify_fee_description)),
+            feeModule,
+            ButtonModule(resourceManager.getString(R.string.add_amount_modify_fee_use), ButtonStyle.Normal) {
+                selectedSpeed = feeModule.selectedSpeed
+                selectedFeeData = feeModule.feePerGram
+                hideDialog()
+            },
+            ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(args)
     }
 
     fun calculateFee(amount: MicroTari, walletError: WalletError) {
@@ -133,7 +130,7 @@ class AddAmountViewModel : CommonViewModel() {
             feeData = listOf(FeeData(grams.slow, slowFee), FeeData(grams.medium, mediumFee), FeeData(grams.fast, fastFee))
             selectedFeeData = feeData[1]
         } catch (e: Throwable) {
-            logger.i(e.message +"calculate fees")
+            logger.i(e.message + "calculate fees")
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
@@ -69,6 +69,7 @@ import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.TxNote
 import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.gyphy.repository.GIFItem
 import com.tari.android.wallet.ui.component.fullEmojiId.EmojiIdSummaryViewController
 import com.tari.android.wallet.ui.component.fullEmojiId.FullEmojiIdViewController
@@ -207,7 +208,7 @@ class AddNoteFragment : CommonFragment<FragmentAddNoteBinding, AddNoteViewModel>
         // disable "send" slider
         disableCallToAction()
         focusEditTextAndShowKeyboard()
-        ui.promptTextView.setTextColor(viewModel.paletteManager.getTextHeading(requireContext()))
+        ui.promptTextView.setTextColor(PaletteManager.getTextHeading(requireContext()))
         ui.noteEditText.imeOptions = EditorInfo.IME_ACTION_DONE
         ui.thumbnailGifsRecyclerView.also {
             val margin = dimen(add_note_gif_inner_margin).toInt()
@@ -219,10 +220,10 @@ class AddNoteFragment : CommonFragment<FragmentAddNoteBinding, AddNoteViewModel>
 
     private fun updateSliderState() {
         if (ui.noteEditText.text?.toString().isNullOrEmpty() && gifContainer.gifItem == null) {
-            ui.promptTextView.setTextColor(viewModel.paletteManager.getTextHeading(requireContext()))
+            ui.promptTextView.setTextColor(PaletteManager.getTextHeading(requireContext()))
             disableCallToAction()
         } else {
-            ui.promptTextView.setTextColor(viewModel.paletteManager.getTextBody(requireContext()))
+            ui.promptTextView.setTextColor(PaletteManager.getTextBody(requireContext()))
             enableCallToAction()
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/amountView/AmountView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/amountView/AmountView.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import com.tari.android.wallet.databinding.ViewAmountBinding
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.component.common.CommonView
 
 class AmountView : CommonView<CommonViewModel, ViewAmountBinding> {
@@ -32,8 +33,8 @@ class AmountView : CommonView<CommonViewModel, ViewAmountBinding> {
 
     fun setupArgs(style: AmountStyle) {
         val color = when(style) {
-            AmountStyle.Normal -> paletteManager.getTextHeading(context)
-            AmountStyle.Warning -> paletteManager.getRed(context)
+            AmountStyle.Normal -> PaletteManager.getTextHeading(context)
+            AmountStyle.Warning -> PaletteManager.getRed(context)
         }
         ui.gem.setColorFilter(color)
         ui.balanceView.setTextColor(color)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/AllSettingsViewModel.kt
@@ -62,7 +62,10 @@ import com.tari.android.wallet.R.string.tari_about_title
 import com.tari.android.wallet.R.string.tari_url
 import com.tari.android.wallet.R.string.ttl_store_url
 import com.tari.android.wallet.R.string.user_agreement_url
+import com.tari.android.wallet.application.YatAdapter
 import com.tari.android.wallet.data.sharedPrefs.CorePrefRepository
+import com.tari.android.wallet.data.sharedPrefs.backup.BackupPrefRepository
+import com.tari.android.wallet.data.sharedPrefs.yat.YatPrefRepository
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.addTo
 import com.tari.android.wallet.infrastructure.backup.BackupManager
@@ -86,10 +89,7 @@ import com.tari.android.wallet.ui.fragment.settings.allSettings.row.SettingsRowS
 import com.tari.android.wallet.ui.fragment.settings.allSettings.row.SettingsRowViewDto
 import com.tari.android.wallet.ui.fragment.settings.allSettings.title.SettingsTitleViewHolderItem
 import com.tari.android.wallet.ui.fragment.settings.allSettings.version.SettingsVersionViewHolderItem
-import com.tari.android.wallet.data.sharedPrefs.backup.BackupPrefRepository
 import com.tari.android.wallet.ui.fragment.settings.userAutorization.BiometricAuthenticationViewModel
-import com.tari.android.wallet.application.YatAdapter
-import com.tari.android.wallet.data.sharedPrefs.yat.YatPrefRepository
 import javax.inject.Inject
 
 class AllSettingsViewModel : CommonViewModel() {
@@ -281,8 +281,7 @@ class AllSettingsViewModel : CommonViewModel() {
     }
 
     private fun showBackupStorageCheckFailedDialog(message: String) {
-        val errorArgs = ErrorDialogArgs(resourceManager.getString(check_backup_storage_status_error_title), message)
-        modularDialog.postValue(errorArgs.getModular(resourceManager))
+        showModularDialog(ErrorDialogArgs(resourceManager.getString(check_backup_storage_status_error_title), message).getModular(resourceManager))
     }
 }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/row/SettingsRowView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/allSettings/row/SettingsRowView.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.ViewSettingsRowBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.component.common.CommonView
 import com.tari.android.wallet.ui.extension.setVisible
 
@@ -35,8 +36,8 @@ class SettingsRowView : CommonView<CommonViewModel, ViewSettingsRowBinding> {
         }
 
         val color = when (dto.style) {
-            SettingsRowStyle.Normal -> paletteManager.getTextHeading(context)
-            SettingsRowStyle.Warning -> paletteManager.getRed(context)
+            SettingsRowStyle.Normal -> PaletteManager.getTextHeading(context)
+            SettingsRowStyle.Warning -> PaletteManager.getRed(context)
         }
 
         ui.title.setTextColor(color)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backgroundService/BackgroundServiceSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backgroundService/BackgroundServiceSettingsViewModel.kt
@@ -28,13 +28,14 @@ class BackgroundServiceSettingsViewModel : CommonViewModel() {
             turnSwitcher(true)
         } else {
             _switchState.value = TariLoadingSwitchState(isChecked = true, isLoading = true)
-            modularDialog.value = ConfirmDialogArgs(
-                resourceManager.getString(R.string.background_service_button_confirmation_title),
-                resourceManager.getString(R.string.background_service_button_confirmation_description),
-                onConfirm = { turnSwitcher(false) },
-                onCancel = { _switchState.value = TariLoadingSwitchState(isChecked = true, isLoading = false) },
-                onDismiss = { _switchState.value = TariLoadingSwitchState(isChecked = _switchState.value!!.isChecked, isLoading = false) }).getModular(
-                resourceManager
+            showModularDialog(
+                ConfirmDialogArgs(
+                    title = resourceManager.getString(R.string.background_service_button_confirmation_title),
+                    description = resourceManager.getString(R.string.background_service_button_confirmation_description),
+                    onConfirm = { turnSwitcher(false) },
+                    onCancel = { _switchState.value = TariLoadingSwitchState(isChecked = true, isLoading = false) },
+                    onDismiss = { _switchState.value = TariLoadingSwitchState(isChecked = _switchState.value!!.isChecked, isLoading = false) }
+                ).getModular(resourceManager)
             )
         }
     }
@@ -42,7 +43,7 @@ class BackgroundServiceSettingsViewModel : CommonViewModel() {
     private fun turnSwitcher(isTurnedOn: Boolean) {
         tariSettingsSharedRepository.backgroundServiceTurnedOn = isTurnedOn
         _switchState.value = TariLoadingSwitchState(isTurnedOn, false)
-        dismissDialog.postValue(Unit)
+        hideDialog()
         serviceLauncher.startIfExist()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupOnboarding/item/BackupOnboardingArgs.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupOnboarding/item/BackupOnboardingArgs.kt
@@ -81,9 +81,6 @@ sealed class BackupOnboardingArgs(
 
 
     companion object {
-
-        private val paletteManager = PaletteManager()
-
         private fun getTitle(resourceManager: ResourceManager, firstPartInt: Int, secondPartInt: Int): SpannableString {
             val firstPart = resourceManager.getString(firstPartInt)
             val secondPart = resourceManager.getString(secondPartInt)
@@ -112,7 +109,7 @@ sealed class BackupOnboardingArgs(
                 )
             }
             val spannable = SpannableString("$firstPart $highlighted$part3")
-            spannable.applyColorStyle(highlighted, paletteManager.getTextLinks(HomeActivity.instance.get()!!))
+            spannable.applyColorStyle(highlighted, PaletteManager.getTextLinks(HomeActivity.instance.get()!!))
             spannable.applyCenterAlignment()
             return spannable
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/BackupSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/backupSettings/BackupSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.tari.android.wallet.R
+import com.tari.android.wallet.data.sharedPrefs.backup.BackupPrefRepository
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.infrastructure.backup.BackupManager
 import com.tari.android.wallet.infrastructure.backup.BackupState
@@ -15,7 +16,6 @@ import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.dialog.error.ErrorDialogArgs
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.settings.backup.backupSettings.option.BackupOptionViewModel
-import com.tari.android.wallet.data.sharedPrefs.backup.BackupPrefRepository
 import com.tari.android.wallet.ui.fragment.settings.userAutorization.BiometricAuthenticationViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -113,14 +113,16 @@ class BackupSettingsViewModel : CommonViewModel() {
             exception is BackupStorageFullException -> resourceManager.getString(
                 R.string.backup_wallet_storage_full_desc
             )
+
             exception is BackupStorageAuthRevokedException -> resourceManager.getString(
                 R.string.check_backup_storage_status_auth_revoked_error_description
             )
+
             exception is UnknownHostException -> resourceManager.getString(R.string.error_no_connection_title)
             exception?.message == null -> resourceManager.getString(R.string.back_up_wallet_backing_up_unknown_error)
             else -> resourceManager.getString(R.string.back_up_wallet_backing_up_error_desc, exception.message!!)
         }
-        modularDialog.postValue(ErrorDialogArgs(errorTitle, errorDescription).getModular(resourceManager))
+        showModularDialog(ErrorDialogArgs(errorTitle, errorDescription).getModular(resourceManager))
     }
 }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/changeSecurePassword/ChangeSecurePasswordFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/changeSecurePassword/ChangeSecurePasswordFragment.kt
@@ -62,6 +62,7 @@ import com.tari.android.wallet.infrastructure.backup.BackupState
 import com.tari.android.wallet.infrastructure.backup.BackupState.BackupFailed
 import com.tari.android.wallet.infrastructure.backup.BackupState.BackupUpToDate
 import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.dialog.error.ErrorDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.ModularDialog
 import com.tari.android.wallet.ui.extension.animateClick
@@ -135,7 +136,7 @@ class ChangeSecurePasswordFragment : CommonFragment<FragmentChangeSecurePassword
     private fun setPageDescription() {
         val generalPart = string(change_password_page_description_general_part)
         val highlightedPart = SpannableString(string(change_password_page_description_highlight_part))
-        val spanColor = ForegroundColorSpan(viewModel.paletteManager.getTextHeading(requireContext()))
+        val spanColor = ForegroundColorSpan(PaletteManager.getTextHeading(requireContext()))
         highlightedPart.setSpan(spanColor, 0, highlightedPart.length, SPAN_EXCLUSIVE_EXCLUSIVE)
         ui.pageDescriptionTextView.text = SpannableStringBuilder().apply {
             insert(0, generalPart)
@@ -205,19 +206,19 @@ class ChangeSecurePasswordFragment : CommonFragment<FragmentChangeSecurePassword
 
     private fun setPlainInputState(errorLabel: TextView, inputTextViews: Iterable<TextView>) {
         errorLabel.gone()
-        inputTextViews.forEach { it.setTextColor(viewModel.paletteManager.getTextHeading(requireContext())) }
+        inputTextViews.forEach { it.setTextColor(PaletteManager.getTextHeading(requireContext())) }
     }
 
     private fun setPasswordTooShortErrorState() {
         ui.passwordTooShortLabelView.visible()
-        ui.enterPasswordLabelTextView.setTextColor(viewModel.paletteManager.getRed(requireContext()))
-        passwordInput.setTextColor(viewModel.paletteManager.getRed(requireContext()))
+        ui.enterPasswordLabelTextView.setTextColor(PaletteManager.getRed(requireContext()))
+        passwordInput.setTextColor(PaletteManager.getRed(requireContext()))
     }
 
     private fun setPasswordMatchErrorState() {
         ui.passwordsNotMatchLabelView.visible()
-        ui.confirmPasswordLabelTextView.setTextColor(viewModel.paletteManager.getRed(requireContext()))
-        confirmInput.setTextColor(viewModel.paletteManager.getRed(requireContext()))
+        ui.confirmPasswordLabelTextView.setTextColor(PaletteManager.getRed(requireContext()))
+        confirmInput.setTextColor(PaletteManager.getRed(requireContext()))
     }
 
     private fun setVerifyButtonState(isEnabled: Boolean) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/writeDownSeedWords/WriteDownSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/backup/writeDownSeedWords/WriteDownSeedPhraseViewModel.kt
@@ -28,10 +28,11 @@ class WriteDownSeedPhraseViewModel : CommonViewModel() {
     }
 
     private fun showError() {
-        val args = ErrorDialogArgs(
-            resourceManager.getString(R.string.common_error_title),
-            resourceManager.getString(R.string.back_up_seed_phrase_error)
+        showModularDialog(
+            ErrorDialogArgs(
+                title = resourceManager.getString(R.string.common_error_title),
+                description = resourceManager.getString(R.string.back_up_seed_phrase_error),
+            ).getModular(resourceManager)
         )
-        modularDialog.postValue(args.getModular(resourceManager))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
@@ -57,14 +57,15 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
 
     fun showQrCode(baseNodeDto: BaseNodeDto) {
         val data = deeplinkHandler.getDeeplink(baseNodeDto.toDeeplink())
-        val args = ModularDialogArgs(
-            DialogArgs(true, canceledOnTouchOutside = true), listOf(
-                HeadModule(resourceManager.getString(R.string.share_via_qr_code_title)),
-                ShareQrCodeModule(data),
-                ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close)
+        showModularDialog(
+            ModularDialogArgs(
+                DialogArgs(true, canceledOnTouchOutside = true), listOf(
+                    HeadModule(resourceManager.getString(R.string.share_via_qr_code_title)),
+                    ShareQrCodeModule(data),
+                    ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close),
+                )
             )
         )
-        modularDialog.postValue(args)
     }
 
     fun refresh() = loadList()
@@ -115,16 +116,11 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
             true
         }
 
-        _inputDialog.postValue(
-            ModularDialogArgs(
-                dialogArgs = DialogArgs(),
-                modules = mutableListOf(
-                    title,
-                    nameInput,
-                    hexInput,
-                    addressInput,
-                )
-            )
+        showInputModalDialog(
+            title,
+            nameInput,
+            hexInput,
+            addressInput,
         )
     }
 
@@ -140,11 +136,11 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
 
             baseNodesManager.addUserBaseNode(baseNode)
             baseNodesManager.setBaseNode(baseNode)
-            dismissDialog.postValue(Unit)
+            hideDialog()
             loadList()
         } else {
             _customBaseNodeState.update { it.copy(customBaseNode = null) }
-            modularDialog.postValue(
+            showModularDialog(
                 ErrorDialogArgs(
                     title = resourceManager.getString(R.string.common_error_title),
                     description = resourceManager.getString(R.string.restore_from_seed_words_form_error_message),

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/bugReporting/BugsReportingViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/bugReporting/BugsReportingViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.viewModelScope
 import com.tari.android.wallet.R
 import com.tari.android.wallet.infrastructure.logging.BugReportingService
 import com.tari.android.wallet.ui.common.CommonViewModel
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
@@ -27,15 +25,11 @@ class BugsReportingViewModel : CommonViewModel() {
             bugReportingService.share(name, email, bugDescription)
             backPressed.postValue(Unit)
         } catch (e: Exception) {
-            val args = ModularDialogArgs(
-                DialogArgs(),
-                listOf(
-                    HeadModule(resourceManager.getString(R.string.common_error_title)),
-                    BodyModule(resourceManager.getString(R.string.common_unknown_error)),
-                    ButtonModule(resourceManager.getString(R.string.common_ok), ButtonStyle.Close)
-                )
+            showModularDialog(
+                HeadModule(resourceManager.getString(R.string.common_error_title)),
+                BodyModule(resourceManager.getString(R.string.common_unknown_error)),
+                ButtonModule(resourceManager.getString(R.string.common_ok), ButtonStyle.Close),
             )
-            modularDialog.postValue(args)
         }
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/deleteWallet/DeleteWalletViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/deleteWallet/DeleteWalletViewModel.kt
@@ -4,8 +4,6 @@ import com.tari.android.wallet.R
 import com.tari.android.wallet.service.service.WalletServiceLauncher
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
-import com.tari.android.wallet.ui.dialog.modular.DialogArgs
-import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
@@ -24,17 +22,14 @@ class DeleteWalletViewModel : CommonViewModel() {
     }
 
     fun confirmDeleteWallet() {
-        val args = ModularDialogArgs(
-            DialogArgs(), listOf(
-                HeadModule(resourceManager.getString(R.string.delete_wallet_confirmation_title)),
-                BodyModule(resourceManager.getString(R.string.delete_wallet_confirmation_description)),
-                ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Warning) {
-                    deleteWallet.postValue(Unit)
-                    dismissDialog.postValue(Unit)
-                },
-                ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
-            )
+        showModularDialog(
+            HeadModule(resourceManager.getString(R.string.delete_wallet_confirmation_title)),
+            BodyModule(resourceManager.getString(R.string.delete_wallet_confirmation_description)),
+            ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Warning) {
+                deleteWallet.postValue(Unit)
+                hideDialog()
+            },
+            ButtonModule(resourceManager.getString(R.string.common_cancel), ButtonStyle.Close)
         )
-        modularDialog.postValue(args)
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/logs/logs/LogsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/logs/logs/LogsViewModel.kt
@@ -52,7 +52,7 @@ class LogsViewModel : CommonViewModel() {
             ) {
                 backPressed.postValue(Unit)
             }
-            modularDialog.postValue(errorArgs.getModular(resourceManager))
+            showModularDialog(errorArgs.getModular(resourceManager))
             logger.i(e.message + "Out of memory on reading big log file")
         }
     }
@@ -60,9 +60,9 @@ class LogsViewModel : CommonViewModel() {
     fun showFilters() {
         val currentLevelFilters = logLevelFilters.value!!
         val currentSourceFilters = logSourceFilters.value!!
-        val levelFilterModules = LogLevelFilters.values()
+        val levelFilterModules = LogLevelFilters.entries
             .map { LogLevelCheckedModule(it, CheckedModule(resourceManager.getString(it.title), currentLevelFilters.contains(it))) }
-        val sourceFiltersModules = LogSourceFilters.values()
+        val sourceFiltersModules = LogSourceFilters.entries
             .map { LogSourceCheckedModule(it, CheckedModule(resourceManager.getString(it.title), currentSourceFilters.contains(it))) }
         val modules = mutableListOf<IDialogModule>()
         modules.add(HeadModule(resourceManager.getString(R.string.debug_log_filter_title)))
@@ -71,14 +71,14 @@ class LogsViewModel : CommonViewModel() {
         modules.addAll(sourceFiltersModules)
         modules.add(SpaceModule(12))
         modules.add(ButtonModule(resourceManager.getString(R.string.debug_log_filter_apply), ButtonStyle.Normal) {
-            dismissDialog.postValue(Unit)
+            hideDialog()
             logLevelFilters.postValue(levelFilterModules.filter { it.checkedModule.isChecked }.map { it.logFilter }.toMutableList())
             logSourceFilters.postValue(sourceFiltersModules.filter { it.checkedModule.isChecked }.map { it.logFilter }.toMutableList())
         })
         modules.add(ButtonModule(resourceManager.getString(R.string.common_close), ButtonStyle.Close))
 
         val modularDialogArgs = ModularDialogArgs(DialogArgs(), modules)
-        modularDialog.postValue(modularDialogArgs)
+        showModularDialog(modularDialogArgs)
     }
 
     fun copyToClipboard(item: LogViewHolderItem) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/screenRecording/ScreenRecordingSettingsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/screenRecording/ScreenRecordingSettingsViewModel.kt
@@ -22,19 +22,21 @@ class ScreenRecordingSettingsViewModel : CommonViewModel() {
             turnSwitcher(false)
         } else {
             _switchState.update { it.startLoading() }
-            modularDialog.value = ConfirmDialogArgs(
-                resourceManager.getString(R.string.screen_recording_button_confirmation_title),
-                resourceManager.getString(R.string.screen_recording_button_confirmation_description),
-                onConfirm = { turnSwitcher(true) },
-                onCancel = { _switchState.update { it.stopLoading() } },
-                onDismiss = { _switchState.update { it.stopLoading() } }
-            ).getModular(resourceManager)
+            showModularDialog(
+                ConfirmDialogArgs(
+                    title = resourceManager.getString(R.string.screen_recording_button_confirmation_title),
+                    description = resourceManager.getString(R.string.screen_recording_button_confirmation_description),
+                    onConfirm = { turnSwitcher(true) },
+                    onCancel = { _switchState.update { it.stopLoading() } },
+                    onDismiss = { _switchState.update { it.stopLoading() } },
+                ).getModular(resourceManager)
+            )
         }
     }
 
     private fun turnSwitcher(isTurnedOn: Boolean) {
         tariSettingsSharedRepository.screenRecordingTurnedOn = isTurnedOn
         _switchState.update { TariLoadingSwitchState(isTurnedOn, false) }
-        dismissDialog.postValue(Unit)
+        hideDialog()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/torBridges/customBridges/CustomTorBridgesViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/torBridges/customBridges/CustomTorBridgesViewModel.kt
@@ -75,10 +75,11 @@ class CustomTorBridgesViewModel : CommonViewModel() {
     }
 
     private fun incorrectFormat() {
-        val args = ErrorDialogArgs(
-            resourceManager.getString(R.string.common_error_title),
-            resourceManager.getString(R.string.tor_bridges_incorrect_format)
+        showModularDialog(
+            ErrorDialogArgs(
+                resourceManager.getString(R.string.common_error_title),
+                resourceManager.getString(R.string.tor_bridges_incorrect_format)
+            ).getModular(resourceManager)
         )
-        modularDialog.postValue(args.getModular(resourceManager))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
@@ -9,6 +9,7 @@ import com.tari.android.wallet.model.PendingInboundTx
 import com.tari.android.wallet.model.PendingOutboundTx
 import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.TxStatus
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolder
 import com.tari.android.wallet.ui.common.recyclerView.ViewHolderBuilder
 import com.tari.android.wallet.ui.component.tari.TariFont
@@ -104,20 +105,20 @@ class TxListHomeViewHolder(view: ItemHomeTxListBinding) : CommonViewHolder<Trans
         val (amountText, textColor, backgroundColor) = when {
             tx is CancelledTx -> Triple(
                 amount,
-                paletteManager.getTextBody(context),
-                paletteManager.getBackgroundPrimary(context)
+                PaletteManager.getTextBody(context),
+                PaletteManager.getBackgroundPrimary(context)
             )
 
             tx is PendingInboundTx -> Triple(
                 "+$amount",
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx is PendingOutboundTx -> Triple(
                 "-$amount",
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx is CompletedTx && tx.status == TxStatus.MINED_UNCONFIRMED -> Triple(
@@ -125,20 +126,20 @@ class TxListHomeViewHolder(view: ItemHomeTxListBinding) : CommonViewHolder<Trans
                     Tx.Direction.OUTBOUND -> "-$amount"
                     Tx.Direction.INBOUND -> "+$amount"
                 },
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx.direction == Tx.Direction.INBOUND -> Triple(
                 "+$amount",
-                paletteManager.getGreen(context),
-                paletteManager.getSecondaryGreen(context)
+                PaletteManager.getGreen(context),
+                PaletteManager.getSecondaryGreen(context)
             )
 
             else -> Triple(
                 "-$amount",
-                paletteManager.getRed(context),
-                paletteManager.getSecondaryRed(context)
+                PaletteManager.getRed(context),
+                PaletteManager.getSecondaryRed(context)
             )
         }
         ui.amountTextView.text = amountText

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
@@ -17,6 +17,7 @@ import com.tari.android.wallet.model.PendingOutboundTx
 import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.TxNote
 import com.tari.android.wallet.model.TxStatus
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.gyphy.presentation.GIFStateConsumer
 import com.tari.android.wallet.ui.common.gyphy.presentation.GlideGIFListener
 import com.tari.android.wallet.ui.common.gyphy.repository.GIFItem
@@ -145,20 +146,20 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
         val (amountText, textColor, backgroundColor) = when {
             tx is CancelledTx -> Triple(
                 amount,
-                paletteManager.getTextBody(context),
-                paletteManager.getBackgroundPrimary(context)
+                PaletteManager.getTextBody(context),
+                PaletteManager.getBackgroundPrimary(context)
             )
 
             tx is PendingInboundTx -> Triple(
                 "+$amount",
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx is PendingOutboundTx -> Triple(
                 "-$amount",
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx is CompletedTx && tx.status == TxStatus.MINED_UNCONFIRMED -> Triple(
@@ -166,20 +167,20 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
                     Tx.Direction.OUTBOUND -> "-$amount"
                     Tx.Direction.INBOUND -> "+$amount"
                 },
-                paletteManager.getYellow(context),
-                paletteManager.getSecondaryYellow(context)
+                PaletteManager.getYellow(context),
+                PaletteManager.getSecondaryYellow(context)
             )
 
             tx.direction == Tx.Direction.INBOUND -> Triple(
                 "+$amount",
-                paletteManager.getGreen(context),
-                paletteManager.getSecondaryGreen(context)
+                PaletteManager.getGreen(context),
+                PaletteManager.getSecondaryGreen(context)
             )
 
             else -> Triple(
                 "-$amount",
-                paletteManager.getRed(context),
-                paletteManager.getSecondaryRed(context)
+                PaletteManager.getRed(context),
+                PaletteManager.getSecondaryRed(context)
             )
         }
         ui.amountTextView.text = amountText

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsViewModel.kt
@@ -82,11 +82,12 @@ class TxDetailsViewModel : CommonViewModel() {
     fun cancelTransaction() {
         val isCancelled = walletService.getWithError { error, wallet -> wallet.cancelPendingTx(TxId(this.tx.value!!.id), error) }
         if (!isCancelled) {
-            val errorDialogArgs = ErrorDialogArgs(
-                resourceManager.getString(R.string.tx_detail_cancellation_error_title),
-                resourceManager.getString(R.string.tx_detail_cancellation_error_description)
+            showModularDialog(
+                ErrorDialogArgs(
+                    title = resourceManager.getString(R.string.tx_detail_cancellation_error_title),
+                    description = resourceManager.getString(R.string.tx_detail_cancellation_error_description),
+                ).getModular(resourceManager)
             )
-            modularDialog.postValue(errorDialogArgs.getModular(resourceManager))
         }
     }
 
@@ -140,11 +141,13 @@ class TxDetailsViewModel : CommonViewModel() {
         val foundTx = findTxById(txId!!, walletService)
 
         if (foundTx == null) {
-            val errorArgs = ErrorDialogArgs(
-                resourceManager.getString(R.string.tx_details_error_tx_not_found_title),
-                resourceManager.getString(R.string.tx_details_error_tx_not_found_desc)
-            ) { backPressed.call() }
-            modularDialog.postValue(errorArgs.getModular(resourceManager))
+            showModularDialog(
+                ErrorDialogArgs(
+                    title = resourceManager.getString(R.string.tx_details_error_tx_not_found_title),
+                    description = resourceManager.getString(R.string.tx_details_error_tx_not_found_desc),
+                    onClose = { backPressed.call() },
+                ).getModular(resourceManager)
+            )
         } else {
             foundTx.let { _txObject.onNext(it) }
             generateExplorerLink(foundTx)
@@ -202,8 +205,7 @@ class TxDetailsViewModel : CommonViewModel() {
             true
         }
 
-        val args = ModularDialogArgs(DialogArgs(), moduleList)
-        _inputDialog.postValue(args)
+        showInputModalDialog(ModularDialogArgs(DialogArgs(), moduleList))
     }
 
     private fun saveDetails(newName: String) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/questionMark/QuestionMarkViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/questionMark/QuestionMarkViewModel.kt
@@ -6,13 +6,14 @@ import com.tari.android.wallet.ui.dialog.confirm.ConfirmDialogArgs
 
 class QuestionMarkViewModel : CommonViewModel() {
     fun showUniversityDialog() {
-        val confirmDialogArgs = ConfirmDialogArgs(
-            resourceManager.getString(R.string.home_balance_info_help_title),
-            resourceManager.getString(R.string.home_balance_info_help_description),
-            resourceManager.getString(R.string.common_cancel),
-            resourceManager.getString(R.string.home_balance_info_help_button),
-            onConfirm = { _openLink.postValue(resourceManager.getString(R.string.tari_lab_university_url)) }
+        showModularDialog(
+            ConfirmDialogArgs(
+                title = resourceManager.getString(R.string.home_balance_info_help_title),
+                description = resourceManager.getString(R.string.home_balance_info_help_description),
+                cancelButtonText = resourceManager.getString(R.string.common_cancel),
+                confirmButtonText = resourceManager.getString(R.string.home_balance_info_help_button),
+                onConfirm = { _openLink.postValue(resourceManager.getString(R.string.tari_lab_university_url)) },
+            ).getModular(resourceManager)
         )
-        modularDialog.postValue(confirmDialogArgs.getModular(resourceManager))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTileListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/adapters/UtxosTileListViewHolder.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.updateLayoutParams
 import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.ItemUtxosTileBinding
+import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolder
 import com.tari.android.wallet.ui.common.recyclerView.ViewHolderBuilder
 import com.tari.android.wallet.ui.extension.dpToPx
@@ -36,7 +37,7 @@ class UtxosTileListViewHolder(view: ItemUtxosTileBinding) : CommonViewHolder<Utx
 
         ui.root.updateLayoutParams<ViewGroup.LayoutParams> { this.height = itemView.context.dpToPx(item.height.toFloat()).toInt() }
 
-        val baseColor = Color.valueOf(paletteManager.getPurpleBrand(itemView.context))
+        val baseColor = Color.valueOf(PaletteManager.getPurpleBrand(itemView.context))
         val newColor = Color.valueOf(getNext(baseColor.red()), getNext(baseColor.green()), getNext(baseColor.blue()))
 
         val shapeDrawable = ContextCompat.getDrawable(itemView.context, R.drawable.vector_utxos_list_tile_bg) as GradientDrawable
@@ -62,7 +63,7 @@ class UtxosTileListViewHolder(view: ItemUtxosTileBinding) : CommonViewHolder<Utx
             val outlineDrawable = ContextCompat.getDrawable(itemView.context, R.drawable.vector_utxos_list_tile_outline_bg)
             ui.outlineContainer.background = outlineDrawable
         } else {
-            ui.outlineContainer.setBackgroundColor(paletteManager.getNeutralSecondary(itemView.context))
+            ui.outlineContainer.setBackgroundColor(PaletteManager.getNeutralSecondary(itemView.context))
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/controllers/CheckedController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/utxos/list/controllers/CheckedController.kt
@@ -10,22 +10,21 @@ class CheckedController(val view: TextView) {
     private var checked: AtomicBoolean = AtomicBoolean(false)
 
     var toggleCallback: (Boolean) -> Unit = {}
-    val paletteManager = PaletteManager()
 
     fun toggleChecked() {
         setChecked(!checked.get())
     }
 
     fun setChecked(checked: Boolean) {
-        if(checked == this.checked.get()) return
+        if (checked == this.checked.get()) return
         this.checked.set(checked)
         toggleCallback(checked)
         if (this.checked.get()) {
             view.setText(R.string.common_cancel)
-            view.setTextColor(paletteManager.getTextLinks(view.context))
+            view.setTextColor(PaletteManager.getTextLinks(view.context))
         } else {
             view.setText(R.string.utxos_selecting)
-            view.setTextColor(paletteManager.getTextHeading(view.context))
+            view.setTextColor(PaletteManager.getTextHeading(view.context))
         }
     }
 }

--- a/app/src/main/res/layout/fragment_create_wallet.xml
+++ b/app/src/main/res/layout/fragment_create_wallet.xml
@@ -245,7 +245,26 @@
                     android:textColor="?attr/palette_text_heading"
                     android:textSize="18sp"
                     android:visibility="invisible"
-                    app:customFont="roman" />
+                    app:customFont="roman"
+                    tools:visibility="visible" />
+
+                <com.tari.android.wallet.ui.component.tari.TariTextView
+                    android:id="@+id/tor_progress_status_text_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/just_sec_desc_text_view"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="20dp"
+                    android:gravity="center"
+                    android:letterSpacing="-0.03"
+                    android:lineSpacingExtra="8dp"
+                    android:textColor="?attr/palette_text_body"
+                    android:textSize="14sp"
+                    android:visibility="invisible"
+                    app:customFont="light"
+                    tools:text="Tor is connecting... \n66 %"
+                    tools:visibility="visible" />
 
                 <View
                     android:id="@+id/just_sec_desc_back_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,8 @@
     <string name="introduction_selected_wallet">Selected Network: %s</string>
 
     <!-- onboarding - create wallet -->
+    <string name="create_wallet_cancel_dialog_title">Cancel Wallet Creation</string>
+    <string name="create_wallet_cancel_dialog_description">Are you sure you want to cancel wallet creation? You will lose all progress.</string>
     <!-- screen #1 -->
     <string name="create_wallet_just_a_sec_label" tools:ignore="TypographyEllipsis">Hold on a sec...</string>
     <string name="create_wallet_just_sec_desc_text">We’re creating your wallet.</string>


### PR DESCRIPTION
Proper implementation of error handling during the onboarding(wallet creation) process.
- The user can cancel the wallet creation flow by clicking the back button
- The wallet creation flow is automatically reset if there are any FFI errors
- Made `DialogManager` Singleton
- Encapsulated the showing dialogs logic to `CommonViewModel`
- Make `PaletteManager` object and remove the DI injection for it
- Refactored code of all screens of the onboarding flow