### PR TITLE
fix: NoSuchMethodError on start wallet

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,5 @@
 
 -keep class **Fragment** { *; }
 -keep class **ViewModel** { *; }
+
+-keep class com.tari.android.wallet.application.walletManager.WalletCallbackListener { *; }

--- a/app/src/main/java/com/tari/android/wallet/application/walletManager/WalletCallbackListener.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/walletManager/WalletCallbackListener.kt
@@ -24,6 +24,8 @@ import javax.inject.Singleton
 /**
  * Wallet callback listener. It's needed because of FFI specific callback handling.
  * We support multiple wallet instances, but from the FFI side, we can only have one static callback listener.
+ *
+ * !! Should be added to proguard rules since method names are used in FFI callbacks. !!
  */
 @Singleton
 class WalletCallbackListener @Inject constructor() {


### PR DESCRIPTION
Added `WalletCallbackListener` to ProGuard rules