### PR TITLE
fix: Don't hide dialogs

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonActivity.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonActivity.kt
@@ -146,7 +146,6 @@ abstract class CommonActivity<Binding : ViewBinding, VM : CommonViewModel> : App
 
     override fun onStop() {
         shakeDetector.stop()
-        dialogManager.dismiss() // TODO don't dismiss dialogs onStop. Think about a better way to handle this.
         super.onStop()
         screenCaptureCallback?.let { unregisterScreenCaptureCallback(it) }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonFragment.kt
@@ -169,11 +169,6 @@ abstract class CommonFragment<Binding : ViewBinding, VM : CommonViewModel> : Fra
             action()
         }
     }
-
-    override fun onDestroy() {
-        dialogManager?.dismiss()
-        super.onDestroy()
-    }
 }
 
 /**

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -17,6 +17,7 @@ import com.tari.android.wallet.di.ApplicationComponent
 import com.tari.android.wallet.di.DiContainer
 import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.addTo
+import com.tari.android.wallet.extension.launchOnMain
 import com.tari.android.wallet.ffi.FFIWallet
 import com.tari.android.wallet.infrastructure.logging.LoggerTags
 import com.tari.android.wallet.model.CoreError
@@ -42,7 +43,6 @@ import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator
 import com.tari.android.wallet.ui.fragment.settings.themeSelector.TariTheme
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -271,7 +271,7 @@ open class CommonViewModel : ViewModel() {
     }
 
     fun hideDialog(dialogId: Int = ModularDialogArgs.DialogId.NO_ID) {
-        viewModelScope.launch(Dispatchers.Main) {
+        launchOnMain {
             dialogManager.dismiss(dialogId)
         }
     }


### PR DESCRIPTION
Don't hide dialogs on destroying activity. Sometimes it comes to race condition and necessary dialogs are dismissed prematurely