### PR TITLE
fix: Empty note on Tx Detail

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/model/Tx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/Tx.kt
@@ -62,5 +62,5 @@ abstract class Tx(
     val isCoinbase
         get() = status.isCoinbase()
 
-    override fun toString() = "Tx(id=$id, direction=$direction, amount=$amount, timestamp=$timestamp, message='$message', user=$tariContact)"
+    override fun toString() = "Tx(id=$id, direction=$direction, amount=$amount, timestamp=$timestamp, message='$message', paymentId='$paymentId', status=$status, tariContact=$tariContact)"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/TxNote.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TxNote.kt
@@ -64,7 +64,8 @@ class TxNote(val message: String?, val gifUrl: String?) {
 
     companion object {
         fun fromTx(tx: Tx, assetsDomain: String = "giphy.com", protocol: String = "https://"): TxNote {
-            val note = if (tx.isOneSided) tx.paymentId else tx.message
+            // The paymentId is a note value for one-sided txs, and message for interactive. But we can't properly check if a tx is OSP
+            val note = tx.paymentId.takeIf { it.isNotBlank() } ?: tx.message
             val lines = note.split(Regex(" "))
             return if (Regex("$protocol$assetsDomain.*").matches(lines.last())) TxNote(
                 message = lines.take(lines.size - 1).filter(String::isNotEmpty)


### PR DESCRIPTION
Fixed empty note on the Tx detail screen

![image](https://github.com/user-attachments/assets/36ff7b6f-ba3d-4282-aaf8-a01bc0318a39)
