### PR TITLE
feat: Receive screen

### DIFF
--- a/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/tari/android/wallet/di/ApplicationComponent.kt
@@ -73,6 +73,7 @@ import com.tari.android.wallet.ui.screen.send.addNote.AddNoteViewModel
 import com.tari.android.wallet.ui.screen.send.addNote.gif.ChooseGIFDialogFragment
 import com.tari.android.wallet.ui.screen.send.addNote.gif.ThumbnailGifViewModel
 import com.tari.android.wallet.ui.screen.send.finalize.FinalizeSendTxViewModel
+import com.tari.android.wallet.ui.screen.send.receive.ReceiveViewModel
 import com.tari.android.wallet.ui.screen.send.requestTari.RequestTariViewModel
 import com.tari.android.wallet.ui.screen.settings.allSettings.AllSettingsViewModel
 import com.tari.android.wallet.ui.screen.settings.allSettings.about.TariAboutViewModel
@@ -191,6 +192,7 @@ interface ApplicationComponent {
     fun inject(viewModel: SampleDesignSystemViewModel)
     fun inject(viewModel: ProfileLoginViewModel)
     fun inject(viewModel: ProfileViewModel)
+    fun inject(viewModel: ReceiveViewModel)
 
     fun inject(tariFcmService: TariFcmService)
 

--- a/app/src/main/java/com/tari/android/wallet/infrastructure/ShareManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/infrastructure/ShareManager.kt
@@ -19,7 +19,7 @@ import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
 import com.tari.android.wallet.ui.dialog.modular.modules.icon.IconModule
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQrCodeModule
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.util.ContactUtil
 import javax.inject.Inject
 

--- a/app/src/main/java/com/tari/android/wallet/navigation/Navigation.kt
+++ b/app/src/main/java/com/tari/android/wallet/navigation/Navigation.kt
@@ -58,6 +58,7 @@ sealed class Navigation {
         data class ToSendTariToUser(val contact: ContactDto, val amount: MicroTari? = null, val note: String = "") : TxList()
         data object HomeTransactionHistory : TxList()
         data object ToTransfer : TxList()
+        data object ToReceive : TxList()
     }
 
     sealed class Chat : Navigation() {

--- a/app/src/main/java/com/tari/android/wallet/navigation/TariNavigator.kt
+++ b/app/src/main/java/com/tari/android/wallet/navigation/TariNavigator.kt
@@ -28,7 +28,7 @@ import com.tari.android.wallet.navigation.Navigation.TorBridge
 import com.tari.android.wallet.navigation.Navigation.TxList
 import com.tari.android.wallet.navigation.Navigation.VerifySeedPhrase
 import com.tari.android.wallet.ui.common.CommonActivity
-import com.tari.android.wallet.ui.common.CommonXmlFragment
+import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.screen.auth.AuthActivity
 import com.tari.android.wallet.ui.screen.auth.FeatureAuthFragment
 import com.tari.android.wallet.ui.screen.biometrics.ChangeBiometricsFragment
@@ -55,6 +55,7 @@ import com.tari.android.wallet.ui.screen.send.addAmount.AddAmountFragment
 import com.tari.android.wallet.ui.screen.send.addNote.AddNoteFragment
 import com.tari.android.wallet.ui.screen.send.common.TransactionData
 import com.tari.android.wallet.ui.screen.send.finalize.FinalizeSendTxFragment
+import com.tari.android.wallet.ui.screen.send.receive.ReceiveFragment
 import com.tari.android.wallet.ui.screen.send.requestTari.RequestTariFragment
 import com.tari.android.wallet.ui.screen.send.transfer.TransferFragment
 import com.tari.android.wallet.ui.screen.settings.allSettings.AllSettingsFragment
@@ -147,6 +148,7 @@ class TariNavigator @Inject constructor(
             is TxList.ToUtxos -> addFragment(UtxosListFragment())
             is TxList.ToAllSettings -> addFragment(AllSettingsFragment.newInstance())
             is TxList.ToTransfer -> addFragment(TransferFragment())
+            is TxList.ToReceive -> addFragment(ReceiveFragment())
             is TxList.HomeTransactionHistory -> addFragment(AllTxHistoryFragment())
 
             is TorBridge.ToCustomBridges -> addFragment(CustomTorBridgesFragment())
@@ -180,7 +182,7 @@ class TariNavigator @Inject constructor(
         navigations.forEach { navigate(it) }
     }
 
-    private fun addFragment(fragment: CommonXmlFragment<*, *>, bundle: Bundle? = null, isRoot: Boolean = false, withAnimation: Boolean = true) {
+    private fun addFragment(fragment: CommonFragment<*>, bundle: Bundle? = null, isRoot: Boolean = false, withAnimation: Boolean = true) {
         currentActivity.addFragment(fragment, bundle, isRoot, withAnimation)
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -166,8 +166,8 @@ open class CommonViewModel : ViewModel(), DialogHandler {
         }
     }
 
-     fun onBackPressed() {
-        _backPressed.call()
+    fun onBackPressed() {
+        _backPressed.value = Unit
     }
 
     override fun showModularDialog(args: ModularDialogArgs) {

--- a/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/common/CommonViewModel.kt
@@ -100,7 +100,8 @@ open class CommonViewModel : ViewModel(), DialogHandler {
 
     val connectionState = connectionStateHandler.connectionState
 
-    val backPressed = SingleLiveEvent<Unit>()
+    private val _backPressed = SingleLiveEvent<Unit>()
+    val backPressed: LiveData<Unit> = _backPressed
 
     protected val _openLink = SingleLiveEvent<String>()
     val openLink: LiveData<String> = _openLink
@@ -150,7 +151,7 @@ open class CommonViewModel : ViewModel(), DialogHandler {
     private fun checkAuthorization() {
         if (authorizedAction != null && securityPrefRepository.isFeatureAuthenticated) {
             securityPrefRepository.isFeatureAuthenticated = false
-            backPressed.value = Unit
+            onBackPressed()
             authorizedAction?.invoke()
             authorizedAction = null
         }
@@ -163,6 +164,10 @@ open class CommonViewModel : ViewModel(), DialogHandler {
         }?.let { deeplink ->
             deeplinkManager.execute(activity, deeplink)
         }
+    }
+
+     fun onBackPressed() {
+        _backPressed.call()
     }
 
     override fun showModularDialog(args: ModularDialogArgs) {

--- a/app/src/main/java/com/tari/android/wallet/ui/compose/PreviewStub.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/compose/PreviewStub.kt
@@ -1,25 +1,36 @@
 package com.tari.android.wallet.ui.compose
 
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
 
 @Composable
 fun PreviewPrimarySurface(
     theme: TariTheme,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     TariDesignSystem(theme) {
-        Surface(color = TariDesignSystem.colors.backgroundPrimary) { content() }
+        Surface(
+            modifier = modifier,
+            color = TariDesignSystem.colors.backgroundPrimary,
+            content = content,
+        )
     }
 }
 
 @Composable
 fun PreviewSecondarySurface(
     theme: TariTheme,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     TariDesignSystem(theme) {
-        Surface(color = TariDesignSystem.colors.backgroundSecondary) { content() }
+        Surface(
+            modifier = modifier,
+            color = TariDesignSystem.colors.backgroundSecondary,
+            content = content,
+        )
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/compose/TariColors.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/compose/TariColors.kt
@@ -208,7 +208,7 @@ val TariLightColorPalette = TariColors(
 
     backgroundPrimary = Color(0xFFFFFFFF),
     backgroundSecondary = Color(0xFFF8F8F9),
-    backgroundAccent = Color(0x1B19210A),
+    backgroundAccent = Color(0x0A1B1921),
     backgroundPopup = Color(0xFFF8F8F9),
 
     actionActive = Color(0x80000000),

--- a/app/src/main/java/com/tari/android/wallet/ui/compose/components/TariButtons.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/compose/components/TariButtons.kt
@@ -2,19 +2,20 @@ package com.tari.android.wallet.ui.compose.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LocalRippleConfiguration
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.RippleConfiguration
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RippleConfiguration
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -30,20 +31,21 @@ import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
 fun TariPrimaryButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     size: TariButtonSize = TariButtonSize.Large,
-    modifier: Modifier = Modifier,
 ) {
     WithRippleColor(TariDesignSystem.colors.buttonPrimaryText) {
         Button(
             onClick = onClick,
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = TariDesignSystem.colors.buttonPrimaryBackground,
-                disabledBackgroundColor = TariDesignSystem.colors.actionDisabledBackground,
+                containerColor = TariDesignSystem.colors.buttonPrimaryBackground,
+                disabledContainerColor = TariDesignSystem.colors.actionDisabledBackground,
             ),
             shape = TariDesignSystem.shapes.button,
             modifier = modifier.defaultMinSize(minHeight = size.minHeight()),
             enabled = enabled,
+            contentPadding = PaddingValues(0.dp),
         ) {
             Text(
                 text = text,
@@ -67,12 +69,13 @@ fun TariSecondaryButton(
         Button(
             onClick = onClick,
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = TariDesignSystem.colors.primaryMain,
-                disabledBackgroundColor = TariDesignSystem.colors.actionDisabledBackground,
+                containerColor = TariDesignSystem.colors.primaryMain,
+                disabledContainerColor = TariDesignSystem.colors.actionDisabledBackground,
             ),
             shape = TariDesignSystem.shapes.button,
             modifier = modifier.defaultMinSize(minHeight = size.minHeight()),
             enabled = enabled,
+            contentPadding = PaddingValues(0.dp),
             content = content,
         )
     }
@@ -105,9 +108,9 @@ fun TariSecondaryButton(
 fun TariOutlinedButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     size: TariButtonSize = TariButtonSize.Large,
-    modifier: Modifier = Modifier,
 ) {
     WithRippleColor(TariDesignSystem.colors.textPrimary) {
         OutlinedButton(
@@ -118,11 +121,12 @@ fun TariOutlinedButton(
             ),
             shape = TariDesignSystem.shapes.button,
             colors = ButtonDefaults.outlinedButtonColors(
-                backgroundColor = TariDesignSystem.colors.backgroundPrimary,
+                containerColor = TariDesignSystem.colors.backgroundPrimary,
                 disabledContentColor = TariDesignSystem.colors.backgroundPrimary,
             ),
             modifier = modifier.defaultMinSize(minHeight = size.minHeight()),
             enabled = enabled,
+            contentPadding = PaddingValues(0.dp),
         ) {
             Text(
                 text = text,
@@ -134,13 +138,12 @@ fun TariOutlinedButton(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun TariInheritTextButton(
     text: String,
     onClick: () -> Unit,
-    enabled: Boolean = true,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     WithRippleColor(TariDesignSystem.colors.textPrimary) {
         OutlinedButton(
@@ -151,7 +154,7 @@ fun TariInheritTextButton(
             ),
             shape = TariDesignSystem.shapes.button,
             colors = ButtonDefaults.outlinedButtonColors(
-                backgroundColor = TariDesignSystem.colors.backgroundPrimary,
+                containerColor = TariDesignSystem.colors.backgroundPrimary,
                 disabledContentColor = TariDesignSystem.colors.backgroundPrimary,
             ),
             modifier = modifier.defaultMinSize(minHeight = TariButtonSize.Medium.minHeight()),
@@ -171,8 +174,8 @@ fun TariInheritTextButton(
 fun TariTextButton(
     text: String,
     onClick: () -> Unit,
-    enabled: Boolean = true,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     WithRippleColor(TariDesignSystem.colors.textPrimary) {
         TextButton(
@@ -216,7 +219,7 @@ private fun TariButtonSize.textHorizontalPadding() = when (this) {
     TariButtonSize.Large -> 22.dp
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WithRippleColor(
     rippleColor: Color,

--- a/app/src/main/java/com/tari/android/wallet/ui/compose/components/TariTopBar.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/compose/components/TariTopBar.kt
@@ -1,0 +1,95 @@
+package com.tari.android.wallet.ui.compose.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tari.android.wallet.R
+import com.tari.android.wallet.ui.compose.PreviewSecondarySurface
+import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
+
+@Composable
+fun TariTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
+    showShadow: Boolean = true,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 56.dp),
+        color = TariDesignSystem.colors.backgroundSecondary,
+        shadowElevation = if (showShadow) 2.dp else 0.dp,
+    ) {
+        Box {
+            if (onBack != null) {
+                IconButton(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(8.dp)
+                        .size(48.dp), onClick = onBack
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.vector_back_button),
+                        contentDescription = null,
+                        tint = TariDesignSystem.colors.componentsNavbarIcons,
+                    )
+                }
+            }
+
+            Text(
+                text = title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Center)
+                    .padding(8.dp),
+                style = TariDesignSystem.typography.headingLarge,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun TariTopBarShadowPreview() {
+    PreviewSecondarySurface(TariTheme.Light, Modifier.fillMaxSize()) {
+        Column {
+            TariTopBar(
+                title = "Toolbar Title",
+                showShadow = true,
+                onBack = {},
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun TariTopBarPreview() {
+    PreviewSecondarySurface(TariTheme.Light, Modifier.fillMaxSize()) {
+        Column {
+            TariTopBar(
+                title = "Toolbar Title",
+                showShadow = false,
+                onBack = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialog.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/ModularDialog.kt
@@ -43,14 +43,14 @@ import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.Security
 import com.tari.android.wallet.ui.dialog.modular.modules.securityStages.SecurityStageHeadModuleView
 import com.tari.android.wallet.ui.dialog.modular.modules.shareOptions.ShareOptionsModule
 import com.tari.android.wallet.ui.dialog.modular.modules.shareOptions.ShareOptionsModuleView
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQRCodeModuleView
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.dialog.modular.modules.shortEmoji.ShortEmojiIdModule
 import com.tari.android.wallet.ui.dialog.modular.modules.shortEmoji.ShortEmojiModuleView
 import com.tari.android.wallet.ui.dialog.modular.modules.space.SpaceModule
 import com.tari.android.wallet.ui.dialog.modular.modules.space.SpaceModuleView
 import com.tari.android.wallet.ui.screen.send.addAmount.feeModule.FeeModule
 import com.tari.android.wallet.ui.screen.send.addAmount.feeModule.FeeModuleView
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQRCodeModuleView
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.screen.settings.backup.learnMore.module.BackupLearnMoreItemModule
 import com.tari.android.wallet.ui.screen.settings.backup.learnMore.module.BackupLearnMoreItemModuleView
 import com.tari.android.wallet.ui.screen.settings.logs.logs.module.LogLevelCheckedModule

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shareQr/ShareQRCodeModuleView.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shareQr/ShareQRCodeModuleView.kt
@@ -1,4 +1,4 @@
-package com.tari.android.wallet.ui.screen.send.shareQr
+package com.tari.android.wallet.ui.dialog.modular.modules.shareQr
 
 import android.annotation.SuppressLint
 import android.content.Context
@@ -8,8 +8,8 @@ import com.tari.android.wallet.R
 import com.tari.android.wallet.databinding.DialogModuleShareQrCodeBinding
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.component.common.CommonView
-import com.tari.android.wallet.util.extension.dimenPx
 import com.tari.android.wallet.util.QrUtil
+import com.tari.android.wallet.util.extension.dimenPx
 
 @SuppressLint("ViewConstructor")
 class ShareQRCodeModuleView(context: Context, buttonModule: ShareQrCodeModule) :

--- a/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shareQr/ShareQrCodeModule.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/dialog/modular/modules/shareQr/ShareQrCodeModule.kt
@@ -1,4 +1,4 @@
-package com.tari.android.wallet.ui.screen.send.shareQr
+package com.tari.android.wallet.ui.dialog.modular.modules.shareQr
 
 import com.tari.android.wallet.ui.dialog.modular.IDialogModule
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/debug/sampleDesign/SampleDesignSystemFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/debug/sampleDesign/SampleDesignSystemFragment.kt
@@ -4,23 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.compose.TariDesignSystem
-import kotlin.getValue
+import com.tari.android.wallet.util.extension.composeContent
 
 class SampleDesignSystemFragment : CommonFragment<SampleDesignSystemViewModel>() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-            setContent {
-                TariDesignSystem(viewModel.currentTheme) {
-                    SampleDesignSystemScreen()
-                }
-            }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        TariDesignSystem(viewModel.currentTheme) {
+            SampleDesignSystemScreen()
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewFragment.kt
@@ -8,38 +8,32 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.application.deeplinks.DeepLink
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.compose.TariDesignSystem
 import com.tari.android.wallet.ui.screen.qr.QrScannerActivity
+import com.tari.android.wallet.util.extension.composeContent
 import com.tari.android.wallet.util.extension.parcelable
 
 class HomeOverviewFragment : CommonFragment<HomeOverviewViewModel>() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-            setContent {
-                val uiState by viewModel.uiState.collectAsState()
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        val uiState by viewModel.uiState.collectAsState()
 
-                TariDesignSystem(viewModel.currentTheme) {
-                    HomeOverviewScreen(
-                        uiState = uiState,
-                        onInviteFriendClick = { viewModel.onInviteFriendClicked() },
-                        onNotificationsClick = { viewModel.onNotificationsClicked() },
-                        onStartMiningClicked = { viewModel.onStartMiningClicked() },
-                        onSendTariClicked = { viewModel.onSendTariClicked() },
-                        onRequestTariClicked = { viewModel.onRequestTariClicked() },
-                        onTxClick = { viewModel.navigateToTxDetail(it.tx) },
-                        onViewAllTxsClick = { viewModel.onAllTxClicked() },
-                        onConnectionStatusClick = { viewModel.showConnectionStatusDialog() },
-                        onSyncDialogDismiss = { viewModel.onSyncDialogDismiss() },
-                    )
-                }
-            }
+        TariDesignSystem(viewModel.currentTheme) {
+            HomeOverviewScreen(
+                uiState = uiState,
+                onInviteFriendClick = { viewModel.onInviteFriendClicked() },
+                onNotificationsClick = { viewModel.onNotificationsClicked() },
+                onStartMiningClicked = { viewModel.onStartMiningClicked() },
+                onSendTariClicked = { viewModel.onSendTariClicked() },
+                onRequestTariClicked = { viewModel.onRequestTariClicked() },
+                onTxClick = { viewModel.navigateToTxDetail(it.tx) },
+                onViewAllTxsClick = { viewModel.onAllTxClicked() },
+                onConnectionStatusClick = { viewModel.showConnectionStatusDialog() },
+                onSyncDialogDismiss = { viewModel.onSyncDialogDismiss() },
+            )
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
@@ -215,8 +215,7 @@ class HomeOverviewViewModel : CommonViewModel() {
     }
 
     fun onRequestTariClicked() {
-
-        tariNavigator.navigate(Navigation.AllSettings.ToRequestTari)
+        tariNavigator.navigate(Navigation.TxList.ToReceive)
     }
 
     fun onAllTxClicked() {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
@@ -152,17 +152,17 @@ class HomeOverviewViewModel : CommonViewModel() {
             showModularDialog(
                 ModularDialogArgs(
                     DialogArgs(cancelable = false, canceledOnTouchOutside = false), listOf(
-                    HeadModule(resourceManager.getString(R.string.data_collection_dialog_title)),
-                    BodyModule(resourceManager.getString(R.string.data_collection_dialog_description)),
-                    ButtonModule(resourceManager.getString(R.string.data_collection_dialog_positive), ButtonStyle.Normal) {
-                        sentryPrefRepository.isEnabled = true
-                        hideDialog()
-                    },
-                    ButtonModule(resourceManager.getString(R.string.data_collection_dialog_negative), ButtonStyle.Close) {
-                        sentryPrefRepository.isEnabled = false
-                        hideDialog()
-                    }
-                ))
+                        HeadModule(resourceManager.getString(R.string.data_collection_dialog_title)),
+                        BodyModule(resourceManager.getString(R.string.data_collection_dialog_description)),
+                        ButtonModule(resourceManager.getString(R.string.data_collection_dialog_positive), ButtonStyle.Normal) {
+                            sentryPrefRepository.isEnabled = true
+                            hideDialog()
+                        },
+                        ButtonModule(resourceManager.getString(R.string.data_collection_dialog_negative), ButtonStyle.Close) {
+                            sentryPrefRepository.isEnabled = false
+                            hideDialog()
+                        }
+                    ))
             )
         }
     }
@@ -215,6 +215,7 @@ class HomeOverviewViewModel : CommonViewModel() {
     }
 
     fun onRequestTariClicked() {
+
         tariNavigator.navigate(Navigation.AllSettings.ToRequestTari)
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/onboarding/inroduction/IntroductionFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/onboarding/inroduction/IntroductionFragment.kt
@@ -6,30 +6,23 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.ui.compose.TariDesignSystem
 import com.tari.android.wallet.ui.screen.onboarding.activity.OnboardingFlowFragment
 import com.tari.android.wallet.util.extension.collectFlow
-import kotlin.getValue
+import com.tari.android.wallet.util.extension.composeContent
 
 class IntroductionFragment : OnboardingFlowFragment<IntroductionViewModel>() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-            setContent {
-                val state by viewModel.uiState.collectAsState()
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        val state by viewModel.uiState.collectAsState()
 
-                TariDesignSystem(viewModel.currentTheme) {
-                    IntroductionScreen(
-                        uiState = state,
-                        onImportWalletClick = { viewModel.onWalletRestoreClick() },
-                        onCreateWalletClick = { viewModel.onCreateWalletClick() },
-                    )
-                }
-            }
+        TariDesignSystem(viewModel.currentTheme) {
+            IntroductionScreen(
+                uiState = state,
+                onImportWalletClick = { viewModel.onWalletRestoreClick() },
+                onCreateWalletClick = { viewModel.onCreateWalletClick() },
+            )
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/pinCode/EnterPinCodeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/pinCode/EnterPinCodeViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import com.tari.android.wallet.R
 import com.tari.android.wallet.data.sharedPrefs.security.LoginAttemptDto
-import com.tari.android.wallet.util.extension.addTo
 import com.tari.android.wallet.navigation.Navigation
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.common.SingleLiveEvent
+import com.tari.android.wallet.util.extension.addTo
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 
@@ -120,7 +120,7 @@ class EnterPinCodeViewModel : CommonViewModel() {
 
     private fun createPinCodeConfirm() {
         if (currentNums.value != stashedPin.value) {
-            backPressed.postValue(Unit)
+            onBackPressed()
             return
         }
         securityPrefRepository.pinCode = currentNums.value.orEmpty()
@@ -133,7 +133,7 @@ class EnterPinCodeViewModel : CommonViewModel() {
 
     private fun changeNewPinCodeConfirm() {
         if (currentNums.value != stashedPin.value) {
-            backPressed.postValue(Unit)
+            onBackPressed()
             return
         }
         securityPrefRepository.pinCode = currentNums.value.orEmpty()

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/profile/login/ProfileLoginFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/profile/login/ProfileLoginFragment.kt
@@ -4,23 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.util.extension.composeContent
 
 class ProfileLoginFragment : CommonFragment<ProfileLoginViewModel>() {
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-            setContent {
-                TariDesignSystem(viewModel.currentTheme) {
-                    ProfileLoginScreen(
-                        authUrl = viewModel.authUrl
-                    )
-                }
-            }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        TariDesignSystem(viewModel.currentTheme) {
+            ProfileLoginScreen(
+                authUrl = viewModel.authUrl
+            )
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/profile/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/profile/profile/ProfileFragment.kt
@@ -6,28 +6,22 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.tari.android.wallet.ui.common.CommonFragment
 import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.util.extension.composeContent
 
 class ProfileFragment : CommonFragment<ProfileViewModel>() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-            setContent {
-                val uiState by viewModel.uiState.collectAsState()
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        val uiState by viewModel.uiState.collectAsState()
 
-                TariDesignSystem(viewModel.currentTheme) {
-                    ProfileScreen(
-                        uiState = uiState,
-                        onInviteLinkShareClick = { viewModel.onInviteLinkShareClick() },
-                        onStartMiningClicked = { viewModel.onStartMiningClicked() },
-                    )
-                }
-            }
+        TariDesignSystem(viewModel.currentTheme) {
+            ProfileScreen(
+                uiState = uiState,
+                onInviteLinkShareClick = { viewModel.onInviteLinkShareClick() },
+                onStartMiningClicked = { viewModel.onStartMiningClicked() },
+            )
         }
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/qr/QrScannerViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/qr/QrScannerViewModel.kt
@@ -33,7 +33,7 @@ class QrScannerViewModel(savedState: SavedStateHandle) : CommonViewModel() {
     private val qrScannerSource: QrScannerSource = savedState.get<QrScannerSource>(EXTRA_QR_DATA_SOURCE) ?: QrScannerSource.None
 
     fun onAlternativeApply(context: Activity) {
-        backPressed.postValue(Unit)
+        onBackPressed()
         launchOnIo {
             delay(500)
             launchOnMain {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/restore/chooseRestoreOption/ChooseRestoreOptionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/restore/chooseRestoreOption/ChooseRestoreOptionViewModel.kt
@@ -235,7 +235,7 @@ class ChooseRestoreOptionViewModel : CommonViewModel() {
         showSimpleDialog(
             title = resourceManager.getString(R.string.restore_wallet_error_title),
             description = resourceManager.getString(R.string.restore_wallet_error_file_not_found),
-            onClose = { backPressed.call() },
+            onClose = { onBackPressed() },
         )
     }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/restore/enterRestorationPassword/EnterRestorationPasswordViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/restore/enterRestorationPassword/EnterRestorationPasswordViewModel.kt
@@ -47,7 +47,7 @@ class EnterRestorationPasswordViewModel : CommonViewModel() {
     val state: LiveData<EnterRestorationPasswordState> = _state
 
     fun onBack() {
-        backPressed.postValue(Unit)
+        onBackPressed()
         launchOnIo {
             backupManager.signOut()
         }
@@ -86,11 +86,12 @@ class EnterRestorationPasswordViewModel : CommonViewModel() {
     }
 
     private fun showUnrecoverableExceptionDialog(message: String) {
-        val args = SimpleDialogArgs(title = resourceManager.getString(R.string.restore_wallet_error_title),
+        val args = SimpleDialogArgs(
+            title = resourceManager.getString(R.string.restore_wallet_error_title),
             description = message,
             cancelable = false,
             canceledOnTouchOutside = false,
-            onClose = { backPressed.call() })
+            onClose = { onBackPressed() })
         showModularDialog(args.getModular(resourceManager))
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveFragment.kt
@@ -1,0 +1,36 @@
+package com.tari.android.wallet.ui.screen.send.receive
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.fragment.app.viewModels
+import com.tari.android.wallet.ui.common.CommonFragment
+import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.util.extension.composeContent
+
+class ReceiveFragment : CommonFragment<ReceiveViewModel>() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = composeContent {
+        val state by viewModel.uiState.collectAsState()
+
+        TariDesignSystem(viewModel.currentTheme) {
+            ReceiveScreen(
+                uiState = state,
+                onBackClick = { viewModel.onBackPressed() },
+                onEmojiCopyClick = { viewModel.onEmojiCopyClick() },
+                onBase58CopyClick = { viewModel.onBase58CopyClick() },
+                onEmojiDetailClick = { viewModel.onAddressDetailsClicked() },
+                onShareClick = { viewModel.onShareClick() },
+            )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val viewModel: ReceiveViewModel by viewModels()
+        bindViewModel(viewModel)
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveScreen.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveScreen.kt
@@ -1,0 +1,254 @@
+package com.tari.android.wallet.ui.screen.send.receive
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tari.android.wallet.R
+import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.ui.compose.PreviewSecondarySurface
+import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.ui.compose.components.TariButtonSize
+import com.tari.android.wallet.ui.compose.components.TariHorizontalDivider
+import com.tari.android.wallet.ui.compose.components.TariPrimaryButton
+import com.tari.android.wallet.ui.compose.components.TariTopBar
+import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
+import com.tari.android.wallet.util.MockDataStub
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReceiveScreen(
+    uiState: ReceiveViewModel.UiState,
+    onBackClick: () -> Unit,
+    onEmojiCopyClick: () -> Unit,
+    onBase58CopyClick: () -> Unit,
+    onEmojiDetailClick: () -> Unit,
+    onShareClick: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding(),
+        containerColor = TariDesignSystem.colors.backgroundSecondary,
+        topBar = {
+            TariTopBar(
+                title = stringResource(R.string.receive_tari_topbar_title),
+                onBack = onBackClick,
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            Spacer(Modifier.size(60.dp))
+            NetworkTitle(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                ticker = uiState.ticker,
+                networkName = uiState.networkName,
+            )
+            Spacer(Modifier.size(32.dp))
+            QrCodeCard(
+                qrBitmap = uiState.qrBitmap,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+            Spacer(Modifier.size(32.dp))
+            AddressCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                address = uiState.tariAddress,
+                onEmojiCopyClick = onEmojiCopyClick,
+                onBase58CopyClick = onBase58CopyClick,
+                onEmojiDetailClick = onEmojiDetailClick,
+            )
+            Spacer(Modifier.weight(1f))
+            TariPrimaryButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                text = stringResource(R.string.common_share),
+                onClick = onShareClick,
+            )
+            Spacer(Modifier.size(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun NetworkTitle(ticker: String, networkName: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.vector_gem),
+            contentDescription = null,
+            tint = TariDesignSystem.colors.textPrimary,
+            modifier = Modifier.size(30.dp),
+        )
+        Spacer(Modifier.size(8.dp))
+        Text(
+            text = ticker,
+            style = TariDesignSystem.typography.heading2XLarge,
+        )
+        Spacer(Modifier.size(8.dp))
+        Box(
+            modifier = Modifier
+                .wrapContentSize()
+                .height(20.dp)
+                .clip(TariDesignSystem.shapes.chip)
+                .background(color = TariDesignSystem.colors.backgroundAccent)
+                .padding(horizontal = 6.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = networkName,
+                style = TariDesignSystem.typography.body2,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QrCodeCard(qrBitmap: Bitmap?, modifier: Modifier = Modifier) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = TariDesignSystem.colors.backgroundPrimary),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+        shape = RoundedCornerShape(24.dp),
+        modifier = modifier.size(232.dp),
+    ) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (qrBitmap != null) {
+                Image(
+                    modifier = modifier.fillMaxSize(),
+                    bitmap = qrBitmap.asImageBitmap(),
+                    contentDescription = null,
+                )
+            } else {
+                CircularProgressIndicator(
+                    color = TariDesignSystem.colors.textPrimary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun AddressCard(
+    address: TariWalletAddress,
+    onEmojiCopyClick: () -> Unit,
+    onBase58CopyClick: () -> Unit,
+    onEmojiDetailClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(TariDesignSystem.shapes.chip)
+            .background(color = TariDesignSystem.colors.backgroundAccent)
+            .padding(horizontal = 16.dp),
+    ) {
+        Spacer(Modifier.size(16.dp))
+        Text(
+            text = stringResource(R.string.receive_tari_your_address),
+            style = TariDesignSystem.typography.body1,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onEmojiDetailClick),
+                text = address.fullEmojiId,
+                style = TariDesignSystem.typography.body1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.size(8.dp))
+            TariPrimaryButton(
+                size = TariButtonSize.Small,
+                text = stringResource(R.string.common_copy),
+                onClick = onEmojiCopyClick,
+            )
+        }
+        Spacer(Modifier.size(8.dp))
+        TariHorizontalDivider()
+        Spacer(Modifier.size(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = address.fullBase58,
+                style = TariDesignSystem.typography.body1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.size(8.dp))
+            TariPrimaryButton(
+                size = TariButtonSize.Small,
+                text = stringResource(R.string.common_copy),
+                onClick = onBase58CopyClick,
+            )
+        }
+        Spacer(Modifier.size(8.dp))
+    }
+}
+
+@Composable
+@Preview
+fun ReceiveScreenPreview() {
+    PreviewSecondarySurface(TariTheme.Light) {
+        ReceiveScreen(
+            uiState = ReceiveViewModel.UiState(
+                ticker = "XTR",
+                networkName = "Mainnet",
+                tariAddress = MockDataStub.WALLET_ADDRESS,
+                qrBitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.tari_splash_screen),
+            ),
+            onBackClick = {},
+            onEmojiCopyClick = {},
+            onBase58CopyClick = {},
+            onEmojiDetailClick = {},
+            onShareClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/send/receive/ReceiveViewModel.kt
@@ -1,0 +1,82 @@
+package com.tari.android.wallet.ui.screen.send.receive
+
+import android.graphics.Bitmap
+import com.tari.android.wallet.R
+import com.tari.android.wallet.application.deeplinks.DeepLink
+import com.tari.android.wallet.model.TariWalletAddress
+import com.tari.android.wallet.navigation.Navigation
+import com.tari.android.wallet.ui.common.CommonViewModel
+import com.tari.android.wallet.util.ContactUtil
+import com.tari.android.wallet.util.QrUtil
+import com.tari.android.wallet.util.extension.launchOnIo
+import com.tari.android.wallet.util.extension.launchOnMain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class ReceiveViewModel : CommonViewModel() {
+
+    @Inject
+    lateinit var contactUtil: ContactUtil
+
+    private val _uiState = MutableStateFlow(
+        UiState(
+            ticker = networkRepository.currentNetwork.ticker,
+            networkName = networkRepository.currentNetwork.network.displayName,
+            tariAddress = sharedPrefsRepository.walletAddress,
+        )
+    )
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        component.inject(this)
+
+        launchOnIo {
+            val bitmap = getQrCodeBitmap()
+            launchOnMain {
+                _uiState.update { it.copy(qrBitmap = bitmap) }
+            }
+        }
+    }
+
+    fun onEmojiCopyClick() {
+        tariNavigator.navigate(Navigation.ShareText(sharedPrefsRepository.walletAddress.fullEmojiId))
+    }
+
+    fun onBase58CopyClick() {
+        tariNavigator.navigate(Navigation.ShareText(sharedPrefsRepository.walletAddress.fullBase58))
+    }
+
+    fun onAddressDetailsClicked() {
+        showAddressDetailsDialog(sharedPrefsRepository.walletAddress)
+    }
+
+    fun onShareClick() {
+        tariNavigator.navigate(Navigation.ShareText(sharedPrefsRepository.walletAddress.fullBase58))
+    }
+
+    private suspend fun getQrCodeBitmap(): Bitmap? = withContext(Dispatchers.IO) {
+        QrUtil.getQrEncodedBitmapOrNull(
+            content = deeplinkManager.getDeeplinkString(
+                DeepLink.UserProfile(
+                    tariAddress = sharedPrefsRepository.walletAddressBase58.orEmpty(),
+                    alias = contactUtil.normalizeAlias(
+                        alias = sharedPrefsRepository.firstName.orEmpty() + " " + sharedPrefsRepository.lastName.orEmpty(),
+                        walletAddress = sharedPrefsRepository.walletAddress,
+                    ),
+                )
+            ),
+            size = resourceManager.getDimenInPx(R.dimen.wallet_info_img_qr_code_size),
+        )
+    }
+
+    data class UiState(
+        val ticker: String,
+        val networkName: String,
+        val tariAddress: TariWalletAddress,
+        val qrBitmap: Bitmap? = null,
+    )
+}

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/send/requestTari/RequestTariFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/send/requestTari/RequestTariFragment.kt
@@ -14,8 +14,8 @@ import com.tari.android.wallet.ui.dialog.modular.ModularDialog
 import com.tari.android.wallet.ui.dialog.modular.ModularDialogArgs
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.screen.send.addAmount.keyboard.KeyboardController
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.util.extension.hideKeyboard
 import com.tari.android.wallet.util.extension.setOnThrottledClickListener
 import com.tari.android.wallet.util.extension.setVisible

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
@@ -49,7 +49,7 @@ class ChangeBaseNodeViewModel : CommonViewModel() {
     fun selectBaseNode(baseNodeDto: BaseNodeDto) {
         baseNodesManager.setBaseNode(baseNodeDto)
         walletManager.syncBaseNode()
-        backPressed.postValue(Unit)
+        onBackPressed()
     }
 
     fun showQrCode(baseNodeDto: BaseNodeDto) {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/baseNodeConfig/changeBaseNode/ChangeBaseNodeViewModel.kt
@@ -15,8 +15,8 @@ import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
 import com.tari.android.wallet.ui.dialog.modular.modules.input.InputModule
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.screen.restore.inputSeedWords.CustomBaseNodeState
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.screen.settings.baseNodeConfig.changeBaseNode.adapter.BaseNodeViewHolderItem
 import com.tari.android.wallet.util.extension.collectFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/bugReporting/BugsReportingViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/bugReporting/BugsReportingViewModel.kt
@@ -19,7 +19,7 @@ class BugsReportingViewModel : CommonViewModel() {
     fun send(name: String, email: String, bugDescription: String) = launchOnIo {
         try {
             bugReportingService.share(name, email, bugDescription)
-            backPressed.postValue(Unit)
+            onBackPressed()
             logger.i("Bug report sent: name=$name, email=$email, bugDescription=$bugDescription")
         } catch (e: Exception) {
             switchToMain {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/logs/logs/LogsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/logs/logs/LogsViewModel.kt
@@ -50,7 +50,7 @@ class LogsViewModel(savedState: SavedStateHandle) : CommonViewModel() {
                     showSimpleDialog(
                         title = resourceManager.getString(R.string.common_error_title),
                         description = resourceManager.getString(R.string.debug_logs_cant_open_file),
-                        onClose = { backPressed.postValue(Unit) },
+                        onClose = { onBackPressed() },
                     )
                 }
                 logger.i("Error reading log file: ${e.message}")

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/networkSelection/NetworkSelectionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/networkSelection/NetworkSelectionViewModel.kt
@@ -39,7 +39,7 @@ class NetworkSelectionViewModel : CommonViewModel() {
 
     fun selectNetwork(networkViewHolderItem: NetworkViewHolderItem) {
         if (networkViewHolderItem.network.network == networkRepository.currentNetwork.network) {
-            backPressed.postValue(Unit)
+            onBackPressed()
             return
         }
 

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/TorBridgesSelectionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/TorBridgesSelectionViewModel.kt
@@ -18,7 +18,7 @@ import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
-import com.tari.android.wallet.ui.screen.send.shareQr.ShareQrCodeModule
+import com.tari.android.wallet.ui.dialog.modular.modules.shareQr.ShareQrCodeModule
 import com.tari.android.wallet.ui.screen.settings.torBridges.torItem.TorBridgeViewHolderItem
 import com.tari.android.wallet.util.DebugConfig
 import com.tari.android.wallet.util.extension.collectFlow

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/TorBridgesSelectionViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/TorBridgesSelectionViewModel.kt
@@ -176,7 +176,7 @@ class TorBridgesSelectionViewModel : CommonViewModel() {
                                 BodyModule(description),
                                 ButtonModule(resourceManager.getString(R.string.common_confirm), ButtonStyle.Normal) {
                                     hideDialog()
-                                    backPressed.postValue(Unit)
+                                    onBackPressed()
                                 },
                             )
                         )

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/customBridges/CustomTorBridgesViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/settings/torBridges/customBridges/CustomTorBridgesViewModel.kt
@@ -62,7 +62,7 @@ class CustomTorBridgesViewModel : CommonViewModel() {
         }
 
         newBridges.forEach { torSharedRepository.addTorBridgeConfiguration(it) }
-        backPressed.postValue(Unit)
+        onBackPressed()
     }
 
     fun handleQrCode(deeplink: DeepLink) {

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsViewModel.kt
@@ -10,16 +10,11 @@ import com.tari.android.wallet.R.string.tx_details_cancel_dialog_cancel
 import com.tari.android.wallet.R.string.tx_details_cancel_dialog_description
 import com.tari.android.wallet.R.string.tx_details_cancel_dialog_not_cancel
 import com.tari.android.wallet.application.walletManager.WalletManager.WalletEvent
-import com.tari.android.wallet.util.extension.collectFlow
-import com.tari.android.wallet.util.extension.launchOnMain
+import com.tari.android.wallet.data.contacts.ContactsRepository
+import com.tari.android.wallet.data.contacts.model.ContactDto
+import com.tari.android.wallet.data.contacts.model.splitAlias
 import com.tari.android.wallet.ffi.FFITxCancellationReason
 import com.tari.android.wallet.ffi.FFIWallet
-import com.tari.android.wallet.model.tx.CancelledTx
-import com.tari.android.wallet.model.tx.CompletedTx
-import com.tari.android.wallet.model.tx.PendingOutboundTx
-import com.tari.android.wallet.model.tx.Tx
-import com.tari.android.wallet.model.tx.Tx.Direction.INBOUND
-import com.tari.android.wallet.model.tx.Tx.Direction.OUTBOUND
 import com.tari.android.wallet.model.TxId
 import com.tari.android.wallet.model.TxStatus.BROADCAST
 import com.tari.android.wallet.model.TxStatus.COINBASE
@@ -37,19 +32,24 @@ import com.tari.android.wallet.model.TxStatus.QUEUED
 import com.tari.android.wallet.model.TxStatus.REJECTED
 import com.tari.android.wallet.model.TxStatus.TX_NULL_ERROR
 import com.tari.android.wallet.model.TxStatus.UNKNOWN
+import com.tari.android.wallet.model.tx.CancelledTx
+import com.tari.android.wallet.model.tx.CompletedTx
+import com.tari.android.wallet.model.tx.PendingOutboundTx
+import com.tari.android.wallet.model.tx.Tx
+import com.tari.android.wallet.model.tx.Tx.Direction.INBOUND
+import com.tari.android.wallet.model.tx.Tx.Direction.OUTBOUND
 import com.tari.android.wallet.ui.common.CommonViewModel
 import com.tari.android.wallet.ui.dialog.modular.modules.body.BodyModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonModule
 import com.tari.android.wallet.ui.dialog.modular.modules.button.ButtonStyle
 import com.tari.android.wallet.ui.dialog.modular.modules.head.HeadModule
 import com.tari.android.wallet.ui.dialog.modular.modules.input.InputModule
-import com.tari.android.wallet.util.extension.string
-import com.tari.android.wallet.data.contacts.ContactsRepository
-import com.tari.android.wallet.data.contacts.model.ContactDto
-import com.tari.android.wallet.data.contacts.model.splitAlias
 import com.tari.android.wallet.ui.screen.tx.details.TxDetailsFragment.Companion.TX_EXTRA_KEY
 import com.tari.android.wallet.ui.screen.tx.details.TxDetailsFragment.Companion.TX_ID_EXTRA_KEY
 import com.tari.android.wallet.ui.screen.tx.details.gif.TxState
+import com.tari.android.wallet.util.extension.collectFlow
+import com.tari.android.wallet.util.extension.launchOnMain
+import com.tari.android.wallet.util.extension.string
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -187,7 +187,7 @@ class TxDetailsViewModel(savedState: SavedStateHandle) : CommonViewModel() {
             showSimpleDialog(
                 title = resourceManager.getString(R.string.tx_details_error_tx_not_found_title),
                 description = resourceManager.getString(R.string.tx_details_error_tx_not_found_desc),
-                onClose = { backPressed.call() },
+                onClose = { onBackPressed() },
             )
         } else {
             setTxArg(foundTx)

--- a/app/src/main/java/com/tari/android/wallet/util/extension/FragmentExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/extension/FragmentExtensions.kt
@@ -33,11 +33,15 @@
 package com.tari.android.wallet.util.extension
 
 import android.graphics.drawable.Drawable
+import android.view.View
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 
 fun Fragment.string(@StringRes id: Int): String = requireContext().string(id)
@@ -54,3 +58,8 @@ fun Fragment.dimenPx(@DimenRes id: Int): Int = requireContext().dimenPx(id)
 fun Fragment.dimen(@DimenRes id: Int): Float = requireContext().dimen(id)
 
 fun Fragment.drawable(@DrawableRes id: Int): Drawable? = requireContext().drawable(id)
+
+fun Fragment.composeContent(content: @Composable () -> Unit): View = ComposeView(requireContext()).apply {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+    setContent(content)
+}

--- a/app/src/main/res/drawable/vector_back_button.xml
+++ b/app/src/main/res/drawable/vector_back_button.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="8dp"
+    android:width="16dp"
     android:height="13dp"
-    android:viewportWidth="8"
+    android:viewportWidth="16"
     android:viewportHeight="13">
   <path
-      android:pathData="M8,1.528L3.051,6.5L8,11.472L6.469,13L0,6.5L6.469,0L8,1.528Z"
-      android:fillColor="#ffffff"/>
+      android:pathData="M0.348,6.838L5.199,11.69C5.646,12.137 6.391,12.137 6.838,11.69C7.285,11.243 7.285,10.498 6.838,10.05L3.974,7.169H14.571C15.216,7.169 15.73,6.656 15.73,6.01C15.73,5.365 15.216,4.851 14.571,4.851H3.974L6.838,1.987C7.285,1.54 7.285,0.795 6.838,0.348C6.606,0.116 6.308,0 6.01,0C5.712,0 5.414,0.116 5.183,0.348L0.348,5.183C0.132,5.398 0,5.696 0,6.01C0,6.325 0.116,6.623 0.348,6.838Z"
+      android:fillColor="#000000"/>
 </vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="common_not_ready_yet_dialog_title">Hang tight, coming soon!</string>
     <string name="common_not_ready_yet_dialog_description">This feature is currently under construction. We\'re working hard to bring it to you soon. Stay tuned!</string>
     <string name="common_copied_to_clipboard">Copied to clipboard</string>
+    <string name="common_copy">Copy</string>
 
     <!-- emoji id copied view -->
     <string name="emoji_id_copied">COPIED</string>
@@ -270,6 +271,10 @@
     <string name="request_tari_generate_qr_code">Generate QR Code</string>
     <string name="request_tari_share">Share</string>
     <string name="request_tari_share_text">Hi! Please send me %s Tari(s) using this link: %s</string>
+
+    <!-- receive -->
+    <string name="receive_tari_topbar_title">Receive</string>
+    <string name="receive_tari_your_address">Your Address</string>
 
     <!-- send tari - add recipient -->
     <string name="add_recipient_recent_tx_contacts">Recent</string>


### PR DESCRIPTION
Created the new Receive screen with basic info about the wallet address and the ability to share it:
- Created `ReceiveScreen`
- Replaced the existing Send Tari screen with the new one
- Added `TariTopBar` component
- Updated TariButton components
- Added `Fragment.composeContent` extension function
- Refactored code and moved some classes to better places

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated “Receive” screen that displays a QR code, wallet address, and options to copy or share address details.
  - Enhanced navigation flow to provide a smoother transition into the receiving experience.

- **Style**
  - Updated key UI elements with Material3 design, including refreshed buttons and a new top bar.
  - Improved visual details such as a modified accent color, a larger black back button, and clearer labels (“Receive”, “Your Address”, “Copy”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->