### PR TITLE
feat: walletViewKeyHashed

### DIFF
--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -1297,3 +1297,16 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniGetBaseNodePeers(
         return wallet_get_seed_peers(pWallet, error);
     });
 }
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniGetPrivateViewKey(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jobject error
+) {
+    return ExecuteWithErrorAndCast<TariPrivateKey *>(jEnv, error, [&](int *error) {
+        auto pWallet = GetPointerField<TariWallet *>(jEnv, jThis);
+        return wallet_get_private_view_key(pWallet, error);
+    });
+}

--- a/app/src/main/java/com/tari/android/wallet/data/push/PushRepository.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/push/PushRepository.kt
@@ -4,6 +4,7 @@ import com.tari.android.wallet.BuildConfig
 import com.tari.android.wallet.data.airdrop.AirdropRepository
 import com.tari.android.wallet.data.sharedPrefs.CorePrefRepository
 import com.tari.android.wallet.ffi.FFIWallet
+import com.tari.android.wallet.util.extension.sha256
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,8 +20,9 @@ class PushRepository @Inject constructor(
         fcmToken: String,
     ) {
         val apiKey = BuildConfig.NOTIFICATIONS_API_KEY
-        val publicKey = wallet.getWalletAddress().notificationHex()
-        val signing = wallet.signMessage(apiKey + publicKey + fcmToken)
+        val publicKey = wallet.getWalletAddress().getSpendKey().getByteVector().hex()
+        val privateViewKey = wallet.getPrivateViewKey().getByteVector().hex().sha256()
+        val signing = wallet.signMessage(apiKey + publicKey + fcmToken + privateViewKey)
         val signature = signing.split("|")[0]
         val nonce = signing.split("|")[1]
 
@@ -31,7 +33,8 @@ class PushRepository @Inject constructor(
                 signature = signature,
                 appId = corePrefs.airdropAnonId,
                 userId = airdropRepository.getUserDetails().getOrNull()?.user?.id,
-                publicNonce = nonce
+                publicNonce = nonce,
+                walletViewKeyHashed = privateViewKey,
             )
         )
     }

--- a/app/src/main/java/com/tari/android/wallet/data/push/PushRetrofitService.kt
+++ b/app/src/main/java/com/tari/android/wallet/data/push/PushRetrofitService.kt
@@ -22,4 +22,5 @@ data class PushRegisterRequestBody(
     @SerializedName("public_nonce") val publicNonce: String,
     @SerializedName("platform") val platform: String = "android",
     @SerializedName("sandbox") val sandbox: Boolean = false,
+    @SerializedName("walletViewKeyHashed") val walletViewKeyHashed: String,
 )

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIPrivateKey.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIPrivateKey.kt
@@ -32,27 +32,18 @@
  */
 package com.tari.android.wallet.ffi
 
-import com.tari.android.wallet.model.Base58
-import com.tari.android.wallet.model.EmojiId
-
 /**
- * Wrapper for native private key type.
+ * Wrapper for native public key type.
  *
  * @author The Tari Development Team
  */
-class FFITariWalletAddress() : FFIBase() {
+class FFIPrivateKey() : FFIBase() {
 
     private external fun jniGetBytes(libError: FFIError): FFIPointer
     private external fun jniDestroy()
     private external fun jniCreate(byteVectorPtr: FFIByteVector, libError: FFIError)
-    private external fun jniFromBase58(base58: Base58, libError: FFIError)
-    private external fun jniFromEmojiId(emoji: EmojiId, libError: FFIError)
-    private external fun jniGetEmojiId(libError: FFIError): EmojiId
-    private external fun jniGetNetwork(libError: FFIError): Int
-    private external fun jniGetFeatures(libError: FFIError): Int
-    private external fun jniGetViewKey(libError: FFIError): FFIPointer
-    private external fun jniGetSpendKey(libError: FFIError): FFIPointer
-    private external fun jniGetChecksum(libError: FFIError): Int
+    private external fun jniFromHex(hexStr: String, libError: FFIError)
+    private external fun jniGetEmojiId(libError: FFIError): String
 
     constructor(pointer: FFIPointer) : this() {
         if (pointer.isNull()) error("Pointer must not be null")
@@ -63,29 +54,15 @@ class FFITariWalletAddress() : FFIBase() {
         runWithError { jniCreate(byteVector, it) }
     }
 
-    constructor(base58: Base58String) : this() {
-        runWithError { jniFromBase58(base58.base58, it) }
-    }
-
-    constructor(emojiId: EmojiId) : this() {
-        runWithError { jniFromEmojiId(emojiId, it) }
+    constructor(hex: HexString) : this() {
+        runWithError { jniFromHex(hex.hex, it) }
     }
 
     fun getByteVector(): FFIByteVector = runWithError { FFIByteVector(jniGetBytes(it)) }
 
-    fun getEmojiId(): EmojiId = runWithError { jniGetEmojiId(it) }
+    fun getEmojiId(): String = runWithError { jniGetEmojiId(it) }
 
-    fun getNetwork(): Int = runWithError { jniGetNetwork(it) }
-
-    fun getFeatures(): Int = runWithError { jniGetFeatures(it) }
-
-    fun getViewKey(): FFIPublicKey? = runWithError { jniGetViewKey(it) }.takeIf { !it.isNull() }?.let { FFIPublicKey(it) }
-
-    fun getSpendKey(): FFIPublicKey = runWithError { FFIPublicKey(jniGetSpendKey(it)) }
-
-    fun getChecksum(): Int = runWithError { jniGetChecksum(it) }
-
-    override fun toString(): String = getEmojiId()
+    override fun toString(): String = runWithError { FFIByteVector(jniGetBytes(it)).hex() }
 
     override fun destroy() = jniDestroy()
 }

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFIWallet.kt
@@ -150,6 +150,7 @@ class FFIWallet(
     private external fun jniSignMessage(message: String, libError: FFIError): String
     private external fun jniVerifyMessageSignature(publicKeyPtr: FFIPublicKey, message: String, signature: String, libError: FFIError): Boolean
     private external fun jniGetBaseNodePeers(libError: FFIError): FFIPointer
+    private external fun jniGetPrivateViewKey(libError: FFIError): FFIPointer
     private external fun jniAddBaseNodePeer(publicKey: FFIPublicKey, address: String, libError: FFIError): Boolean
     private external fun jniStartTXOValidation(libError: FFIError): ByteArray
     private external fun jniStartTxValidation(libError: FFIError): ByteArray
@@ -375,6 +376,8 @@ class FFIWallet(
             )
         ).runWithDestroy { TariCoinPreview(it) }
     }
+
+    fun getPrivateViewKey(): FFIPrivateKey = runWithError { FFIPrivateKey(jniGetPrivateViewKey(it)) }
 
     fun signMessage(message: String): String = runWithError { jniSignMessage(message, it) }
 

--- a/app/src/main/java/com/tari/android/wallet/util/extension/StringExtensions.kt
+++ b/app/src/main/java/com/tari/android/wallet/util/extension/StringExtensions.kt
@@ -43,6 +43,7 @@ import android.text.style.RelativeSizeSpan
 import com.tari.android.wallet.ui.component.tari.TariFont
 import com.tari.android.wallet.ui.component.tari.TariLetterSpacingSpan
 import com.tari.android.wallet.ui.component.tari.TariTypefaceSpan
+import java.security.MessageDigest
 
 /**
  * Used to apply partial font styles to a string.
@@ -149,3 +150,12 @@ fun String.makeTextBold(context: Context, vararg wordsToBeBold: String): Spannab
 )
 
 fun String.removeWhitespaces() = replace(" ", "")
+
+/**
+ * Computes the SHA-256 hash for the given String and returns a hexadecimal representation.
+ */
+fun String.sha256(): String {
+    val bytes = this.toByteArray(Charsets.UTF_8)
+    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+    return digest.joinToString(separator = "") { "%02x".format(it) }
+}


### PR DESCRIPTION
Added the `walletViewKeyHashed` parameter to PUSH registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced ability to retrieve the wallet's private view key and use it within the app.
  - Added a new hashed private view key field to push notification registration for enhanced payloads.
  - Added a new private key wrapper for safer and more flexible private key handling.

- **Improvements**
  - Push notification registration now uses a more secure public key derivation and includes a hashed private view key.
  - Added a utility function for SHA-256 hashing of strings.

- **Removals**
  - Removed the notification hex method from wallet address handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->