### PR TITLE
feat: New address format – Link Contact

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shortEmoji/ShortEmojiModuleView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shortEmoji/ShortEmojiModuleView.kt
@@ -7,12 +7,13 @@ import android.view.ViewGroup
 import com.tari.android.wallet.databinding.DialogModuleShortEmojiBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.component.common.CommonView
-import com.tari.android.wallet.ui.component.fullEmojiId.EmojiIdSummaryViewController
+import com.tari.android.wallet.util.addressFirstEmojis
+import com.tari.android.wallet.util.addressLastEmojis
+import com.tari.android.wallet.util.addressPrefixEmojis
 
 @SuppressLint("ViewConstructor")
-class ShortEmojiModuleView(context: Context, buttonModule: ShortEmojiIdModule) : CommonView<CommonViewModel, DialogModuleShortEmojiBinding>(context) {
-
-    private val emojiController = EmojiIdSummaryViewController(ui.participantEmojiIdView)
+class ShortEmojiModuleView(context: Context, shortEmojiModule: ShortEmojiIdModule) :
+    CommonView<CommonViewModel, DialogModuleShortEmojiBinding>(context) {
 
     override fun bindingInflate(layoutInflater: LayoutInflater, parent: ViewGroup?, attachToRoot: Boolean): DialogModuleShortEmojiBinding =
         DialogModuleShortEmojiBinding.inflate(layoutInflater, parent, attachToRoot)
@@ -20,6 +21,8 @@ class ShortEmojiModuleView(context: Context, buttonModule: ShortEmojiIdModule) :
     override fun setup() = Unit
 
     init {
-        emojiController.display(buttonModule.tariWalletAddress.fullEmojiId)
+        ui.emojiIdViewContainer.textViewEmojiPrefix.text = shortEmojiModule.tariWalletAddress.addressPrefixEmojis()
+        ui.emojiIdViewContainer.textViewEmojiFirstPart.text = shortEmojiModule.tariWalletAddress.addressFirstEmojis()
+        ui.emojiIdViewContainer.textViewEmojiLastPart.text = shortEmojiModule.tariWalletAddress.addressLastEmojis()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/contactBook/link/adapter/link_header/ContactLinkHeaderViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/contactBook/link/adapter/link_header/ContactLinkHeaderViewHolder.kt
@@ -2,12 +2,13 @@ package com.tari.android.wallet.ui.fragment.contactBook.link.adapter.link_header
 
 import android.app.Activity
 import androidx.appcompat.widget.SearchView
-import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.ItemContactLinkHeaderBinding
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolder
 import com.tari.android.wallet.ui.common.recyclerView.ViewHolderBuilder
 import com.tari.android.wallet.ui.extension.showKeyboard
-import com.tari.android.wallet.util.extractEmojis
+import com.tari.android.wallet.util.addressFirstEmojis
+import com.tari.android.wallet.util.addressLastEmojis
+import com.tari.android.wallet.util.addressPrefixEmojis
 
 class ContactLinkHeaderViewHolder(view: ItemContactLinkHeaderBinding) :
     CommonViewHolder<ContactLinkHeaderViewHolderItem, ItemContactLinkHeaderBinding>(view) {
@@ -29,11 +30,9 @@ class ContactLinkHeaderViewHolder(view: ItemContactLinkHeaderBinding) :
         ui.searchView.requestFocus()
         (ui.searchView.context as? Activity)?.showKeyboard(ui.searchView)
 
-        val emojiId = item.walletAddress.fullEmojiId.extractEmojis()
-        // TODO move it to a helper function
-        val shortEmojiId = emojiId.take(3) + itemView.context.getString(R.string.emoji_id_bullet_separator) + emojiId.takeLast(3)
-        val shortString = shortEmojiId.joinToString("")
-        ui.linkContactMessage.text = itemView.context.getString(R.string.contact_book_contacts_book_link_message, shortString)
+        ui.emojiIdViewContainer.textViewEmojiPrefix.text = item.walletAddress.addressPrefixEmojis()
+        ui.emojiIdViewContainer.textViewEmojiFirstPart.text = item.walletAddress.addressFirstEmojis()
+        ui.emojiIdViewContainer.textViewEmojiLastPart.text = item.walletAddress.addressLastEmojis()
     }
 
     companion object {

--- a/app/src/main/res/layout/dialog_module_short_emoji.xml
+++ b/app/src/main/res/layout/dialog_module_short_emoji.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <include
-        android:id="@+id/participant_emoji_id_view"
-        layout="@layout/view_emoji_id_summary"
+        android:id="@+id/emoji_id_view_container"
+        layout="@layout/view_address_short_small"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_gravity="center"
         android:layout_marginBottom="10dp"
         android:layout_weight="1" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/item_contact_link_header.xml
+++ b/app/src/main/res/layout/item_contact_link_header.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clickable="true"
@@ -9,17 +8,24 @@
     android:orientation="vertical">
 
     <com.tari.android.wallet.ui.component.tari.TariTextView
-        android:id="@+id/link_contact_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="20dp"
         android:layout_marginTop="20dp"
         android:gravity="center"
         android:lineSpacingExtra="8dp"
-        app:customFont="medium"
-        tools:text="@string/long_dummy_message" />
+        android:text="@string/contact_book_contacts_book_link_message"
+        app:customFont="medium" />
 
-    <com.tari.android.wallet.ui.component.tari.background.obsolete.TariPrimaryBackgroundConstraint
+    <include
+        android:id="@+id/emoji_id_view_container"
+        layout="@layout/view_address_short_small"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="10dp" />
+
+    <com.tari.android.wallet.ui.component.tari.background.TariPrimaryBackground
         android:id="@+id/search_view_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -35,7 +41,5 @@
             android:hint="@string/contact_book_search_hint"
             app:defaultQueryHint="@string/contact_book_search_hint"
             app:queryBackground="@null" />
-
-    </com.tari.android.wallet.ui.component.tari.background.obsolete.TariPrimaryBackgroundConstraint>
-
+    </com.tari.android.wallet.ui.component.tari.background.TariPrimaryBackground>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -830,7 +830,7 @@
     <string name="contact_book_contacts_book_link_message_secondLine"><![CDATA[to <b>%s</b>]]></string>
     <string name="contact_book_contacts_book_link_success_message_firstLine"><![CDATA[You have successfully linked]]></string>
     <string name="contact_book_contacts_book_link_success_message_secondLine"><![CDATA[to <b>%s</b>]]></string>
-    <string name="contact_book_contacts_book_link_message">You can quickly associate an Emoji ID or Yat with a contact already present in your phone. Simply click on a name below and it will be linked to %s</string>
+    <string name="contact_book_contacts_book_link_message">You can quickly associate an Emoji ID or Yat with a contact already present in your phone. Simply click on a name below and it will be linked to:</string>
     <string name="contact_book_contacts_book_unlink_title">Unlink Contact</string>
     <string name="contact_book_contacts_book_unlink_message_firstLine"><![CDATA[Click "confirm" to unlink]]></string>
     <string name="contact_book_contacts_book_unlink_message_secondLine"><![CDATA[from <b>%s</b>]]></string>


### PR DESCRIPTION
Aligned the Link Contact screens with the new wallet address format:

<img src="https://github.com/user-attachments/assets/db4afc29-fc2a-48f1-ac5c-14e59febcc1b" width="350" />
