### PR TITLE
feat: Payment Referense

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(
         jniTariWalletAddress.cpp
         jniTariUnblindedOutput.cpp
         jniTariBaseNodeState.cpp
+        jniTariPaymentRecord.cpp
 )
 
 find_library(

--- a/app/src/main/cpp/jniCollections.cpp
+++ b/app/src/main/cpp/jniCollections.cpp
@@ -209,3 +209,37 @@ Java_com_tari_android_wallet_ffi_FFITariUnblindedOutputs_jniDestroy(
     unblinded_outputs_destroy(GetPointerField<TariUnblindedOutputs *>(jEnv, jThis));
     SetNullPointerField(jEnv, jThis);
 }
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_tari_android_wallet_ffi_FFITariPaymentRecords_jniGetLength(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jobject error) {
+    return ExecuteWithError<jint>(jEnv, error, [&](int *errorPointer) {
+        auto pPaymentRecords = GetPointerField<TariPaymentRecords *>(jEnv, jThis);
+        return payment_records_get_length(pPaymentRecords, errorPointer);
+    });
+}
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_tari_android_wallet_ffi_FFITariPaymentRecords_jniGetAt(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jint index,
+        jobject error) {
+    return ExecuteWithErrorAndCast<TariPaymentRecord *>(jEnv, error, [&](int *errorPointer) {
+        auto pPaymentRecords = GetPointerField<TariPaymentRecords *>(jEnv, jThis);
+        return payment_records_get_at(pPaymentRecords, static_cast<unsigned int>(index), errorPointer);
+    });
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_tari_android_wallet_ffi_FFITariPaymentRecords_jniDestroy(
+        JNIEnv *jEnv,
+        jobject jThis) {
+    payment_records_destroy(GetPointerField<TariPaymentRecords *>(jEnv, jThis));
+    SetNullPointerField(jEnv, jThis);
+}

--- a/app/src/main/cpp/jniTariPaymentRecord.cpp
+++ b/app/src/main/cpp/jniTariPaymentRecord.cpp
@@ -1,0 +1,34 @@
+#include <jni.h>
+#include <wallet.h>
+#include "jniCommon.cpp"
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_tari_android_wallet_ffi_FFITariPaymentRecord_jniLoadData(
+        JNIEnv *jEnv,
+        jobject jThis) {
+    jclass dataClass = jEnv->GetObjectClass(jThis);
+    auto outputs = GetPointerField<TariPaymentRecord *>(jEnv, jThis);
+
+    // Create a Java byte array for the unsigned char[32] payment_reference.
+    jbyteArray jPaymentReference = jEnv->NewByteArray(32);
+    jEnv->SetByteArrayRegion(jPaymentReference, 0, 32, reinterpret_cast<jbyte *>(outputs->payment_reference));
+    jfieldID paymentReferenceField = jEnv->GetFieldID(dataClass, "paymentReference", "[B");
+    jEnv->SetObjectField(jThis, paymentReferenceField, jPaymentReference);
+
+    jfieldID amountField = jEnv->GetFieldID(dataClass, "amount", "J");
+    auto amount = (long) (outputs->amount);
+    jEnv->SetLongField(jThis, amountField, amount);
+
+    jfieldID blockHeightField = jEnv->GetFieldID(dataClass, "blockHeight", "J");
+    auto blockHeight = (long) (outputs->block_height);
+    jEnv->SetLongField(jThis, blockHeightField, blockHeight);
+
+    jfieldID minedTimestampField = jEnv->GetFieldID(dataClass, "minedTimestamp", "J");
+    auto minedTimestamp = (long) (outputs->mined_timestamp);
+    jEnv->SetLongField(jThis, minedTimestampField, minedTimestamp);
+
+    jfieldID directionField = jEnv->GetFieldID(dataClass, "direction", "I");
+    auto statusValue = (jbyte) (outputs->direction);
+    jEnv->SetIntField(jThis, directionField, statusValue);
+}

--- a/app/src/main/cpp/jniWallet.cpp
+++ b/app/src/main/cpp/jniWallet.cpp
@@ -1310,3 +1310,20 @@ Java_com_tari_android_wallet_ffi_FFIWallet_jniGetPrivateViewKey(
         return wallet_get_private_view_key(pWallet, error);
     });
 }
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_tari_android_wallet_ffi_FFIWallet_jniGetTxPayRefs(
+        JNIEnv *jEnv,
+        jobject jThis,
+        jstring jTxId,
+        jobject error
+) {
+    return ExecuteWithErrorAndCast<TariPaymentRecords *>(jEnv, error, [&](int *errorPointer) {
+        auto pWallet = GetPointerField<TariWallet *>(jEnv, jThis);
+        const char *nativeString = jEnv->GetStringUTFChars(jTxId, JNI_FALSE);
+        char *pEnd;
+        unsigned long long id = strtoull(nativeString, &pEnd, 10);
+        return wallet_get_transaction_payrefs(pWallet, id, errorPointer);
+    });
+}

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITariPaymentRecord.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITariPaymentRecord.kt
@@ -1,0 +1,19 @@
+package com.tari.android.wallet.ffi
+
+class FFITariPaymentRecord(pointer: FFIPointer) : FFIBase() {
+
+    var paymentReference: ByteArray? = null
+    var amount: Long = -1L
+    var blockHeight: Long = -1L
+    var minedTimestamp: Long = -1L
+    var direction: Int = -1
+
+    private external fun jniLoadData()
+
+    init {
+        this.pointer = pointer
+        jniLoadData()
+    }
+
+    override fun destroy() = Unit
+}

--- a/app/src/main/java/com/tari/android/wallet/ffi/FFITariPaymentRecords.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/FFITariPaymentRecords.kt
@@ -1,0 +1,19 @@
+package com.tari.android.wallet.ffi
+
+class FFITariPaymentRecords() : FFIIterableBase<FFITariPaymentRecord>() {
+
+    private external fun jniGetLength(libError: FFIError): Int
+    private external fun jniGetAt(index: Int, libError: FFIError): FFIPointer
+    private external fun jniDestroy()
+
+    constructor(pointer: FFIPointer) : this() {
+        if (pointer.isNull()) error("Pointer must not be null")
+        this.pointer = pointer
+    }
+
+    override fun getLength(): Int = runWithError { jniGetLength(it) }
+
+    override fun getAt(index: Int): FFITariPaymentRecord = runWithError { FFITariPaymentRecord(jniGetAt(index, it)) }
+
+    override fun destroy() = jniDestroy()
+}

--- a/app/src/main/java/com/tari/android/wallet/ffi/HexString.kt
+++ b/app/src/main/java/com/tari/android/wallet/ffi/HexString.kt
@@ -49,3 +49,14 @@ data class HexString(val hex: String) {
         }
     )
 }
+
+fun ByteArray.toHex(): String {
+    val hexChars = "0123456789ABCDEF"
+    val result = StringBuilder(size * 2)
+    forEach { byte ->
+        val octet = byte.toInt() and 0xFF
+        result.append(hexChars[octet ushr 4])
+        result.append(hexChars[octet and 0x0F])
+    }
+    return result.toString()
+}

--- a/app/src/main/java/com/tari/android/wallet/model/TariPaymentRecord.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/TariPaymentRecord.kt
@@ -1,0 +1,34 @@
+package com.tari.android.wallet.model
+
+import android.os.Parcelable
+import com.tari.android.wallet.ffi.FFITariPaymentRecord
+import com.tari.android.wallet.ffi.toHex
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TariPaymentRecord(
+    val paymentReference: String,
+    val amount: Long,
+    val blockHeight: Long,
+    val minedTimestamp: Long,
+    val direction: Direction,
+) : Parcelable {
+
+    constructor(ffiObject: FFITariPaymentRecord) : this(
+        paymentReference = ffiObject.paymentReference?.toHex() ?: "",
+        amount = ffiObject.amount,
+        blockHeight = ffiObject.blockHeight,
+        minedTimestamp = ffiObject.minedTimestamp,
+        direction = Direction.fromValue(ffiObject.direction),
+    )
+
+    enum class Direction(val value: Int) {
+        Inbound(0),
+        Outbound(1),
+        Change(2);
+
+        companion object {
+            fun fromValue(value: Int): Direction = entries.first { it.value == value }
+        }
+    }
+}

--- a/app/src/main/java/com/tari/android/wallet/model/tx/CancelledTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/tx/CancelledTx.kt
@@ -74,4 +74,16 @@ data class CancelledTx(
     )
 
     override fun toString() = "CanceledTx(fee=$fee, status=$status) ${super.toString()}"
+
+    override val rawDetails: String
+        get() = "{" +
+                "\"id\":\"$id\"," +
+                "\"direction\":\"$direction\"," +
+                "\"amount\":\"${amount.value}\"," +
+                "\"fee\":\"${fee.value}\"," +
+                "\"timestamp\":\"$timestamp\"," +
+                "\"paymentId\":\"$paymentId\"," +
+                "\"status\":\"$status\"," +
+                "\"cancellationReason\":\"$cancellationReason\"," +
+                "}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/tx/CompletedTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/tx/CompletedTx.kt
@@ -90,4 +90,19 @@ data class CompletedTx(
     constructor(pointer: FFIPointer) : this(FFICompletedTx(pointer))
 
     override fun toString() = "CompletedTx(fee=$fee, status=$status, confirmationCount=$confirmationCount) ${super.toString()}"
+
+    override val rawDetails: String
+        get() = "{" +
+                "\"id\":\"$id\"," +
+                "\"direction\":\"$direction\"," +
+                "\"amount\":\"${amount.value}\"," +
+                "\"fee\":\"${fee.value}\"," +
+                "\"timestamp\":\"$timestamp\"," +
+                "\"paymentId\":\"$paymentId\"," +
+                "\"status\":\"$status\"," +
+                "\"confirmationCount\":\"$confirmationCount\"," +
+                "\"txKernel\":${txKernel?.let { "{\"excess\":\"${it.excess}\",\"publicNonce\":\"${it.publicNonce}\"," + "\"signature\":\"${it.signature}\"}" } ?: "null"}," +
+                "\"minedTimestamp\":\"$minedTimestamp\"," +
+                "\"minedHeight\":\"$minedHeight\"" +
+                "}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/tx/PendingInboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/tx/PendingInboundTx.kt
@@ -81,4 +81,14 @@ data class PendingInboundTx(
     )
 
     override fun toString() = "PendingInboundTx(status=$status) ${super.toString()}"
+
+    override val rawDetails: String
+        get() = "{" +
+                "\"id\":\"$id\"," +
+                "\"direction\":\"$direction\"," +
+                "\"amount\":\"${amount.value}\"," +
+                "\"timestamp\":\"$timestamp\"," +
+                "\"paymentId\":\"$paymentId\"," +
+                "\"status\":\"$status\"," +
+                "}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/tx/PendingOutboundTx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/tx/PendingOutboundTx.kt
@@ -84,4 +84,15 @@ data class PendingOutboundTx(
     )
 
     override fun toString() = "PendingOutboundTx(fee=$fee, status=$status) ${super.toString()}"
+
+    override val rawDetails: String
+        get() = "{" +
+                "\"id\":\"$id\"," +
+                "\"direction\":\"$direction\"," +
+                "\"amount\":\"${amount.value}\"," +
+                "\"fee\":\"${fee.value}\"," +
+                "\"timestamp\":\"$timestamp\"," +
+                "\"paymentId\":\"$paymentId\"," +
+                "\"status\":\"$status\"," +
+                "}"
 }

--- a/app/src/main/java/com/tari/android/wallet/model/tx/Tx.kt
+++ b/app/src/main/java/com/tari/android/wallet/model/tx/Tx.kt
@@ -55,6 +55,8 @@ abstract class Tx(
     open val tariContact: TariContact, // This is the receiver for an outbound tx and sender for an inbound tx.
 ) : Parcelable {
 
+    abstract val rawDetails: String
+
     enum class Direction {
         INBOUND,
         OUTBOUND

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/home/overview/HomeOverviewViewModel.kt
@@ -101,7 +101,10 @@ class HomeOverviewViewModel : CommonViewModel() {
         collectFlow(walletManager.walletEvent) { event ->
             when (event) {
                 is WalletEvent.TxSend.TxSendFailed -> onTxSendFailed(event.failureReason)
-                is WalletEvent.TxSend.TxSendSuccessful -> showTxDetail(event.txId)
+                is WalletEvent.TxSend.TxSendSuccessful -> {
+                    delay(300L) // Sometimes this callback arrives before we have cleared fragment navigation stack, so we need to wait a bit
+                    showTxDetail(event.txId)
+                }
 
                 else -> Unit
             }

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsFragment.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsFragment.kt
@@ -29,6 +29,8 @@ class TxDetailsFragment : CommonFragment<TxDetailsViewModel>() {
                 onContactEditClick = { viewModel.onContactEditClicked() },
                 onFeeInfoClick = { viewModel.onFeeInfoClicked() },
                 onEmojiIdDetailsClick = { viewModel.onAddressDetailsClicked() },
+                onRawDetailsClick = { viewModel.onRawDetailsClicked() },
+                onPaymentReferenceInfoClick = { viewModel.onPaymentReferenceInfoClicked() },
             )
         }
     }

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsScreen.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/TxDetailsScreen.kt
@@ -26,6 +26,7 @@ import com.tari.android.wallet.application.walletManager.WalletConfig
 import com.tari.android.wallet.model.TxStatus
 import com.tari.android.wallet.model.tx.CompletedTx
 import com.tari.android.wallet.ui.compose.TariDesignSystem
+import com.tari.android.wallet.ui.compose.components.TariOutlinedButton
 import com.tari.android.wallet.ui.compose.components.TariPrimaryButton
 import com.tari.android.wallet.ui.compose.components.TariTextButton
 import com.tari.android.wallet.ui.compose.components.TariTopBar
@@ -33,6 +34,7 @@ import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
 import com.tari.android.wallet.ui.screen.tx.details.widget.TxDetailInfoAddressItem
 import com.tari.android.wallet.ui.screen.tx.details.widget.TxDetailInfoContactNameItem
 import com.tari.android.wallet.ui.screen.tx.details.widget.TxDetailInfoItem
+import com.tari.android.wallet.ui.screen.tx.details.widget.TxDetailInfoPayRefItem
 import com.tari.android.wallet.ui.screen.tx.details.widget.TxDetailInfoStatusItem
 import com.tari.android.wallet.util.MockDataStub
 import com.tari.android.wallet.util.extension.isNotTrue
@@ -44,10 +46,12 @@ fun TxDetailsScreen(
     uiState: TxDetailsModel.UiState,
     onBackClick: () -> Unit,
     onCancelTxClick: () -> Unit,
+    onRawDetailsClick: () -> Unit,
     onCopyValueClick: (value: String) -> Unit,
     onBlockExplorerClick: () -> Unit,
     onContactEditClick: () -> Unit,
     onFeeInfoClick: () -> Unit,
+    onPaymentReferenceInfoClick: () -> Unit,
     onEmojiIdDetailsClick: () -> Unit,
 ) {
     Scaffold(
@@ -90,6 +94,20 @@ fun TxDetailsScreen(
                     onEmojiIdDetailsClick = onEmojiIdDetailsClick,
                 )
             }
+
+            uiState.payRefStatus
+                ?.takeIf { uiState.heightOfLongestChain > 0 }
+                ?.let { payRefStatus ->
+                    Spacer(Modifier.size(10.dp))
+                    TxDetailInfoPayRefItem(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                        paymentReference = payRefStatus,
+                        onInfoClicked = onPaymentReferenceInfoClick,
+                        onCopyClicked = onCopyValueClick,
+                    )
+                }
 
             uiState.contact?.let { contact ->
                 Spacer(Modifier.size(10.dp))
@@ -157,17 +175,16 @@ fun TxDetailsScreen(
                 )
             }
 
-
-            if (uiState.blockExplorerLink != null) {
-                Spacer(Modifier.size(10.dp))
-                TxDetailInfoItem(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp),
-                    title = stringResource(R.string.tx_details_txn_id),
-                    value = uiState.tariTxnId ?: stringResource(R.string.tx_details_txn_id_processing),
-                    singleLine = false,
-                ) {
+            Spacer(Modifier.size(10.dp))
+            TxDetailInfoItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                title = stringResource(R.string.tx_details_block_height),
+                value = uiState.minedHeight?.toString() ?: stringResource(R.string.tx_details_txn_id_processing),
+                singleLine = false,
+            ) {
+                if (uiState.blockExplorerLink != null) {
                     IconButton(onClick = onBlockExplorerClick) {
                         Icon(
                             painter = painterResource(R.drawable.vector_icon_open_url),
@@ -206,7 +223,16 @@ fun TxDetailsScreen(
 
             Spacer(Modifier.weight(1f))
 
+            TariOutlinedButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                text = stringResource(R.string.tx_details_copy_raw_data_button),
+                onClick = onRawDetailsClick,
+            )
+
             if (uiState.showCloseButton) {
+                Spacer(Modifier.size(16.dp))
                 TariPrimaryButton(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -242,6 +268,7 @@ private fun TxDetailsScreenPreview() {
                 ticker = "XTM",
                 blockExplorerBaseUrl = "",
                 contact = MockDataStub.createContact(),
+                heightOfLongestChain = 1000,
             ),
             onBackClick = {},
             onCancelTxClick = {},
@@ -250,6 +277,8 @@ private fun TxDetailsScreenPreview() {
             onContactEditClick = {},
             onFeeInfoClick = {},
             onEmojiIdDetailsClick = {},
+            onRawDetailsClick = {},
+            onPaymentReferenceInfoClick = {},
         )
     }
 }
@@ -268,14 +297,17 @@ private fun TxDetailsScreenInProgressPreview() {
                 ticker = "XTM",
                 blockExplorerBaseUrl = "",
                 contact = MockDataStub.createContact(),
+                heightOfLongestChain = 1000,
             ),
             onBackClick = {},
             onCancelTxClick = {},
+            onRawDetailsClick = {},
             onCopyValueClick = {},
             onBlockExplorerClick = {},
             onContactEditClick = {},
             onFeeInfoClick = {},
             onEmojiIdDetailsClick = {},
+            onPaymentReferenceInfoClick = {},
         )
     }
 }
@@ -293,14 +325,17 @@ private fun TxDetailsScreenCancelledPreview() {
                 ticker = "XTM",
                 blockExplorerBaseUrl = "",
                 contact = MockDataStub.createContact(),
+                heightOfLongestChain = 1000,
             ),
             onBackClick = {},
             onCancelTxClick = {},
+            onRawDetailsClick = {},
             onCopyValueClick = {},
             onBlockExplorerClick = {},
             onContactEditClick = {},
             onFeeInfoClick = {},
             onEmojiIdDetailsClick = {},
+            onPaymentReferenceInfoClick = {},
         )
     }
 }
@@ -318,14 +353,17 @@ private fun TxDetailsScreenPendingPreview() {
                 ticker = "XTM",
                 blockExplorerBaseUrl = "",
                 contact = MockDataStub.createContact(),
+                heightOfLongestChain = 1000,
             ),
             onBackClick = {},
+            onRawDetailsClick = {},
             onCancelTxClick = {},
             onCopyValueClick = {},
             onBlockExplorerClick = {},
             onContactEditClick = {},
             onFeeInfoClick = {},
             onEmojiIdDetailsClick = {},
+            onPaymentReferenceInfoClick = {},
         )
     }
 }

--- a/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/widget/TxDetailInfoItem.kt
+++ b/app/src/main/java/com/tari/android/wallet/ui/screen/tx/details/widget/TxDetailInfoItem.kt
@@ -31,6 +31,7 @@ import com.tari.android.wallet.ui.compose.TariDesignSystem
 import com.tari.android.wallet.ui.compose.components.TariHorizontalDivider
 import com.tari.android.wallet.ui.screen.settings.themeSelector.TariTheme
 import com.tari.android.wallet.ui.screen.tx.details.TxDetailsModel
+import com.tari.android.wallet.ui.screen.tx.details.TxDetailsModel.UiState.PayRefStatus
 import com.tari.android.wallet.util.MockDataStub
 import com.tari.android.wallet.util.base58Ellipsized
 import com.tari.android.wallet.util.shortString
@@ -207,6 +208,55 @@ fun TxDetailInfoAddressItem(
 }
 
 @Composable
+fun TxDetailInfoPayRefItem(
+    paymentReference: PayRefStatus,
+    onCopyClicked: (value: String) -> Unit,
+    onInfoClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TxDetailInfoItem(
+        modifier = modifier,
+        title = stringResource(R.string.tx_detail_payment_reference),
+        value = when (paymentReference) {
+            is PayRefStatus.Ready -> paymentReference.paymentReferenceHex
+            is PayRefStatus.Waiting -> stringResource(
+                R.string.tx_detail_payment_reference_waiting,
+                paymentReference.totalSteps,
+                paymentReference.step,
+                paymentReference.totalSteps,
+            )
+        },
+        valueTextColor = when (paymentReference) {
+            is PayRefStatus.Ready -> TariDesignSystem.colors.textPrimary
+            is PayRefStatus.Waiting -> TariDesignSystem.colors.warningMain
+        },
+        singleLine = false,
+    ) {
+        IconButton(
+            // needed to remove "margin" between two IconButtons
+            modifier = Modifier.offset(x = if (paymentReference is PayRefStatus.Ready) 12.dp else 0.dp),
+            onClick = onInfoClicked,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.vector_icon_question_circle),
+                contentDescription = null,
+                tint = TariDesignSystem.colors.componentsNavbarIcons,
+            )
+        }
+
+        if (paymentReference is PayRefStatus.Ready) {
+            IconButton(onClick = { onCopyClicked(paymentReference.paymentReferenceHex) }) {
+                Icon(
+                    painter = painterResource(R.drawable.vector_icon_copy),
+                    contentDescription = null,
+                    tint = TariDesignSystem.colors.componentsNavbarIcons,
+                )
+            }
+        }
+    }
+}
+
+@Composable
 @Preview
 private fun TxDetailInfoItemPreview() {
     PreviewSecondarySurface(TariTheme.Light) {
@@ -245,6 +295,18 @@ private fun TxDetailInfoItemPreview() {
                 onCopyClicked = {},
                 onEmojiIdDetailsClick = {},
                 title = stringResource(R.string.common_from),
+            )
+
+            TxDetailInfoPayRefItem(
+                paymentReference = PayRefStatus.Ready("1234567890abcdef1234567890abcdef"),
+                onCopyClicked = {},
+                onInfoClicked = {},
+            )
+
+            TxDetailInfoPayRefItem(
+                paymentReference = PayRefStatus.Waiting(step = 3, totalSteps = 5),
+                onCopyClicked = {},
+                onInfoClicked = {},
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,6 +310,7 @@
     <string name="tx_detail_payment_id_error">An error occurred while retrieving the Payment ID</string>
     <string name="tx_detail_edit">Edit</string>
     <string name="tx_detail_transaction_fee">Transaction Fee</string>
+    <string name="tx_detail_payment_reference">Payment Reference</string>
     <string name="tx_detail_waiting_for_recipient">Waiting for recipient to come online</string>
     <string name="tx_detail_waiting_for_sender_to_complete">Waiting for sender to complete transaction</string>
     <string name="tx_detail_in_progress">In progress</string>
@@ -327,11 +328,12 @@
     <string name="tx_details_paid">Paid</string>
     <string name="tx_details_received">"Received</string>
     <string name="tx_details_date">Date</string>
-    <string name="tx_details_txn_id">Tari Txn ID</string>
-    <string name="tx_details_txn_id_processing">Processing</string>
+    <string name="tx_details_block_height">Mined in Block Height</string>
+    <string name="tx_details_txn_id_processing">Processing...</string>
     <string name="tx_details_status">Status</string>
     <string name="tx_details_completed">Completed</string>
     <string name="tx_details_add_contact_name_hint">Add contact name…</string>
+    <string name="tx_details_copy_raw_data_button">Copy Raw Details</string>
 
     <string name="tx_details_cancellation_reason_unknown">The transaction failed for an unknown reason.</string>
     <string name="tx_details_cancellation_reason_user_cancelled">The transaction was canceled by the sender.</string>
@@ -343,11 +345,13 @@
     <string name="tx_details_cancellation_reason_abandoned_coinbase">The coinbase was abandoned.</string>
     <string name="tx_details_cancellation_reason_not_cancelled">The transaction was not cancelled, but for some reason looks like cancelled.
         Please, contact us directly if you see this message.</string>
-
-    <!-- Fee tooltip -->
     <string name="tx_detail_fee_tooltip_transaction_fee">Transaction Fee</string>
     <string name="tx_detail_fee_tooltip_desc">The transaction fee is distributed to the thousands of computers (also known as \"miners\") who
         ensure that your XTM transactions are fast and secure.</string>
+    <string name="tx_detail_payment_reference_tooltip_title">Your unique payment ID!</string>
+    <string name="tx_detail_payment_reference_tooltip_desc">Share this with anyone who needs to confirm your payment –
+    they can look it up on a block explorer while your privacy stays protected.</string>
+    <string name="tx_detail_payment_reference_waiting">Waiting for %s block confirmations (%s of %s confirmed)</string>
 
     <!-- debug screens -->
     <!-- logs -->


### PR DESCRIPTION
Added the new `Payment Reference` field to the Tx Details:
- Add C++ wrappers for the new FFI methods
- Show payment reference in the tx details if available
- Show progress if payment is fully mined (5 blocks minimum)
- Show block height in the Tx Details is available
- Added "Copy Raw Details" button to the Tx Details screen

<img src="https://github.com/user-attachments/assets/c9016631-c3d2-4985-ad6a-c83428636c74" width="300"> <img src="https://github.com/user-attachments/assets/eafb94b2-a467-44b2-aea1-2e957cf2cd8d" width="300"> <img src="https://github.com/user-attachments/assets/db47670a-09ab-4080-b09a-14058dd43ea4" width="300"> 
