### PR TITLE
feat: Paper Wallet – wallet sync status handling

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/application/baseNodes/BaseNodesManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/baseNodes/BaseNodesManager.kt
@@ -10,7 +10,6 @@ import com.tari.android.wallet.data.sharedPrefs.baseNode.BaseNodePrefRepository
 import com.tari.android.wallet.data.sharedPrefs.network.NetworkPrefRepository
 import com.tari.android.wallet.ffi.FFITariBaseNodeState
 import com.tari.android.wallet.ffi.FFIWallet
-import com.tari.android.wallet.service.baseNode.BaseNodeState
 import com.tari.android.wallet.util.DebugConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -111,10 +110,6 @@ class BaseNodesManager @Inject constructor(
 
     fun refreshBaseNodeList(wallet: FFIWallet) {
         baseNodeSharedRepository.ffiBaseNodes = loadBaseNodesFromFFI(wallet)
-    }
-
-    fun setBaseNodeState(state: BaseNodeState) {
-        baseNodeSharedRepository.baseNodeState = state
     }
 
     private fun loadBaseNodesFromFFI(wallet: FFIWallet): BaseNodeList = wallet.getBaseNodePeers()

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/baseNode/BaseNodePrefRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/baseNode/BaseNodePrefRepository.kt
@@ -36,11 +36,8 @@ import android.content.SharedPreferences
 import com.tari.android.wallet.data.sharedPrefs.CommonPrefRepository
 import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefGsonDelegate
 import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefGsonNullableDelegate
-import com.tari.android.wallet.data.sharedPrefs.delegates.SharedPrefIntDelegate
 import com.tari.android.wallet.data.sharedPrefs.network.NetworkPrefRepository
 import com.tari.android.wallet.data.sharedPrefs.network.formatKey
-import com.tari.android.wallet.event.EventBus
-import com.tari.android.wallet.service.baseNode.BaseNodeState
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -53,7 +50,6 @@ class BaseNodePrefRepository @Inject constructor(
     private object Key {
         const val CURRENT_BASE_NODE = "tari_wallet_current_base_node"
         const val USER_BASE_NODE_LIST = "tari_wallet_user_base_nodes"
-        const val BASE_NODE_STATE = "tari_wallet_user_base_node_state"
         const val FFI_BASE_NODE_LIST = "FFI_BASE_NODE_LIST"
     }
 
@@ -78,23 +74,6 @@ class BaseNodePrefRepository @Inject constructor(
         type = BaseNodeList::class.java,
         defValue = BaseNodeList(),
     )
-
-    // ordinal value of BaseNodeState enum class
-    private var baseNodeStateOrdinal: Int by SharedPrefIntDelegate(
-        prefs = sharedPrefs,
-        commonRepository = this,
-        name = Key.BASE_NODE_STATE,
-        defValue = BaseNodeState.Syncing.ordinal,
-    )
-    var baseNodeState: BaseNodeState
-        get() = BaseNodeState.get(baseNodeStateOrdinal)
-        set(value) {
-            baseNodeStateOrdinal = value.ordinal
-        }
-
-    init {
-        EventBus.baseNodeState.post(baseNodeState)
-    }
 
     fun clear() {
         currentBaseNode = null

--- a/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
@@ -35,8 +35,6 @@ package com.tari.android.wallet.event
 import com.tari.android.wallet.infrastructure.backup.BackupsState
 import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.model.recovery.WalletRestorationResult
-import com.tari.android.wallet.service.baseNode.BaseNodeState
-import com.tari.android.wallet.service.baseNode.BaseNodeSyncState
 
 /**
  * Event bus for the pub/sub model.
@@ -53,29 +51,17 @@ object EventBus : GeneralEventBus() {
 
     val backupState = BehaviorEventBus<BackupsState>()
 
-    val baseNodeState = BehaviorEventBus<BaseNodeState>()
-
-    val baseNodeSyncState = BehaviorEventBus<BaseNodeSyncState>()
-
     val walletRestorationState = BehaviorEventBus<WalletRestorationResult>()
-
-    init {
-        baseNodeSyncState.post(BaseNodeSyncState.Syncing)
-    }
 
     fun unsubscribeAll(subscriber: Any) {
         EventBus.unsubscribe(subscriber)
         backupState.unsubscribe(subscriber)
-        baseNodeState.unsubscribe(subscriber)
-        baseNodeSyncState.unsubscribe(subscriber)
         walletRestorationState.unsubscribe(subscriber)
     }
 
     override fun clear() {
         super.clear()
         backupState.clear()
-        baseNodeState.clear()
-        baseNodeSyncState.clear()
         walletRestorationState.clear()
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
+++ b/app/src/main/java/com/tari/android/wallet/event/EventBus.kt
@@ -35,7 +35,6 @@ package com.tari.android.wallet.event
 import com.tari.android.wallet.infrastructure.backup.BackupsState
 import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.model.recovery.WalletRestorationResult
-import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.service.baseNode.BaseNodeState
 import com.tari.android.wallet.service.baseNode.BaseNodeSyncState
 
@@ -52,8 +51,6 @@ object EventBus : GeneralEventBus() {
 
     val balanceState = BehaviorEventBus<BalanceInfo>()
 
-    val networkConnectionState = BehaviorEventBus<NetworkConnectionState>()
-
     val backupState = BehaviorEventBus<BackupsState>()
 
     val baseNodeState = BehaviorEventBus<BaseNodeState>()
@@ -68,7 +65,6 @@ object EventBus : GeneralEventBus() {
 
     fun unsubscribeAll(subscriber: Any) {
         EventBus.unsubscribe(subscriber)
-        networkConnectionState.unsubscribe(subscriber)
         backupState.unsubscribe(subscriber)
         baseNodeState.unsubscribe(subscriber)
         baseNodeSyncState.unsubscribe(subscriber)
@@ -77,11 +73,9 @@ object EventBus : GeneralEventBus() {
 
     override fun clear() {
         super.clear()
-        networkConnectionState.clear()
         backupState.clear()
         baseNodeState.clear()
         baseNodeSyncState.clear()
         walletRestorationState.clear()
     }
 }
-

--- a/app/src/main/java/com/tari/android/wallet/network/NetworkConnectionStateHandler.kt
+++ b/app/src/main/java/com/tari/android/wallet/network/NetworkConnectionStateHandler.kt
@@ -1,0 +1,21 @@
+package com.tari.android.wallet.network
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkConnectionStateHandler @Inject constructor() {
+
+    private val _networkConnectionState = MutableStateFlow(NetworkConnectionState.UNKNOWN)
+    val networkConnectionState = _networkConnectionState.asStateFlow()
+
+    fun updateState(state: NetworkConnectionState) {
+        _networkConnectionState.value = state
+    }
+
+    fun isNetworkConnected(): Boolean {
+        return networkConnectionState.value == NetworkConnectionState.CONNECTED
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/service/baseNode/BaseNodeStateHandler.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/baseNode/BaseNodeStateHandler.kt
@@ -1,0 +1,31 @@
+package com.tari.android.wallet.service.baseNode
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BaseNodeStateHandler @Inject constructor() {
+
+    /**
+     * Base node state. Showing the wallet is connected to the base node or not.
+     */
+    private val _baseNodeState = MutableStateFlow(BaseNodeState.Syncing)
+    val baseNodeState = _baseNodeState.asStateFlow()
+
+    /**
+     * Base node sync state. Showing the wallet validation status after connecting to the base node.
+     */
+    private val _baseNodeSyncState = MutableStateFlow<BaseNodeSyncState>(BaseNodeSyncState.NotStarted)
+    val baseNodeSyncState = _baseNodeSyncState.asStateFlow()
+
+    fun updateState(state: BaseNodeState) {
+        _baseNodeState.update { state }
+    }
+
+    fun updateSyncState(state: BaseNodeSyncState) {
+        _baseNodeSyncState.update { state }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
@@ -6,6 +6,7 @@ import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.extension.combineToPair
 import com.tari.android.wallet.network.NetworkConnectionState
+import com.tari.android.wallet.network.NetworkConnectionStateHandler
 import com.tari.android.wallet.service.baseNode.BaseNodeState
 import com.tari.android.wallet.service.baseNode.BaseNodeSyncState
 import com.tari.android.wallet.tor.TorProxyState
@@ -28,6 +29,9 @@ class ConnectionIndicatorViewModel : CommonViewModel() {
 
     @Inject
     lateinit var baseNodesManager: BaseNodesManager
+
+    @Inject
+    lateinit var networkConnectionStateHandler: NetworkConnectionStateHandler
 
     private val _state = MutableStateFlow(UiState())
     val state = _state.asStateFlow()
@@ -61,7 +65,7 @@ class ConnectionIndicatorViewModel : CommonViewModel() {
     }
 
     private fun subscribeOnEventBus() {
-        EventBus.networkConnectionState.subscribe(this) { networkState ->
+        collectFlow(networkConnectionStateHandler.networkConnectionState) { networkState ->
             _state.update { it.copy(networkState = networkState) }
             showStatesDialog(true)
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/component/networkStateIndicator/ConnectionIndicatorViewModel.kt
@@ -2,12 +2,12 @@ package com.tari.android.wallet.ui.component.networkStateIndicator
 
 import com.tari.android.wallet.R
 import com.tari.android.wallet.application.baseNodes.BaseNodesManager
-import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.extension.combineToPair
 import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.network.NetworkConnectionStateHandler
 import com.tari.android.wallet.service.baseNode.BaseNodeState
+import com.tari.android.wallet.service.baseNode.BaseNodeStateHandler
 import com.tari.android.wallet.service.baseNode.BaseNodeSyncState
 import com.tari.android.wallet.tor.TorProxyState
 import com.tari.android.wallet.tor.TorProxyStateHandler
@@ -32,6 +32,9 @@ class ConnectionIndicatorViewModel : CommonViewModel() {
 
     @Inject
     lateinit var networkConnectionStateHandler: NetworkConnectionStateHandler
+
+    @Inject
+    lateinit var baseNodeStateHandler: BaseNodeStateHandler
 
     private val _state = MutableStateFlow(UiState())
     val state = _state.asStateFlow()
@@ -69,15 +72,14 @@ class ConnectionIndicatorViewModel : CommonViewModel() {
             _state.update { it.copy(networkState = networkState) }
             showStatesDialog(true)
         }
-        EventBus.baseNodeState.subscribe(this) { baseNodeState ->
+        collectFlow(baseNodeStateHandler.baseNodeState) { baseNodeState ->
             _state.update { it.copy(baseNodeState = baseNodeState) }
             showStatesDialog(true)
         }
-        EventBus.baseNodeSyncState.subscribe(this) { syncState ->
+        collectFlow(baseNodeStateHandler.baseNodeSyncState) { syncState ->
             _state.update { it.copy(baseNodeSyncState = syncState) }
             showStatesDialog(true)
         }
-
         collectFlow(torProxyStateHandler.torProxyState) { torProxyState ->
             _state.update { it.copy(torProxyState = torProxyState) }
             showStatesDialog(true)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
@@ -17,7 +17,7 @@ import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.model.TxId
-import com.tari.android.wallet.network.NetworkConnectionState
+import com.tari.android.wallet.network.NetworkConnectionStateHandler
 import com.tari.android.wallet.ui.common.CommonActivity
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.dialog.modular.DialogArgs
@@ -101,10 +101,11 @@ import javax.inject.Singleton
 // TODO: move navigation logic to only the navigate() method and make all navigation methods private
 @Singleton
 class TariNavigator @Inject constructor(
-    val prefs: CorePrefRepository,
-    val tariSettingsSharedRepository: TariSettingsPrefRepository,
-    val walletManager: WalletManager,
+    private val prefs: CorePrefRepository,
+    private val tariSettingsSharedRepository: TariSettingsPrefRepository,
+    private val walletManager: WalletManager,
     private val yatAdapter: YatAdapter,
+    private val networkConnection: NetworkConnectionStateHandler,
 ) {
 
     lateinit var activity: CommonActivity<*, *>
@@ -311,7 +312,7 @@ class TariNavigator @Inject constructor(
     }
 
     private fun continueToAddNote(transactionData: TransactionData) {
-        if (EventBus.networkConnectionState.publishSubject.value != NetworkConnectionState.CONNECTED) {
+        if (!networkConnection.isNetworkConnected()) {
             showInternetConnectionErrorDialog(this.activity)
             return
         }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
@@ -63,12 +63,10 @@ import com.tari.android.wallet.R.dimen.add_note_gif_inner_margin
 import com.tari.android.wallet.R.dimen.add_note_slide_button_left_margin
 import com.tari.android.wallet.R.dimen.add_note_slide_button_width
 import com.tari.android.wallet.databinding.FragmentAddNoteBinding
-import com.tari.android.wallet.event.EventBus
 import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.model.TxNote
-import com.tari.android.wallet.network.NetworkConnectionState
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.common.domain.PaletteManager
 import com.tari.android.wallet.ui.common.gyphy.repository.GifItem
@@ -407,7 +405,7 @@ class AddNoteFragment : CommonFragment<FragmentAddNoteBinding, AddNoteViewModel>
 
     private fun onSlideAnimationEnd() {
         hideKeyboard()
-        if (EventBus.networkConnectionState.publishSubject.value != NetworkConnectionState.CONNECTED) {
+        if (!viewModel.isNetworkConnectionAvailable()) {
             ui.rootView.postDelayed(Constants.UI.keyboardHideWaitMs) {
                 restoreSlider()
                 ui.noteEditText.isEnabled = true

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteViewModel.kt
@@ -1,11 +1,16 @@
 package com.tari.android.wallet.ui.fragment.send.addNote
 
 import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.network.NetworkConnectionStateHandler
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.send.common.TransactionData
+import javax.inject.Inject
 
 class AddNoteViewModel : CommonViewModel() {
+
+    @Inject
+    lateinit var networkConnection: NetworkConnectionStateHandler
 
     init {
         component.inject(this)
@@ -18,4 +23,6 @@ class AddNoteViewModel : CommonViewModel() {
     fun continueToFinalizeSendTx(newData: TransactionData) {
         tariNavigator.navigate(Navigation.AddAmountNavigation.ContinueToFinalizing(newData))
     }
+
+    fun isNetworkConnectionAvailable(): Boolean = networkConnection.isNetworkConnected()
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
@@ -6,13 +6,13 @@ import com.tari.android.wallet.R
 import com.tari.android.wallet.application.baseNodes.BaseNodesManager
 import com.tari.android.wallet.application.deeplinks.DeeplinkHandler
 import com.tari.android.wallet.data.sharedPrefs.baseNode.BaseNodeDto
-import com.tari.android.wallet.data.sharedPrefs.baseNode.BaseNodePrefRepository
-import com.tari.android.wallet.event.EventBus
+import com.tari.android.wallet.extension.collectFlow
+import com.tari.android.wallet.service.baseNode.BaseNodeStateHandler
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.recyclerView.CommonViewHolderItem
-import com.tari.android.wallet.ui.dialog.modular.SimpleDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.DialogArgs
 import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
+import com.tari.android.wallet.ui.dialog.modular.SimpleDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
@@ -28,10 +28,10 @@ import javax.inject.Inject
 class ChangeBaseNodeViewModel : CommonViewModel() {
 
     @Inject
-    lateinit var baseNodeSharedRepository: BaseNodePrefRepository
+    lateinit var baseNodesManager: BaseNodesManager
 
     @Inject
-    lateinit var baseNodesManager: BaseNodesManager
+    lateinit var baseNodeStateHandler: BaseNodeStateHandler
 
     @Inject
     lateinit var deeplinkHandler: DeeplinkHandler
@@ -45,7 +45,7 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
     init {
         component.inject(this)
 
-        EventBus.baseNodeState.subscribe(this) { loadList() }
+        collectFlow(baseNodeStateHandler.baseNodeState) { loadList() }
 
         loadList()
     }
@@ -77,9 +77,9 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
     }
 
     private fun loadList() {
-        val currentBaseNode = baseNodeSharedRepository.currentBaseNode
+        val currentBaseNode = baseNodesManager.currentBaseNode
         val items = mutableListOf<CommonViewHolderItem>()
-        items.addAll(baseNodeSharedRepository.userBaseNodes.map { BaseNodeViewHolderItem(it, currentBaseNode, this::deleteBaseNode) })
+        items.addAll(baseNodesManager.userBaseNodes.map { BaseNodeViewHolderItem(it, currentBaseNode, this::deleteBaseNode) })
         items.addAll(baseNodesManager.baseNodeList.map { BaseNodeViewHolderItem(it, currentBaseNode, this::deleteBaseNode) })
         _baseNodeList.postValue(items)
     }
@@ -150,5 +150,4 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
             )
         }
     }
-
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/themeSelector/ThemeSelectorViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/settings/themeSelector/ThemeSelectorViewModel.kt
@@ -1,12 +1,17 @@
 package com.tari.android.wallet.ui.fragment.settings.themeSelector
 
 import androidx.lifecycle.MutableLiveData
-import com.tari.android.wallet.event.EventBus
+import com.tari.android.wallet.extension.collectFlow
+import com.tari.android.wallet.service.baseNode.BaseNodeStateHandler
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
 import com.tari.android.wallet.ui.fragment.settings.themeSelector.adapter.ThemeViewHolderItem
+import javax.inject.Inject
 
 class ThemeSelectorViewModel : CommonViewModel() {
+
+    @Inject
+    lateinit var baseNodeStateHandler: BaseNodeStateHandler
 
     val themes: MutableLiveData<List<ThemeViewHolderItem>> = MutableLiveData()
 
@@ -15,7 +20,7 @@ class ThemeSelectorViewModel : CommonViewModel() {
     init {
         component.inject(this)
 
-        EventBus.baseNodeState.subscribe(this) { loadList() }
+        collectFlow(baseNodeStateHandler.baseNodeState) { loadList() }
 
         loadList()
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/tx/HomeFragment.kt
@@ -132,7 +132,6 @@ class HomeFragment : CommonFragment<FragmentHomeBinding, HomeFragmentViewModel>(
 
     override fun onDestroyView() {
         EventBus.unsubscribe(this)
-        EventBus.networkConnectionState.unsubscribe(this)
         super.onDestroyView()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutines_version = '1.8.0'
 
     // build & version
-    ext.buildNumber = 306
+    ext.buildNumber = 307
     ext.versionNumber = "0.27.1"
 
     // JNI libs


### PR DESCRIPTION
- Created handlers for the network connection state, base node state, and base node sync state instead of handling them by `EventBus`
- Fixed calling base node sync multiple times simultaneously 
- Don't save the base node state to shared prefs, refresh this value every start instead
- Fixed the call from FFI thread issue while calling the Wallet inside of a wallet callback block