### PR TITLE
build: 1.0.0 Mainnet release

### DIFF
--- a/app/src/main/cpp/jniCommsConfig.cpp
+++ b/app/src/main/cpp/jniCommsConfig.cpp
@@ -67,7 +67,6 @@ Java_com_tari_android_wallet_ffi_FFICommsConfig_jniCreate(
                 pDatastorePath,
                 static_cast<unsigned long long int>(jDiscoveryTimeoutSec),
                 static_cast<unsigned long long int>(jSafDurationSec),
-                false,
                 errorPointer
         );
         jEnv->ReleaseStringUTFChars(jPublicAddress, pControlServiceAddress);

--- a/app/src/main/java/com/tari/android/wallet/application/MigrationManager.kt
+++ b/app/src/main/java/com/tari/android/wallet/application/MigrationManager.kt
@@ -15,9 +15,10 @@ class MigrationManager @Inject constructor(
     suspend fun validateVersion(onValid: () -> Unit, onError: () -> Unit) = withContext(Dispatchers.IO) {
         val walletVersion = walletManager.getLastAccessedToDbVersion()
             .replace("v", "")
+            .replace("-", ".")
             .takeIf { it.isNotEmpty() }
             ?.let { DefaultArtifactVersion(it) }
-        val minValidVersion = DefaultArtifactVersion(BuildConfig.LIB_WALLET_MIN_VALID_VERSION.replace("v", ""))
+        val minValidVersion = DefaultArtifactVersion(BuildConfig.LIB_WALLET_MIN_VALID_VERSION.replace("v", "").replace("-", "."))
 
         if (walletVersion == null || walletVersion < minValidVersion) {
             onError()

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/CorePrefRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/CorePrefRepository.kt
@@ -172,9 +172,11 @@ class CorePrefRepository @Inject constructor(
         onboardingAuthSetupStarted = false
         onboardingAuthSetupCompleted = false
         onboardingDisplayedAtHome = false
+        keepScreenAwakeWhenRestore = true
         airdropAnonId = null
         airdropToken = null
         airdropRefreshToken = null
+        mainnetLaunchModalShown = false
     }
 
     fun generateDatabasePassphrase(): String {

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkPrefRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkPrefRepository.kt
@@ -41,7 +41,7 @@ class NetworkPrefRepository @Inject constructor(sharedPrefs: SharedPreferences) 
         private val NETWORK_MAINNET: TariNetwork = TariNetwork(
             network = Network.MAINNET,
             dnsPeer = "seeds.tari.com",
-            blockExplorerBaseUrl = "https://explore-mainnet.tari.com",
+            blockExplorerBaseUrl = "https://explore.tari.com",
             ticker = TICKER_MAINNET,
             recommended = true,
         )

--- a/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkPrefRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/sharedPrefs/network/NetworkPrefRepository.kt
@@ -11,9 +11,9 @@ import javax.inject.Singleton
 @Singleton
 class NetworkPrefRepository @Inject constructor(sharedPrefs: SharedPreferences) {
     // defaultNetwork is the network that will be used if the current network is not set or is not supported
-    private val defaultNetwork = if (DebugConfig.mockNetwork) NETWORK_ESMERALDA else NETWORK_NEXTNET
+    private val defaultNetwork = if (DebugConfig.mockNetwork) NETWORK_ESMERALDA else NETWORK_MAINNET
 
-    var supportedNetworks: List<TariNetwork> = if (DebugConfig.mockNetwork) listOf(NETWORK_ESMERALDA) else listOf(NETWORK_NEXTNET)
+    var supportedNetworks: List<TariNetwork> = if (DebugConfig.mockNetwork) listOf(NETWORK_ESMERALDA) else listOf(NETWORK_MAINNET)
 
     private var _currentNetwork: Network by SharedPrefGsonDelegate(
         prefs = sharedPrefs,
@@ -40,7 +40,7 @@ class NetworkPrefRepository @Inject constructor(sharedPrefs: SharedPreferences) 
 
         private val NETWORK_MAINNET: TariNetwork = TariNetwork(
             network = Network.MAINNET,
-            dnsPeer = "seeds.testmnet.tari.com",
+            dnsPeer = "seeds.tari.com",
             blockExplorerBaseUrl = "https://explore-mainnet.tari.com",
             ticker = TICKER_MAINNET,
             recommended = true,

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/onboarding/createWallet/CreateWalletFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/onboarding/createWallet/CreateWalletFragment.kt
@@ -226,6 +226,7 @@ class CreateWalletFragment : OnboardingFlowXmlFragment<FragmentCreateWalletBindi
             override fun onAnimationEnd(animation: Animator) {
                 super.onAnimationEnd(animation)
                 startCreateEmojiIdAnimation()
+                ui.checkmarkLottieAnimationView.gone()
             }
         })
 
@@ -444,6 +445,7 @@ class CreateWalletFragment : OnboardingFlowXmlFragment<FragmentCreateWalletBindi
             addListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
                     ui.seeFullEmojiIdButton.isEnabled = true
+                    onSeeFullEmojiIdButtonClicked(ui.seeFullEmojiIdButton)
                     uiHandler.postDelayed({
                         hideFullEmojiId()
                     }, Constants.UI.mediumDurationMs)

--- a/app/src/main/res/drawable/vector_check_mark_bg.xml
+++ b/app/src/main/res/drawable/vector_check_mark_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#33FFFFFF" />
+    <size
+        android:width="160dp"
+        android:height="160dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_create_wallet.xml
+++ b/app/src/main/res/layout/fragment_create_wallet.xml
@@ -266,6 +266,8 @@
                     android:layout_height="wrap_content"
                     android:layout_centerHorizontal="true"
                     android:layout_marginTop="26dp"
+                    android:background="@drawable/vector_check_mark_bg"
+                    android:padding="36dp"
                     android:scaleX="0.5"
                     android:scaleY="0.5"
                     android:visibility="gone"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@
     <string name="home_wallet_balance">Wallet Balance</string>
     <string name="home_wallet_balance_hidden">*******</string>
     <string name="home_empty_state_title">You don’t have any activity yet. </string>
-    <string name="home_empty_state_description">Once you receive some tXTM, you’ll see it here.</string>
+    <string name="home_empty_state_description">Once you receive some XTM, you’ll see it here.</string>
     <string name="home_empty_state_button">Start Mining Tari</string>
     <string name="home_tx_list_recent_activity">Recent activity</string>
     <string name="home_sync_dialog_title">Welcome back!</string>
@@ -585,7 +585,7 @@
     <string name="restore_wallet_invalid_qr_code">Invalid QR Code</string>
     <string name="restore_wallet_invalid_qr_code_description">The QR code you scanned does not contain valid paper wallet seeds</string>
     <string name="restore_wallet_paper_wallet_title">Sync your Universe wallet?</string>
-    <string name="restore_wallet_paper_wallet_body">You just scanned a wallet from the Tari Universe desktop app! Syncing it will let you track your real-time tXTM balance right on your phone.\nWhat would you like to do?</string>
+    <string name="restore_wallet_paper_wallet_body">You just scanned a wallet from the Tari Universe desktop app! Syncing it will let you track your real-time XTM balance right on your phone.\nWhat would you like to do?</string>
     <string name="restore_wallet_paper_wallet_restore_button">Sync Wallet</string>
     <string name="restore_wallet_paper_wallet_do_not_restore_button">Don\'t restore right now</string>
     <string name="restore_wallet_paper_wallet_sweep_funds_button">Sweep the funds</string>
@@ -625,7 +625,7 @@
     <string name="restore_from_seed_words_cancel_dialog_title">Are you sure you want to cancel?</string>
     <string name="restore_from_seed_words_cancel_dialog_description">You will lose your progress, but don\'t worry, you can always start over.</string>
     <string name="recovery_success_dialog_title">Wallet Synced! 🎉</string>
-    <string name="recovery_success_dialog_description">Your real-time tXTM balance is now available on your phone. 🚀</string>
+    <string name="recovery_success_dialog_description">Your real-time XTM balance is now available on your phone. 🚀</string>
     <string name="recovery_success_dialog_close">Awesome, thanks!</string>
 
     <!--Restore -->

--- a/buildSrc/src/main/kotlin/TariBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/TariBuildConfig.kt
@@ -9,8 +9,8 @@ object TariBuildConfig {
     const val compileSdk = 35
 
     object LibWallet {
-        const val version = "v2.0.0-alpha.1"
-        const val minValidVersion = "v2.0.0-alpha.1"
+        const val version = "v2.0.0-alpha.3"
+        const val minValidVersion = "v2.0.0-alpha.3"
 
         const val hostURL = "https://github.com/tari-project/tari/releases/download/"
         const val x64A = "libminotari_wallet_ffi.android_x86_64.a"

--- a/buildSrc/src/main/kotlin/TariBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/TariBuildConfig.kt
@@ -7,8 +7,8 @@ object TariBuildConfig {
     const val compileSdk = 35
 
     object LibWallet {
-        const val version = "v1.13.0-rc.0"
-        const val minValidVersion = "v1.13.0-rc.0"
+        const val version = "v1.17.0-rc.1"
+        const val minValidVersion = "v1.17.0-rc.1"
 
         const val hostURL = "https://github.com/tari-project/tari/releases/download/"
         const val x64A = "libminotari_wallet_ffi.android_x86_64.a"

--- a/buildSrc/src/main/kotlin/TariBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/TariBuildConfig.kt
@@ -1,14 +1,14 @@
 object TariBuildConfig {
 
-    const val versionNumber = "0.32.0"
+    const val versionNumber = "0.32.1"
 
     const val minSdk = 26
     const val targetSdk = 34
     const val compileSdk = 35
 
     object LibWallet {
-        const val version = "v1.17.0-rc.1"
-        const val minValidVersion = "v1.17.0-rc.1"
+        const val version = "v1.18.0-rc.0"
+        const val minValidVersion = "v1.18.0-rc.0"
 
         const val hostURL = "https://github.com/tari-project/tari/releases/download/"
         const val x64A = "libminotari_wallet_ffi.android_x86_64.a"

--- a/buildSrc/src/main/kotlin/TariBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/TariBuildConfig.kt
@@ -1,14 +1,16 @@
+@file:Suppress("ConstPropertyName")
+
 object TariBuildConfig {
 
-    const val versionNumber = "0.32.1"
+    const val versionNumber = "1.0.0"
 
     const val minSdk = 26
     const val targetSdk = 34
     const val compileSdk = 35
 
     object LibWallet {
-        const val version = "v1.18.0-rc.0"
-        const val minValidVersion = "v1.18.0-rc.0"
+        const val version = "v2.0.0-alpha.1"
+        const val minValidVersion = "v2.0.0-alpha.1"
 
         const val hostURL = "https://github.com/tari-project/tari/releases/download/"
         const val x64A = "libminotari_wallet_ffi.android_x86_64.a"


### PR DESCRIPTION
Prepared a release for MAINNET:
- Updated the FFI lib to `v2.0.0-alpha.3`
- Updated the app version to `1.0.0`
- Pointed the network config to the `NETWORK_MAINNET` as the only option
- Set `dnsPeer = "seeds.tari.com"` for the MAINNET network
- Set `blockExplorerBaseUrl = "https://explore.tari.com"` for the MAINNET network
- Removed remaining wrong tickers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new checkmark background drawable for enhanced visual styling during wallet creation.

- **UI Improvements**
  - Updated the checkmark animation with a new background and padding for improved appearance.
  - Improved onboarding flow: the full emoji ID is now shown automatically after wallet creation animation, and the checkmark animation hides earlier for a smoother experience.

- **Bug Fixes**
  - Corrected and standardized currency symbol from "tXTM" to "XTM" across various user-facing texts.

- **Chores**
  - Updated default network to Mainnet and refreshed related network configuration.
  - Increased app and library version numbers to reflect the latest release.
  - Improved version string normalization for migration checks.
  - Reset additional preference fields to default values when clearing app preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->