### PR TITLE
fix: No tx note from QR data

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkParser.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/deeplinks/DeeplinkParser.kt
@@ -13,12 +13,12 @@ import javax.inject.Singleton
 class DeeplinkParser @Inject constructor(private val networkRepository: NetworkPrefRepository) {
 
     fun parse(deepLink: String): DeepLink? {
-        val torBridges = getTorDeeplink(deepLink)
+        val torBridges = getTorDeeplink(deepLink.trim())
         if (torBridges.isNotEmpty()) {
             return DeepLink.TorBridges(torBridges)
         }
 
-        val uri = runCatching { Uri.parse(URLDecoder.decode(deepLink, "UTF-8")) }.getOrNull() ?: return null
+        val uri = runCatching { Uri.parse(URLDecoder.decode(deepLink.trim(), "UTF-8")) }.getOrNull() ?: return null
 
         if (!uri.authority.equals(networkRepository.currentNetwork.network.uriComponent)) {
             return null

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/home/navigation/TariNavigator.kt
@@ -289,11 +289,7 @@ class TariNavigator @Inject constructor(
             showInternetConnectionErrorDialog(this.activity)
             return
         }
-        val bundle = Bundle().apply {
-            putParcelable(PARAMETER_TRANSACTION, transactionData)
-            activity.intent.getStringExtra(PARAMETER_NOTE)?.let { putString(PARAMETER_NOTE, it) }
-        }
-        addFragment(AddNoteFragment(), bundle)
+        addFragment(AddNoteFragment.newInstance(transactionData))
     }
 
     private fun continueToFinalizeSendTx(transactionData: TransactionData) {
@@ -333,24 +329,16 @@ class TariNavigator @Inject constructor(
         walletManager.walletInstance?.getWalletAddress() // TODO move all the logic beside of navigation from here
         val address = TariWalletAddress.fromBase58(deeplink.walletAddress)
         val contact = (activity as HomeActivity).viewModel.contactsRepository.getContactByAddress(address)
-        val bundle = Bundle().apply {
-            putParcelable(PARAMETER_CONTACT, contact)
-            putParcelable(PARAMETER_AMOUNT, deeplink.amount)
-        }
 
-        addFragment(AddAmountFragment(), bundle)
+        addFragment(AddAmountFragment.newInstance(contact, deeplink.amount, deeplink.note))
     }
 
     private fun sendToUser(recipientUser: ContactDto, amount: MicroTari? = null) {
-        val bundle = Bundle().apply {
-            putParcelable(PARAMETER_CONTACT, recipientUser)
-            val innerAmount = (activity.intent.getDoubleExtra(PARAMETER_AMOUNT, Double.MIN_VALUE))
-            val tariAmount = amount ?: if (innerAmount != Double.MIN_VALUE) MicroTari(BigInteger.valueOf(innerAmount.toLong())) else null
-            tariAmount?.let { putParcelable(PARAMETER_AMOUNT, it) }
-            activity.intent.parcelable<ContactDto>(PARAMETER_CONTACT)?.let { putParcelable(PARAMETER_CONTACT, it) }
-        }
+        val contact = activity.intent.parcelable<ContactDto>(PARAMETER_CONTACT) ?: recipientUser
+        val innerAmount = activity.intent.getDoubleExtra(PARAMETER_AMOUNT, Double.MIN_VALUE)
+        val tariAmount = amount ?: MicroTari(BigInteger.valueOf(innerAmount.toLong())).takeIf { innerAmount != Double.MIN_VALUE }
 
-        addFragment(AddAmountFragment(), bundle)
+        addFragment(AddAmountFragment.newInstance(contact, tariAmount))
     }
 
     private fun toChatDetail(walletAddress: TariWalletAddress, isNew: Boolean) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
@@ -53,6 +53,7 @@ import com.tari.android.wallet.R.string.error_fee_more_than_amount_description
 import com.tari.android.wallet.R.string.error_fee_more_than_amount_title
 import com.tari.android.wallet.R.string.tx_detail_fee_tooltip_desc
 import com.tari.android.wallet.R.string.tx_detail_fee_tooltip_transaction_fee
+import com.tari.android.wallet.application.walletManager.WalletFileUtil
 import com.tari.android.wallet.databinding.FragmentAddAmountBinding
 import com.tari.android.wallet.extension.getWithError
 import com.tari.android.wallet.extension.observe
@@ -75,13 +76,13 @@ import com.tari.android.wallet.ui.fragment.contactBook.data.contacts.ContactDto
 import com.tari.android.wallet.ui.fragment.home.navigation.Navigation
 import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_AMOUNT
 import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_CONTACT
+import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_NOTE
 import com.tari.android.wallet.ui.fragment.send.addAmount.feeModule.NetworkSpeed
 import com.tari.android.wallet.ui.fragment.send.addAmount.keyboard.KeyboardController
 import com.tari.android.wallet.ui.fragment.send.amountView.AmountStyle
 import com.tari.android.wallet.ui.fragment.send.common.TransactionData
 import com.tari.android.wallet.util.Constants
 import com.tari.android.wallet.util.DebugConfig
-import com.tari.android.wallet.application.walletManager.WalletFileUtil
 import com.tari.android.wallet.util.addressFirstEmojis
 import com.tari.android.wallet.util.addressLastEmojis
 import com.tari.android.wallet.util.addressPrefixEmojis
@@ -94,6 +95,7 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
      * Recipient is either an emoji id or a user from contacts or recent txs.
      */
     private lateinit var contactDto: ContactDto
+    private lateinit var note: String
 
     private var keyboardController: KeyboardController = KeyboardController()
 
@@ -128,6 +130,7 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
         val amount = arguments?.parcelable<MicroTari>(PARAMETER_AMOUNT)
         keyboardController.setup(requireContext(), AmountCheckRunnable(), ui.numpad, ui.amount, amount?.tariValue?.toDouble() ?: Double.MIN_VALUE)
         contactDto = arguments?.parcelable<ContactDto>(PARAMETER_CONTACT)!!
+        note = arguments?.getString(PARAMETER_NOTE).orEmpty()
         // hide tx fee
         ui.txFeeContainerView.invisible()
 
@@ -257,7 +260,7 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
         val transactionData = TransactionData(
             recipientContact = contactDto,
             amount = keyboardController.currentAmount,
-            note = null,
+            note = note,
             feePerGram = viewModel.selectedFeeData!!.feePerGram,
             isOneSidePayment = isOneSidePayment,
         )
@@ -376,6 +379,16 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
 
         private fun hideContinueButton() = with(ui) {
             continueButton.isEnabled = false
+        }
+    }
+
+    companion object {
+        fun newInstance(contact: ContactDto, amount: MicroTari?, note: String = "") = AddAmountFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(PARAMETER_CONTACT, contact)
+                putParcelable(PARAMETER_AMOUNT, amount)
+                putString(PARAMETER_NOTE, note)
+            }
         }
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addNote/AddNoteFragment.kt
@@ -83,7 +83,6 @@ import com.tari.android.wallet.ui.extension.showInternetConnectionErrorDialog
 import com.tari.android.wallet.ui.extension.temporarilyDisableClick
 import com.tari.android.wallet.ui.extension.visible
 import com.tari.android.wallet.ui.fragment.contactBook.data.contacts.ContactDto
-import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_NOTE
 import com.tari.android.wallet.ui.fragment.home.navigation.TariNavigator.Companion.PARAMETER_TRANSACTION
 import com.tari.android.wallet.ui.fragment.send.addNote.gif.ChooseGIFDialogFragment
 import com.tari.android.wallet.ui.fragment.send.addNote.gif.GifContainer
@@ -207,8 +206,7 @@ class AddNoteFragment : CommonFragment<FragmentAddNoteBinding, AddNoteViewModel>
         amount = transactionData.amount!!
         isOneSidePayment = transactionData.isOneSidePayment
         if (savedInstanceState == null) {
-            requireArguments().getString(PARAMETER_NOTE)
-                ?.let { ui.noteEditText.setText(it) }
+            ui.noteEditText.setText(transactionData.note.orEmpty())
         }
     }
 
@@ -448,6 +446,12 @@ class AddNoteFragment : CommonFragment<FragmentAddNoteBinding, AddNoteViewModel>
             start()
         }
     }
+
+    companion object {
+        fun newInstance(transactionData: TransactionData) = AddNoteFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(PARAMETER_TRANSACTION, transactionData)
+            }
+        }
+    }
 }
-
-

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/common/TransactionData.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/common/TransactionData.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 data class TransactionData(
     val recipientContact: ContactDto?,
     val amount: MicroTari?,
-    private val note: String?,
+    val note: String?,
     val feePerGram: MicroTari?,
     val isOneSidePayment: Boolean,
 ) : Parcelable {


### PR DESCRIPTION
Use the note value from the QR code deeplink for sending a tx as a prefilled value