### PR TITLE
feat: Paper Wallet – private key QR

### DIFF
--- a/app/src/main/cpp/jniSeedWords.cpp
+++ b/app/src/main/cpp/jniSeedWords.cpp
@@ -50,6 +50,24 @@ Java_com_tari_android_wallet_ffi_FFISeedWords_jniCreate(
 
 extern "C"
 JNIEXPORT void JNICALL
+Java_com_tari_android_wallet_ffi_FFISeedWords_jniFromBase58(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jstring jCypher,
+        jstring jPassphrase,
+        jobject error) {
+    ExecuteWithError(jEnv, error, [&](int *errorPointer) {
+        const char *pCypher = jEnv->GetStringUTFChars(jCypher, JNI_FALSE);
+        const char *pPassphrase = jEnv->GetStringUTFChars(jPassphrase, JNI_FALSE);
+        TariSeedWords *pSeedWords = seed_words_create_from_cipher(pCypher, pPassphrase, errorPointer);
+        jEnv->ReleaseStringUTFChars(jCypher, pCypher);
+        jEnv->ReleaseStringUTFChars(jPassphrase, pPassphrase);
+        SetPointerField(jEnv, jThis, reinterpret_cast<jlong>(pSeedWords));
+    });
+}
+
+extern "C"
+JNIEXPORT void JNICALL
 Java_com_tari_android_wallet_ffi_FFISeedWords_jniGetMnemonicWordListForLanguage(
         JNIEnv *jEnv,
         jobject jThis,

--- a/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkParser.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkParser.kt
@@ -25,7 +25,7 @@ class DeeplinkParser @Inject constructor(private val networkRepository: NetworkP
         }
 
         val command = uri.path.orEmpty().trimStart('/')
-        val parameters = if (command == DeepLink.Contacts.COMMAND_CONTACTS || command == DeepLink.PaperWallet.COMMAND_PAPER_WALLET) { // list params
+        val parameters = if (command == DeepLink.Contacts.COMMAND_CONTACTS) { // list params
             uri.query.orEmpty().split("&").associate {
                 val (key, value) = it.split("=")
                 key to value

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFISeedWords.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFISeedWords.kt
@@ -42,6 +42,7 @@ import com.tari.android.wallet.model.seedPhrase.SeedWordsWordPushResult
 class FFISeedWords() : FFIBase() {
 
     private external fun jniCreate()
+    private external fun jniFromBase58(cypher: String, passphrase: String, libError: FFIError)
     private external fun jniPushWord(word: String, libError: FFIError): Int
     private external fun jniGetLength(libError: FFIError): Int
     private external fun jniGetAt(index: Int, libError: FFIError): String
@@ -51,6 +52,10 @@ class FFISeedWords() : FFIBase() {
 
     init {
         jniCreate()
+    }
+
+    constructor(base58: Base58, passphrase: String) : this() {
+        runWithError { jniFromBase58(base58, passphrase, it) }
     }
 
     constructor(pointer: FFIPointer) : this() {

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialogArgs.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialogArgs.kt
@@ -17,5 +17,6 @@ data class ModularDialogArgs(
         const val DEEPLINK_ADD_CONTACTS = 605
         const val DEEPLINK_PAPER_WALLET = 606
         const val DEEPLINK_PAPER_WALLET_REMEMBER_TO_BACKUP = 606
+        const val DEEPLINK_PAPER_WALLET_ENTER_PASSPHRASE = 607
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,6 +584,11 @@
     <string name="restore_wallet_paper_wallet_remember_backup_body">Do you want to back up your current wallet before replacing it? If you don\’t back it up first, you will lose all the funds in your current wallet!</string>
     <string name="restore_wallet_paper_wallet_remember_backup_yes_button">Yes, back it up</string>
     <string name="restore_wallet_paper_wallet_remember_backup_no_button">No, just replace it</string>
+    <string name="restore_wallet_paper_wallet_enter_passphrase_title">Password</string>
+    <string name="restore_wallet_paper_wallet_enter_passphrase_body">Enter the paper wallet password</string>
+    <string name="restore_wallet_paper_wallet_enter_passphrase_hint">Password</string>
+    <string name="restore_wallet_paper_wallet_error_title">Incorrect password</string>
+    <string name="restore_wallet_paper_wallet_error_body">The password you entered is incorrect. Please try again.</string>
 
     <!-- Wallet recovery with seed phrase -->
     <string name="restore_from_seed_words_title">Restore With Seed Phrase</string>


### PR DESCRIPTION
Changed the format for paper wallet QR: 
- Parse a private key value
- Ask the user to enter the passphrase
- Create a list of seed words using private key and passphrase
- Show an error dialog if the passphrase is incorrect

<img src="https://github.com/user-attachments/assets/9b027e6f-3e88-4daf-906a-c0c2bc8432b9" width="350" /> <img src="https://github.com/user-attachments/assets/1549372c-f38d-477c-8574-782dcc438a24" width="350" />

