### PR TITLE
feat: Disable interactive payments for OSP QR

### DIFF
--- a/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
+++ b/app/src/main/aidl/com/tari/android/wallet/service/TariWalletService.aidl
@@ -39,8 +39,6 @@ interface TariWalletService {
 
     BalanceInfo getBalanceInfo(out WalletError error);
 
-    MicroTari estimateTxFee(in MicroTari amount, out WalletError error, in MicroTari feePerGram);
-
     List<TariContact> getContacts(out WalletError error);
 
     List<CompletedTx> getCompletedTxs(out WalletError error);

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -38,6 +38,7 @@ import com.tari.android.wallet.data.sharedPrefs.network.TariNetwork
 import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.model.CancelledTx
 import com.tari.android.wallet.model.CompletedTx
+import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.PendingInboundTx
 import com.tari.android.wallet.model.PendingOutboundTx
 import com.tari.android.wallet.model.PublicKey
@@ -47,6 +48,7 @@ import com.tari.android.wallet.model.TariVector
 import com.tari.android.wallet.model.TariWalletAddress
 import com.tari.android.wallet.model.Tx
 import com.tari.android.wallet.recovery.WalletRestorationState
+import com.tari.android.wallet.util.Constants
 import java.math.BigInteger
 
 /**
@@ -271,8 +273,21 @@ class FFIWallet(
 
     fun cancelPendingTx(id: BigInteger): Boolean = runWithError { jniCancelPendingTx(id.toString(), it) }
 
-    fun estimateTxFee(amount: BigInteger, gramFee: BigInteger, kernelCount: BigInteger, outputCount: BigInteger): BigInteger = runWithError {
-        BigInteger(1, jniEstimateTxFee(amount.toString(), gramFee.toString(), kernelCount.toString(), outputCount.toString(), it))
+    fun estimateTxFee(amount: MicroTari, feePerGram: MicroTari?): MicroTari = runWithError { error ->
+        val defaultKernelCount = BigInteger("1")
+        val defaultOutputCount = BigInteger("2")
+        val gram = feePerGram?.value ?: Constants.Wallet.DEFAULT_FEE_PER_GRAM.value
+        MicroTari(
+            BigInteger(
+                1, jniEstimateTxFee(
+                    amount = amount.value.toString(),
+                    gramFee = gram.toString(),
+                    kernelCount = defaultKernelCount.toString(),
+                    outputCount = defaultOutputCount.toString(),
+                    libError = error,
+                )
+            )
+        )
     }
 
     fun sendTx(

--- a/app/src/main/java/com/tari/android/wallet/model/TariWalletAddress.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariWalletAddress.kt
@@ -84,6 +84,12 @@ data class TariWalletAddress(
     val coreKeyEmojis: EmojiId
         get() = viewKeyEmojis + spendKeyEmojis + checksumEmoji
 
+    val oneSided: Boolean
+        get() = features.contains(Feature.ONE_SIDED)
+
+    val interactive: Boolean
+        get() = features.contains(Feature.INTERACTIVE)
+
     fun isUnknownUser(): Boolean = unknownAddress
 
     override fun equals(other: Any?): Boolean = (other is TariWalletAddress) && uniqueIdentifier == other.uniqueIdentifier

--- a/app/src/main/java/com/tari/android/wallet/service/service/TariWalletServiceStubImpl.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/TariWalletServiceStubImpl.kt
@@ -52,13 +52,6 @@ class TariWalletServiceStubImpl(
 
     override fun getBalanceInfo(error: WalletError): BalanceInfo? = runMapping(error) { wallet.getBalance() }
 
-    override fun estimateTxFee(amount: MicroTari, error: WalletError, feePerGram: MicroTari?): MicroTari? = runMapping(error) {
-        val defaultKernelCount = BigInteger("1")
-        val defaultOutputCount = BigInteger("2")
-        val gram = feePerGram?.value ?: Constants.Wallet.DEFAULT_FEE_PER_GRAM.value
-        MicroTari(wallet.estimateTxFee(amount.value, gram, defaultKernelCount, defaultOutputCount))
-    }
-
     /**
      * Get all contacts.
      */

--- a/app/src/main/java/com/tari/android/wallet/service/service/TariWalletServiceStubProxy.kt
+++ b/app/src/main/java/com/tari/android/wallet/service/service/TariWalletServiceStubProxy.kt
@@ -28,9 +28,6 @@ class TariWalletServiceStubProxy : TariWalletService.Stub() {
 
     override fun getBalanceInfo(error: WalletError): BalanceInfo? = stub?.getBalanceInfo(error)
 
-    override fun estimateTxFee(amount: MicroTari, error: WalletError, feePerGram: MicroTari?): MicroTari? =
-        stub?.estimateTxFee(amount, error, feePerGram)
-
     override fun getContacts(error: WalletError): List<TariContact>? = stub?.getContacts(error)
 
     override fun getCompletedTxs(error: WalletError): List<CompletedTx>? = stub?.getCompletedTxs(error)

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
@@ -55,8 +55,8 @@ import com.tari.android.wallet.R.string.tx_detail_fee_tooltip_desc
 import com.tari.android.wallet.R.string.tx_detail_fee_tooltip_transaction_fee
 import com.tari.android.wallet.application.walletManager.WalletFileUtil
 import com.tari.android.wallet.databinding.FragmentAddAmountBinding
+import com.tari.android.wallet.extension.collectFlow
 import com.tari.android.wallet.extension.getWithError
-import com.tari.android.wallet.extension.observe
 import com.tari.android.wallet.model.BalanceInfo
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.model.TariWalletAddress
@@ -67,7 +67,6 @@ import com.tari.android.wallet.ui.dialog.modular.SimpleDialogArgs
 import com.tari.android.wallet.ui.dialog.tooltipDialog.TooltipDialogArgs
 import com.tari.android.wallet.ui.extension.gone
 import com.tari.android.wallet.ui.extension.invisible
-import com.tari.android.wallet.ui.extension.parcelable
 import com.tari.android.wallet.ui.extension.setVisible
 import com.tari.android.wallet.ui.extension.string
 import com.tari.android.wallet.ui.extension.temporarilyDisableClick
@@ -119,18 +118,20 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
     }
 
     private fun subscribeVM() = with(viewModel) {
-        observe(isOneSidePaymentEnabled) { ui.oneSidePaymentSwitchView.isChecked = it }
-
-        observe(serviceConnected) { setupUI() }
-
-        observe(feePerGrams) { showOrHideCustomFeeDialog(it) }
+        collectFlow(uiState) { uiState ->
+            ui.oneSidePaymentSwitchView.isChecked = uiState.isOneSidedPaymentEnabled || uiState.isOneSidedPaymentForced
+            ui.oneSidePaymentSwitchView.isEnabled = !uiState.isOneSidedPaymentForced
+            showOrHideCustomFeeDialog(uiState.feePerGrams)
+            if (uiState.serviceConnected) {
+                setupUI(uiState)
+            }
+        }
     }
 
-    private fun setupUI() {
-        val amount = arguments?.parcelable<MicroTari>(PARAMETER_AMOUNT)
-        keyboardController.setup(requireContext(), AmountCheckRunnable(), ui.numpad, ui.amount, amount?.tariValue?.toDouble() ?: Double.MIN_VALUE)
-        contactDto = arguments?.parcelable<ContactDto>(PARAMETER_CONTACT)!!
-        note = arguments?.getString(PARAMETER_NOTE).orEmpty()
+    private fun setupUI(uiState: AddAmountModel.UiState) {
+        keyboardController.setup(requireContext(), AmountCheckRunnable(), ui.numpad, ui.amount, uiState.amount)
+        contactDto = uiState.contactDto
+        note = uiState.note
         // hide tx fee
         ui.txFeeContainerView.invisible()
 
@@ -160,16 +161,22 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
         ui.oneSidePaymentSwitchView.setOnClickListener { viewModel.toggleOneSidePayment() }
     }
 
-    private fun showOrHideCustomFeeDialog(feePerGram: FeePerGramOptions) {
-        ui.feeCalculating.setVisible(false)
-        ui.networkTrafficText.setVisible(true)
-        ui.modifyButton.setVisible(feePerGram.networkSpeed != NetworkSpeed.Slow, View.INVISIBLE)
-        val iconId = when (feePerGram.networkSpeed) {
-            NetworkSpeed.Slow -> R.drawable.vector_network_slow
-            NetworkSpeed.Medium -> R.drawable.vector_network_medium
-            NetworkSpeed.Fast -> R.drawable.vector_network_fast
+    private fun showOrHideCustomFeeDialog(feePerGram: FeePerGramOptions?) {
+        if (feePerGram == null) {
+            ui.feeCalculating.visible()
+            ui.networkTrafficText.gone()
+            ui.modifyButton.gone()
+        } else {
+            ui.feeCalculating.gone()
+            ui.networkTrafficText.visible()
+            ui.modifyButton.setVisible(feePerGram.networkSpeed != NetworkSpeed.Slow, View.INVISIBLE)
+            val iconId = when (feePerGram.networkSpeed) {
+                NetworkSpeed.Slow -> R.drawable.vector_network_slow
+                NetworkSpeed.Medium -> R.drawable.vector_network_medium
+                NetworkSpeed.Fast -> R.drawable.vector_network_fast
+            }
+            ui.networkTrafficIcon.setImageDrawable(ContextCompat.getDrawable(requireContext(), iconId))
         }
-        ui.networkTrafficIcon.setImageDrawable(ContextCompat.getDrawable(requireContext(), iconId))
     }
 
     private fun displayAlias(alias: String) {

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountFragment.kt
@@ -122,8 +122,13 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
             ui.oneSidePaymentSwitchView.isChecked = uiState.isOneSidedPaymentEnabled || uiState.isOneSidedPaymentForced
             ui.oneSidePaymentSwitchView.isEnabled = !uiState.isOneSidedPaymentForced
             showOrHideCustomFeeDialog(uiState.feePerGrams)
-            if (uiState.serviceConnected) {
-                setupUI(uiState)
+        }
+
+        collectFlow(effect) { effect ->
+            when (effect) {
+                is AddAmountModel.Effect.OnServiceConnected -> {
+                    setupUI(effect.uiState)
+                }
             }
         }
     }
@@ -281,8 +286,9 @@ class AddAmountFragment : CommonFragment<FragmentAddAmountBinding, AddAmountView
     private inner class AmountCheckRunnable : Runnable {
 
         override fun run() {
+            // TODO error handling should be in the view model
             val error = WalletError()
-            viewModel.calculateFee(keyboardController.currentAmount, error)
+            viewModel.calculateFee(keyboardController.currentAmount)
             if (error != WalletError.NoError) {
                 showErrorState(error)
                 return

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountModel.kt
@@ -1,0 +1,16 @@
+package com.tari.android.wallet.ui.fragment.send.addAmount
+
+import com.tari.android.wallet.ui.fragment.contactBook.data.contacts.ContactDto
+
+object AddAmountModel {
+    data class UiState(
+        val isOneSidedPaymentEnabled: Boolean,
+        val isOneSidedPaymentForced: Boolean = false,
+        val feePerGrams: FeePerGramOptions? = null,
+        val serviceConnected: Boolean = false,
+
+        val amount: Double,
+        val contactDto: ContactDto,
+        val note: String,
+    )
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/AddAmountModel.kt
@@ -7,10 +7,13 @@ object AddAmountModel {
         val isOneSidedPaymentEnabled: Boolean,
         val isOneSidedPaymentForced: Boolean = false,
         val feePerGrams: FeePerGramOptions? = null,
-        val serviceConnected: Boolean = false,
 
         val amount: Double,
         val contactDto: ContactDto,
         val note: String,
     )
+
+    sealed class Effect {
+        data class OnServiceConnected(val uiState: UiState) : Effect()
+    }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/FeePerGramOptions.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/FeePerGramOptions.kt
@@ -1,7 +1,36 @@
 package com.tari.android.wallet.ui.fragment.send.addAmount
 
+import com.tari.android.wallet.ffi.FFIFeePerGramStats
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.ui.fragment.send.addAmount.feeModule.NetworkSpeed
+import kotlin.math.min
 
-data class FeePerGramOptions(val networkSpeed: NetworkSpeed, val slow: MicroTari, val medium: MicroTari, val fast: MicroTari)
+data class FeePerGramOptions(val networkSpeed: NetworkSpeed, val slow: MicroTari, val medium: MicroTari, val fast: MicroTari) {
 
+    constructor(ffiFeePerGramStats: FFIFeePerGramStats) : this(
+        networkSpeed = when (min(ffiFeePerGramStats.getLength(), 3)) {
+            1 -> NetworkSpeed.Slow
+            2 -> NetworkSpeed.Medium
+            3 -> NetworkSpeed.Fast
+            else -> throw Exception("Unexpected block count")
+        },
+        slow = when (min(ffiFeePerGramStats.getLength(), 3)) {
+            1 -> ffiFeePerGramStats.getAt(0).getMin()
+            2 -> ffiFeePerGramStats.getAt(1).getAverage()
+            3 -> ffiFeePerGramStats.getAt(2).getAverage()
+            else -> throw Exception("Unexpected block count")
+        }.let { MicroTari(it) },
+        medium = when (min(ffiFeePerGramStats.getLength(), 3)) {
+            1 -> ffiFeePerGramStats.getAt(0).getAverage()
+            2 -> ffiFeePerGramStats.getAt(0).getMin()
+            3 -> ffiFeePerGramStats.getAt(1).getAverage()
+            else -> throw Exception("Unexpected block count")
+        }.let { MicroTari(it) },
+        fast = when (min(ffiFeePerGramStats.getLength(), 3)) {
+            1 -> ffiFeePerGramStats.getAt(0).getMax()
+            2 -> ffiFeePerGramStats.getAt(0).getMax()
+            3 -> ffiFeePerGramStats.getAt(0).getMax()
+            else -> throw Exception("Unexpected block count")
+        }.let { MicroTari(it) },
+    )
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/FeePerGramOptions.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/FeePerGramOptions.kt
@@ -3,5 +3,5 @@ package com.tari.android.wallet.ui.fragment.send.addAmount
 import com.tari.android.wallet.model.MicroTari
 import com.tari.android.wallet.ui.fragment.send.addAmount.feeModule.NetworkSpeed
 
-class FeePerGramOptions(val networkSpeed: NetworkSpeed, val slow: MicroTari, val medium: MicroTari, val fast: MicroTari)
+data class FeePerGramOptions(val networkSpeed: NetworkSpeed, val slow: MicroTari, val medium: MicroTari, val fast: MicroTari)
 

--- a/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/keyboard/KeyboardController.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/fragment/send/addAmount/keyboard/KeyboardController.kt
@@ -98,6 +98,7 @@ class KeyboardController {
         // setup amount validation
         amountCheckRunnable.run()
         // add first digit to the element list
+        elements.clear()
         elements.add(Pair("0", amountInputBinding.amountElement0TextView))
 
         // input start amount

--- a/app/src/main/res/drawable/tari_switch_compat_selector_track.xml
+++ b/app/src/main/res/drawable/tari_switch_compat_selector_track.xml
@@ -1,5 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape>
+            <solid android:color="?attr/palette_neutral_inactive" />
+            <corners android:radius="15dp" />
+            <size android:height="30dp" />
+        </shape>
+    </item>
     <item android:state_checked="true">
         <shape>
             <solid android:color="?attr/palette_system_green" />
@@ -7,7 +13,7 @@
             <size android:height="30dp" />
         </shape>
     </item>
-    <item >
+    <item>
         <shape>
             <solid android:color="?attr/palette_neutral_inactive" />
             <corners android:radius="15dp" />

--- a/app/src/main/res/layout/fragment_add_amount.xml
+++ b/app/src/main/res/layout/fragment_add_amount.xml
@@ -282,6 +282,7 @@
                 android:layout_height="24dp"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="16dp"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
                 android:src="@drawable/vector_help_icon_24dp" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_add_amount.xml
+++ b/app/src/main/res/layout/fragment_add_amount.xml
@@ -132,14 +132,16 @@
                 android:id="@+id/amount"
                 layout="@layout/view_input_amount" />
 
-            <androidx.appcompat.widget.LinearLayoutCompat
+            <LinearLayout
                 android:id="@+id/fee_calculating"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentBottom="true"
                 android:layout_centerHorizontal="true"
                 android:layout_marginBottom="12dp"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
 
                 <com.tari.android.wallet.ui.component.tari.TariProgressBar
                     android:layout_width="24dp"
@@ -155,8 +157,7 @@
                     android:textColor="#A9AFC4"
                     android:textSize="@dimen/add_amount_tx_fee_text_size"
                     app:customFont="heavy" />
-
-            </androidx.appcompat.widget.LinearLayoutCompat>
+            </LinearLayout>
 
             <RelativeLayout
                 android:id="@+id/tx_fee_container_view"
@@ -175,7 +176,9 @@
                     android:layout_height="22dp"
                     android:layout_above="@+id/fee_container"
                     android:layout_centerHorizontal="true"
-                    android:orientation="horizontal">
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    tools:visibility="visible">
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/network_traffic_icon"

--- a/app/src/main/res/layout/view_numpad.xml
+++ b/app/src/main/res/layout/view_numpad.xml
@@ -20,6 +20,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_1"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -31,6 +32,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_2"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -42,6 +44,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_3"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -60,6 +63,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_4"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -71,6 +75,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_5"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -82,6 +87,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_6"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -100,6 +106,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_7"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -111,6 +118,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_8"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -122,6 +130,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_9"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -140,6 +149,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_decimal_separator_bullet_char"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
@@ -152,6 +162,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:padding="8dp"
             android:src="@drawable/vector_fingerprint"
             android:tint="?attr/palette_brand_purple"
@@ -165,17 +176,25 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
+            android:foreground="?attr/selectableItemBackground"
             android:text="@string/digit_0"
             android:textColor="?attr/palette_text_heading"
             android:textSize="@dimen/add_amount_keypad_text_size"
             app:customFont="heavy" />
         <!-- delete -->
-        <com.tari.android.wallet.ui.component.tari.TariIconView
+        <FrameLayout
             android:id="@+id/delete_button"
             android:layout_width="0dp"
-            android:layout_height="16dp"
+            android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
             android:layout_weight="1"
-            android:src="@drawable/vector_delete_button" />
+            android:foreground="?attr/selectableItemBackground">
+
+            <com.tari.android.wallet.ui.component.tari.TariIconView
+                android:layout_width="wrap_content"
+                android:layout_height="16dp"
+                android:layout_gravity="center"
+                android:src="@drawable/vector_delete_button" />
+        </FrameLayout>
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
- Disabled the OSP switcher on the Add Amount screen if there is an address which is one-sided only
- Added touch event animations for the Numpad
- Moved the fee calculation logic from `WalletService` to `FFIWallet`
- Fixed improper progress state while fee is being calculated

<img src="https://github.com/user-attachments/assets/fcde61f1-f766-476a-bf5d-88f30af22e40" width="350" />
