### PR TITLE
feat: Payment ID for note

### DIFF
--- a/app/src/main/cpp/jniCompletedTransaction.cpp
+++ b/app/src/main/cpp/jniCompletedTransaction.cpp
@@ -139,6 +139,21 @@ Java_com_tari_android_wallet_ffi_FFICompletedTx_jniGetMessage(
 }
 
 extern "C"
+JNIEXPORT jstring JNICALL
+Java_com_tari_android_wallet_ffi_FFICompletedTx_jniGetPaymentId(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jobject error) {
+    return ExecuteWithError<jstring>(jEnv, error, [&](int *errorPointer) {
+        auto pCompletedTx = GetPointerField<TariCompletedTransaction *>(jEnv, jThis);
+        const char *pPaymentId = completed_transaction_get_payment_id(pCompletedTx, errorPointer);
+        jstring result = jEnv->NewStringUTF(pPaymentId);
+        string_destroy(const_cast<char *>(pPaymentId));
+        return result;
+    });
+}
+
+extern "C"
 JNIEXPORT jint JNICALL
 Java_com_tari_android_wallet_ffi_FFICompletedTx_jniGetStatus(
         JNIEnv *jEnv,

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFICompletedTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFICompletedTx.kt
@@ -45,6 +45,7 @@ class FFICompletedTx() : FFITxBase() {
     private external fun jniGetFee(libError: FFIError): ByteArray
     private external fun jniGetTimestamp(libError: FFIError): ByteArray
     private external fun jniGetMessage(libError: FFIError): String
+    private external fun jniGetPaymentId(libError: FFIError): String
     private external fun jniGetStatus(libError: FFIError): Int
     private external fun jniGetConfirmationCount(libError: FFIError): ByteArray
     private external fun jniIsOutbound(libError: FFIError): Boolean
@@ -71,6 +72,8 @@ class FFICompletedTx() : FFITxBase() {
     fun getTimestamp(): BigInteger = runWithError { BigInteger(1, jniGetTimestamp(it)) }
 
     fun getMessage(): String = runWithError { jniGetMessage(it) }
+
+    fun getPaymentId(): String = runWithError { jniGetPaymentId(it) }
 
     fun getStatus(): FFITxStatus = runWithError { FFITxStatus.map(jniGetStatus(it)) }
 

--- a/app/src/main/java/com/tari/android/wallet/model/CancelledTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/CancelledTx.kt
@@ -51,11 +51,12 @@ data class CancelledTx(
     override val amount: MicroTari = 0.toMicroTari(),
     override val timestamp: BigInteger = 0.toBigInteger(),
     override val message: String = "",
+    override val paymentId: String = "",
     override val status: TxStatus = TxStatus.PENDING,
     override val tariContact: TariContact,
     val fee: MicroTari = 0.toMicroTari(),
     val cancellationReason: FFITxCancellationReason = FFITxCancellationReason.NotCancelled,
-) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
+) : Tx(id, direction, amount, timestamp, message, paymentId, status, tariContact), Parcelable {
 
     constructor(tx: FFICompletedTx) : this(
         id = tx.getId(),
@@ -64,6 +65,7 @@ data class CancelledTx(
         amount = MicroTari(tx.getAmount()),
         timestamp = tx.getTimestamp(),
         message = tx.getMessage(),
+        paymentId = tx.getPaymentId(),
         status = TxStatus.map(tx.getStatus()),
         fee = MicroTari(tx.getFee()),
         cancellationReason = tx.getCancellationReason(),

--- a/app/src/main/java/com/tari/android/wallet/model/CompletedTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/CompletedTx.kt
@@ -51,12 +51,13 @@ data class CompletedTx(
     override val amount: MicroTari = 0.toMicroTari(),
     override val timestamp: BigInteger = 0.toBigInteger(),
     override val message: String = "",
+    override val paymentId: String = "",
     override val status: TxStatus = TxStatus.PENDING,
     override val tariContact: TariContact,
     val fee: MicroTari = 0.toMicroTari(),
     val confirmationCount: BigInteger = 0.toBigInteger(),
     val txKernel: CompletedTransactionKernel? = null,
-) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
+) : Tx(id, direction, amount, timestamp, message, paymentId, status, tariContact), Parcelable {
 
     constructor(tx: FFICompletedTx) : this(
         id = tx.getId(),
@@ -64,6 +65,7 @@ data class CompletedTx(
         amount = MicroTari(tx.getAmount()),
         timestamp = tx.getTimestamp(),
         message = tx.getMessage(),
+        paymentId = tx.getPaymentId(),
         status = TxStatus.map(tx.getStatus()),
         tariContact = tx.getContact(),
         fee = MicroTari(tx.getFee()),

--- a/app/src/main/java/com/tari/android/wallet/model/PendingInboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/PendingInboundTx.kt
@@ -51,9 +51,10 @@ data class PendingInboundTx(
     override val amount: MicroTari = 0.toMicroTari(),
     override val timestamp: BigInteger = 0.toBigInteger(),
     override val message: String = "",
+    override val paymentId: String = "",
     override val status: TxStatus = TxStatus.PENDING,
     override val tariContact: TariContact,
-) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
+) : Tx(id, direction, amount, timestamp, message, paymentId, status, tariContact), Parcelable {
 
     constructor(tx: FFICompletedTx) : this(
         id = tx.getId(),
@@ -62,6 +63,7 @@ data class PendingInboundTx(
         amount = tx.getAmount().toMicroTari(),
         timestamp = tx.getTimestamp(),
         message = tx.getMessage(),
+        paymentId = tx.getPaymentId(),
         status = TxStatus.map(tx.getStatus()),
     )
 

--- a/app/src/main/java/com/tari/android/wallet/model/PendingOutboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/PendingOutboundTx.kt
@@ -51,10 +51,11 @@ data class PendingOutboundTx(
     override val amount: MicroTari = 0.toMicroTari(),
     override val timestamp: BigInteger = 0.toBigInteger(),
     override val message: String = "",
+    override val paymentId: String = "",
     override val status: TxStatus = TxStatus.PENDING,
     override val tariContact: TariContact,
     val fee: MicroTari = 0.toMicroTari(),
-) : Tx(id, direction, amount, timestamp, message, status, tariContact), Parcelable {
+) : Tx(id, direction, amount, timestamp, message, paymentId, status, tariContact), Parcelable {
 
     constructor(tx: FFICompletedTx) : this(
         id = tx.getId(),
@@ -64,6 +65,7 @@ data class PendingOutboundTx(
         fee = tx.getFee().toMicroTari(),
         timestamp = tx.getTimestamp(),
         message = tx.getMessage(),
+        paymentId = tx.getPaymentId(),
         status = TxStatus.map(tx.getStatus()),
     )
 

--- a/app/src/main/java/com/tari/android/wallet/model/Tx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/Tx.kt
@@ -46,6 +46,7 @@ abstract class Tx(
     open val amount: MicroTari,
     open val timestamp: BigInteger, // Seconds
     open val message: String,
+    open val paymentId: String,
     open val status: TxStatus,
     open val tariContact: TariContact, // This is the receiver for an outbound tx and sender for an inbound tx.
 ) : Parcelable {

--- a/app/src/main/java/com/tari/android/wallet/model/TxNote.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TxNote.kt
@@ -63,7 +63,8 @@ class TxNote(val message: String?, val gifUrl: String?) {
     override fun toString(): String = "TransactionNote(message=$message, gifUrl=$gifUrl)"
 
     companion object {
-        fun fromNote(note: String, assetsDomain: String = "giphy.com", protocol: String = "https://"): TxNote {
+        fun fromTx(tx: Tx, assetsDomain: String = "giphy.com", protocol: String = "https://"): TxNote {
+            val note = if (tx.isOneSided) tx.paymentId else tx.message
             val lines = note.split(Regex(" "))
             return if (Regex("$protocol$assetsDomain.*").matches(lines.last())) TxNote(
                 message = lines.take(lines.size - 1).filter(String::isNotEmpty)

--- a/app/src/main/java/com/tari/android/wallet/ui/common/gyphy/presentation/GifViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/gyphy/presentation/GifViewModel.kt
@@ -3,6 +3,7 @@ package com.tari.android.wallet.ui.common.gyphy.presentation
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.tari.android.wallet.extension.addTo
+import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.TxNote
 import com.tari.android.wallet.ui.common.gyphy.presentation.GifState.ErrorState
 import com.tari.android.wallet.ui.common.gyphy.presentation.GifState.LoadingState
@@ -19,14 +20,14 @@ import io.reactivex.subjects.BehaviorSubject
 
 class GifViewModel(private val repository: GifRepository) {
     private val compositeDisposable = CompositeDisposable()
-    private val subject = BehaviorSubject.create<String>()
+    private val subject = BehaviorSubject.create<Tx>()
     private val _gifState = MutableLiveData<GifState>()
     val gifState: LiveData<GifState> get() = _gifState
 
     init {
         _gifState.postValue(NoGIFState)
         subject
-            .map(TxNote.Companion::fromNote)
+            .map(TxNote.Companion::fromTx)
             .map { it.gifId ?: "" }
             .switchMap {
                 if (it.isEmpty()) Observable.just(NoGIFState)
@@ -50,7 +51,7 @@ class GifViewModel(private val repository: GifRepository) {
         }
     }
 
-    fun onNewTxNote(note: String) = subject.onNext(note)
+    fun onNewTx(tx: Tx) = subject.onNext(tx)
 
     fun retry() {
         subject.value?.let(subject::onNext)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListHomeViewHolder.kt
@@ -41,7 +41,7 @@ class TxListHomeViewHolder(view: ItemHomeTxListBinding) : CommonViewHolder<Trans
             displayDate(this)
         }
 
-        item.gifViewModel.onNewTxNote(tx.message)
+        item.gifViewModel.onNewTx(tx)
     }
 
     private fun displayAliasOrEmojiId(tx: Tx, contact: ContactDto?) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/adapter/TxListViewHolder.kt
@@ -58,7 +58,7 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
             displayMessage(this)
         }
 
-        item.gifViewModel.onNewTxNote(tx.message)
+        item.gifViewModel.onNewTx(tx)
         ui.gifContainer.retryLoadingGifTextView.setOnClickListener { item.gifViewModel.retry() }
         item.gifViewModel.gifState.observeForever { it.handle(this) }
     }
@@ -231,12 +231,12 @@ class TxListViewHolder(view: ItemTxListBinding) : CommonViewHolder<TransactionIt
     }
 
     private fun displayMessage(tx: Tx) {
-        val note = TxNote.fromNote(tx.message)
+        val note = TxNote.fromTx(tx)
         if (note.message.isNullOrBlank()) {
             ui.messageTextView.gone()
         } else {
             ui.messageTextView.visible()
-            ui.messageTextView.text = if (tx.isOneSided) string(R.string.tx_list_you_received_one_side_payment) else note.message
+            ui.messageTextView.text = note.message
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/details/TxDetailsFragment.kt
@@ -55,7 +55,6 @@ import com.tari.android.wallet.R.string.tx_detail_pending_payment_received
 import com.tari.android.wallet.R.string.tx_detail_waiting_for_recipient
 import com.tari.android.wallet.R.string.tx_detail_waiting_for_sender_to_complete
 import com.tari.android.wallet.R.string.tx_details_fee_value
-import com.tari.android.wallet.R.string.tx_list_you_received_one_side_payment
 import com.tari.android.wallet.databinding.FragmentTxDetailsBinding
 import com.tari.android.wallet.extension.collectNonNullFlow
 import com.tari.android.wallet.extension.observe
@@ -157,7 +156,7 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
     }
 
     private fun fetchGIFIfAttached(tx: Tx) {
-        val gifId = TxNote.fromNote(tx.message).gifId ?: return
+        val gifId = TxNote.fromTx(tx).gifId ?: return
         val gifViewModel: GifViewModel by viewModels()
         gifViewModel.onGIFFetchRequested(gifId)
         GifView(ui.gifContainer, Glide.with(this), gifViewModel, this).displayGif()
@@ -224,11 +223,12 @@ class TxDetailsFragment : CommonFragment<FragmentTxDetailsBinding, TxDetailsView
 
     private fun setTxMetaData(tx: Tx) {
         ui.dateTextView.text = Date(tx.timestamp.toLong() * 1000).txFormattedDate()
-        val note = TxNote.fromNote(tx.message)
-        if (note.message == null) {
+        val note = TxNote.fromTx(tx)
+        if (note.message.isNullOrBlank()) {
             ui.txNoteTextView.gone()
         } else {
-            ui.txNoteTextView.text = if (tx.isOneSided) string(tx_list_you_received_one_side_payment) else note.message
+            ui.txNoteTextView.visible()
+            ui.txNoteTextView.text = note.message
         }
         ui.gifContainer.root.visible()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,7 +245,6 @@
     <string name="tx_list_emoji_one_side_payment_placeholder">➡️</string>
     <string name="tx_list_emoji_coinbase_payment_placeholder">🪙</string>
     <string name="tx_list_someone">Someone</string>
-    <string name="tx_list_you_received_one_side_payment">You received a one side payment</string>
 
     <!-- send tari -->
     <string name="send_tari_title">Send To</string>

--- a/app/src/test/java/com/tari/android/wallet/ui/presentation/TxNoteTest.kt
+++ b/app/src/test/java/com/tari/android/wallet/ui/presentation/TxNoteTest.kt
@@ -32,7 +32,10 @@
  */
 package com.tari.android.wallet.ui.presentation
 
+import com.tari.android.wallet.model.CompletedTx
+import com.tari.android.wallet.model.TariContact
 import com.tari.android.wallet.model.TxNote
+import com.tari.android.wallet.util.MockDataStub.WALLET_ADDRESS
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -80,7 +83,7 @@ class TxNoteTest {
 
     @Test
     fun `fromNote, assert that empty note and no gif will be returnedif note is empty`() {
-        val note = TxNote.fromNote("")
+        val note = TxNote.fromTx(CompletedTx(message = "", tariContact = TariContact(WALLET_ADDRESS, "Test")))
         assertEquals("", note.message)
         assertNull(note.gifUrl)
     }
@@ -88,13 +91,17 @@ class TxNoteTest {
     @Test
     fun `fromNote, assert that only message was included if gif is null`() {
         val givenMessage = "alala"
-        assertEquals(TxNote(givenMessage, null), TxNote.fromNote(givenMessage))
+        assertEquals(
+            TxNote(givenMessage, null), TxNote.fromTx(CompletedTx(message = givenMessage, tariContact = TariContact(WALLET_ADDRESS, "Test")))
+        )
     }
 
     @Test
     fun `fromNote, assert that only url with a whitespace was included if message is null`() {
         val givenUrl = "https://giphy.com/embed/l2Sq9qGTQnL5NyI6Y"
-        assertEquals(TxNote(null, givenUrl), TxNote.fromNote(" $givenUrl"))
+        assertEquals(
+            TxNote(null, givenUrl), TxNote.fromTx(CompletedTx(message = " $givenUrl", tariContact = TariContact(WALLET_ADDRESS, "Test")))
+        )
     }
 
     @Test
@@ -103,7 +110,7 @@ class TxNoteTest {
         val givenUrl = "https://giphy.com/embed/l2Sq9qGTQnL5NyI6Y"
         assertEquals(
             TxNote(givenMessage, givenUrl),
-            TxNote.fromNote("$givenMessage $givenUrl")
+            TxNote.fromTx(CompletedTx(message = "$givenMessage $givenUrl", tariContact = TariContact(WALLET_ADDRESS, "Test")))
         )
     }
 


### PR DESCRIPTION
[#1182](https://github.com/tari-project/wallet-android/issues/1182)
Now we use the `paymentId` field as the note for one-sided txs.

<img src="https://github.com/user-attachments/assets/3d501e5e-a2fa-48ec-854c-1446bc890820" width="350" /> <img src="https://github.com/user-attachments/assets/e46aea67-cd09-473e-843b-ab09d625f6cd" width="350" />