### PR TITLE
feat: Keep screen awake during sync

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/CorePrefRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/CorePrefRepository.kt
@@ -88,6 +88,7 @@ class CorePrefRepository @Inject constructor(
         const val ONBOARDING_DISPLAYED_AT_HOME = "tari_wallet_onboarding_displayed_at_home"
         const val NEED_TO_SHOW_RECOVERY_SUCCESS_DIALOG = "NEED_TO_SHOW_RECOVERY_SUCCESS_DIALOG"
         const val IS_DATA_CLEARED = "tari_is_data_cleared"
+        const val KEEP_SCREEN_AWAKE_WHEN_RESTORE = "KEEP_SCREEN_AWAKE_WHEN_RESTORE"
     }
 
     var walletAddressBase58: Base58? by SharedPrefStringDelegate(sharedPrefs, this, formatKey(Key.WALLET_ADDRESS_BASE58))
@@ -124,6 +125,13 @@ class CorePrefRepository @Inject constructor(
     )
 
     var isDataCleared: Boolean by SharedPrefBooleanDelegate(sharedPrefs, this, formatKey(Key.IS_DATA_CLEARED), true)
+
+    var keepScreenAwakeWhenRestore: Boolean by SharedPrefBooleanDelegate(
+        prefs = sharedPrefs,
+        commonRepository = this,
+        name = formatKey(Key.KEEP_SCREEN_AWAKE_WHEN_RESTORE),
+        defValue = true,
+    )
 
     val walletAddress: TariWalletAddress
         get() = walletAddressBase58?.let { TariWalletAddress.fromBase58(it) } ?: error("Wallet address is not set to shared preferences")

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/restore/walletRestoring/WalletRestoringFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/restore/walletRestoring/WalletRestoringFragment.kt
@@ -36,9 +36,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.databinding.FragmentWalletRestoringBinding
 import com.tari.android.wallet.ui.common.CommonXmlFragment
+import com.tari.android.wallet.ui.component.loadingSwitch.TariLoadingSwitchState
 import com.tari.android.wallet.util.extension.collectFlow
 
 class WalletRestoringFragment : CommonXmlFragment<FragmentWalletRestoringBinding, WalletRestoringViewModel>() {
@@ -61,6 +63,16 @@ class WalletRestoringFragment : CommonXmlFragment<FragmentWalletRestoringBinding
 
     private fun subscribeUI() = with(viewModel) {
         collectFlow(recoveryState) { processRecoveryState(it) }
+        collectFlow(keepScreenAwake) { keep ->
+            ui.awakeSwitchView.setState(TariLoadingSwitchState(isChecked = keep))
+
+            if (keep) {
+                requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+        ui.awakeSwitchView.setOnCheckedChangeListener { toggleKeepScreenAwake(it) }
     }
 
     private fun processRecoveryState(state: WalletRestoringViewModel.RestorationState) {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/restore/walletRestoring/WalletRestoringViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/restore/walletRestoring/WalletRestoringViewModel.kt
@@ -42,6 +42,9 @@ class WalletRestoringViewModel : CommonViewModel() {
     private val _recoveryState = MutableStateFlow<RestorationState>(RestorationState.ConnectingToBaseNode(resourceManager))
     val recoveryState = _recoveryState.asStateFlow()
 
+    private val _keepScreenAwake = MutableStateFlow(sharedPrefsRepository.keepScreenAwakeWhenRestore)
+    val keepScreenAwake = _keepScreenAwake.asStateFlow()
+
     init {
         component.inject(this)
     }
@@ -163,6 +166,11 @@ class WalletRestoringViewModel : CommonViewModel() {
     private fun cancelRecovery() {
         walletManager.deleteWallet()
         tariNavigator.navigate(Navigation.SplashScreen())
+    }
+
+    fun toggleKeepScreenAwake(checked: Boolean) {
+        sharedPrefsRepository.keepScreenAwakeWhenRestore = checked
+        _keepScreenAwake.value = checked
     }
 
     sealed class RestorationError(title: String, message: String, dismissAction: () -> Unit) {

--- a/app/src/main/res/layout/fragment_wallet_restoring.xml
+++ b/app/src/main/res/layout/fragment_wallet_restoring.xml
@@ -1,96 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.tari.android.wallet.ui.component.tari.background.obsolete.TariPrimaryBackgroundConstraint xmlns:android="http://schemas.android.com/apk/res/android"
+<com.tari.android.wallet.ui.component.tari.background.TariSecondaryBackground xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:fitsSystemWindows="true"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
-    <androidx.appcompat.widget.AppCompatImageButton
-        android:id="@+id/icon_view"
-        android:layout_width="52dp"
-        android:layout_height="52dp"
-        android:layout_marginBottom="38dp"
-        android:background="@drawable/vector_send_button_back"
-        android:elevation="10dp"
-        android:src="@drawable/tari_splash_gem_small"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.4" />
-
-    <com.tari.android.wallet.ui.component.tari.TariTextView
-        android:id="@+id/label_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
-        android:lineSpacingMultiplier="1.5"
-        android:text="@string/back_up_wallet_restoring_wallet_label"
-        android:textColor="?attr/palette_text_heading"
-        android:textSize="18sp"
-        app:customFont="light"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/icon_view" />
-
-    <com.tari.android.wallet.ui.component.tari.TariTextView
-        android:id="@+id/description_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="25dp"
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
         android:gravity="center"
-        android:lineSpacingMultiplier="1.5"
-        android:text="@string/back_up_wallet_restoring_wallet_label_description"
-        android:textColor="?attr/palette_text_body"
-        app:customFont="medium"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/label_view" />
+        android:orientation="vertical">
 
-    <com.tari.android.wallet.ui.component.tari.TariTextView
-        android:id="@+id/status_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="12dp"
-        android:gravity="center"
-        android:lineSpacingMultiplier="1.5"
-        android:textColor="?attr/palette_text_body"
-        app:customFont="medium"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/description_view"
-        tools:text="Waiting for connection" />
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/icon_view"
+            android:layout_width="52dp"
+            android:layout_height="52dp"
+            android:layout_marginTop="138dp"
+            android:layout_marginBottom="38dp"
+            android:background="@drawable/vector_send_button_back"
+            android:elevation="10dp"
+            android:src="@drawable/tari_splash_gem_small" />
 
-    <com.tari.android.wallet.ui.component.tari.TariTextView
-        android:id="@+id/progress_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="5dp"
-        android:gravity="center"
-        android:textColor="?attr/palette_text_body"
-        android:textSize="18sp"
-        app:customFont="light"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/status_label"
-        tools:text="Attempts 5 out of 10" />
+        <com.tari.android.wallet.ui.component.tari.TariTextView
+            android:id="@+id/label_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:lineSpacingMultiplier="1.5"
+            android:text="@string/back_up_wallet_restoring_wallet_label"
+            android:textColor="?attr/palette_text_heading"
+            android:textSize="18sp"
+            app:customFont="light" />
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/progress_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="30dp"
-        android:lineSpacingMultiplier="1.5"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:lottie_autoPlay="true"
-        app:lottie_enableMergePathsForKitKatAndAbove="true"
-        app:lottie_loop="true"
-        app:lottie_rawRes="@raw/onboarding_bottom_spinner"
-        app:lottie_renderMode="automatic" />
+        <com.tari.android.wallet.ui.component.tari.TariTextView
+            android:id="@+id/description_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25dp"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.5"
+            android:text="@string/back_up_wallet_restoring_wallet_label_description"
+            android:textColor="?attr/palette_text_body"
+            app:customFont="medium" />
 
-</com.tari.android.wallet.ui.component.tari.background.obsolete.TariPrimaryBackgroundConstraint>
+        <com.tari.android.wallet.ui.component.tari.TariTextView
+            android:id="@+id/status_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.5"
+            android:textColor="?attr/palette_text_body"
+            app:customFont="medium"
+            tools:text="Waiting for connection" />
+
+        <com.tari.android.wallet.ui.component.tari.TariTextView
+            android:id="@+id/progress_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="5dp"
+            android:gravity="center"
+            android:textColor="?attr/palette_text_body"
+            android:textSize="18sp"
+            app:customFont="light"
+            tools:text="Attempts 5 out of 10" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ProgressBar
+            android:layout_width="50dp"
+            android:layout_height="50dp" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginVertical="40dp"
+            app:cardCornerRadius="16dp">
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:layout_editor_absoluteX="25dp"
+                tools:layout_editor_absoluteY="0dp">
+
+                <com.tari.android.wallet.ui.component.tari.TariTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginEnd="20dp"
+                    android:layout_weight="1"
+                    android:lineSpacingMultiplier="1.2"
+                    android:text="@string/back_up_wallet_keep_screen_awake"
+                    android:textColor="?attr/palette_text_heading"
+                    android:textSize="15sp"
+                    app:customFont="medium" />
+
+                <com.tari.android.wallet.ui.component.loadingSwitch.TariLoadingSwitchView
+                    android:id="@+id/awake_switch_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end|center_vertical"
+                    android:layout_marginEnd="16dp"
+                    android:elevation="0dp" />
+            </androidx.appcompat.widget.LinearLayoutCompat>
+        </androidx.cardview.widget.CardView>
+    </LinearLayout>
+</com.tari.android.wallet.ui.component.tari.background.TariSecondaryBackground>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -540,6 +540,7 @@
     <string name="back_up_wallet_restore_with_local_files">Restore with Local files</string>
     <string name="back_up_wallet_restore_with_dropbox">Restore with Dropbox</string>
     <string name="back_up_wallet_restore_with_paper_wallet">Sync with Universe desktop</string>
+    <string name="back_up_wallet_keep_screen_awake">Keep screen awake during sync</string>
 
     <!-- Wallet back up with seed phrase -->
     <string name="back_up_seed_phrase_page_title">Back Up With Seed Phrase</string>


### PR DESCRIPTION
Add the switcher to the Wallet Restoring screen to keep phone awake:

<img src="https://github.com/user-attachments/assets/69a9b225-b90d-4492-b60c-50fddef6aa35"  width="300">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting on the wallet restoration screen that allows users to keep their screen awake during synchronization.
  - Updated the screen layout with a refreshed design, including enhanced visual feedback and intuitive toggle controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->